### PR TITLE
add method to use default APIC addresses

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -329,8 +329,8 @@ pub fn init() {
 
 	// Detect CPUs and APICs.
 	let local_apic_physical_address = detect_from_uhyve()
-		.or_else(|| detect_from_acpi())
-		.unwrap_or_else(|| default_apic());
+		.or_else(|_| detect_from_acpi())
+		.unwrap_or_else(|_| default_apic());
 
 	// Initialize x2APIC or xAPIC, depending on what's available.
 	init_x2apic();


### PR DESCRIPTION
- if ACPI isn't available, we use the default APIC addresses
- however, we don't have an guarantee, if these addresses are correct