### PR TITLE
Replace use of internal syscalls

### DIFF
--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -1,3 +1,4 @@
+use alloc::alloc::{alloc, Layout};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
@@ -141,10 +142,12 @@ impl SyscallInterface for Uhyve {
 		let mut argv = Box::new(Vec::with_capacity(syscmdsize.argc as usize));
 		let mut argv_phy = Vec::with_capacity(syscmdsize.argc as usize);
 		for i in 0..syscmdsize.argc as usize {
-			argv.push(
-				crate::__sys_malloc(syscmdsize.argsz[i] as usize * mem::size_of::<u8>(), 1)
-					.cast_const(),
-			);
+			let layout =
+				Layout::from_size_align(syscmdsize.argsz[i] as usize * mem::size_of::<u8>(), 1)
+					.unwrap();
+
+			argv.push(unsafe { alloc(layout).cast_const() });
+
 			argv_phy.push(
 				paging::virtual_to_physical(VirtAddr(argv[i] as u64))
 					.unwrap()
@@ -156,10 +159,11 @@ impl SyscallInterface for Uhyve {
 		let mut env = Box::new(Vec::with_capacity(syscmdsize.envc as usize + 1));
 		let mut env_phy = Vec::with_capacity(syscmdsize.envc as usize + 1);
 		for i in 0..syscmdsize.envc as usize {
-			env.push(
-				crate::__sys_malloc(syscmdsize.envsz[i] as usize * mem::size_of::<u8>(), 1)
-					.cast_const(),
-			);
+			let layout =
+				Layout::from_size_align(syscmdsize.envsz[i] as usize * mem::size_of::<u8>(), 1)
+					.unwrap();
+			env.push(unsafe { alloc(layout).cast_const() });
+
 			env_phy.push(
 				paging::virtual_to_physical(VirtAddr(env[i] as u64))
 					.unwrap()


### PR DESCRIPTION
Closes #676 

I found no internal uses of `__sys_realloc()` or `__sys_free()` anywhere.

I did find one reference to `__sys_shutdown()`:
https://github.com/hermitcore/libhermit-rs/blob/df7483de1b762c570f5d52e48fc396cdb739a12d/src/arch/x86_64/kernel/processor.rs#L832-L836

It doesn't redirect to any functions in [`lib.rs`](https://github.com/hermitcore/libhermit-rs/blob/master/src/lib.rs) like `__sys_malloc()` does. Does it need to be replaced as well?