### PR TITLE
Remove uses of alloc::prelude

### DIFF
--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use alloc::prelude::v1::Box;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::mem;
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
alloc::prelude has been removed in https://github.com/rust-lang/rust/pull/89898, effective since nightly-2021-10-17.

bors r+