### PR TITLE
add basic UDP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ harness = false
 default = ["pci", "pci-ids", "acpi", "fsgsbase", "smp", "tcp", "dhcpv4", "fs"]
 acpi = []
 dhcpv4 = [
-    "tcp",
+    "smoltcp",
     "smoltcp/proto-dhcpv4",
     "smoltcp/socket-dhcpv4",
 ]
@@ -58,7 +58,8 @@ newlib = []
 pci = []
 rtl8139 = ["tcp", "pci"]
 smp = ["include-transformed"]
-tcp = ["smoltcp"]
+tcp = ["smoltcp", "smoltcp/socket-tcp"]
+udp = ["smoltcp", "smoltcp/socket-udp"]
 trace = []
 vga = []
 
@@ -100,8 +101,6 @@ features = [
     "medium-ethernet",
     "proto-ipv4",
     "proto-ipv6",
-    "socket-tcp",
-    "socket-udp",
     # Enable IP fragmentation
     #"proto-ipv4-fragmentation",
     #

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -1,6 +1,6 @@
 pub mod core_local;
 pub mod interrupts;
-#[cfg(all(not(feature = "pci"), feature = "tcp"))]
+#[cfg(all(not(feature = "pci"), any(feature = "tcp", feature = "udp")))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -88,6 +88,10 @@ pub fn init_drivers() {
 	// Initialize PCI Drivers for x86_64
 	#[cfg(feature = "pci")]
 	crate::drivers::pci::init_drivers();
-	#[cfg(all(target_arch = "x86_64", not(feature = "pci"), feature = "tcp"))]
+	#[cfg(all(
+		target_arch = "x86_64",
+		not(feature = "pci"),
+		any(feature = "tcp", feature = "udp")
+	))]
 	crate::arch::x86_64::kernel::mmio::init_drivers();
 }

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -17,7 +17,7 @@ pub mod apic;
 pub mod core_local;
 pub mod gdt;
 pub mod interrupts;
-#[cfg(all(not(feature = "pci"), feature = "tcp"))]
+#[cfg(all(not(feature = "pci"), any(feature = "tcp", feature = "udp")))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,5 +12,5 @@ pub(crate) const VIRTIO_MAX_QUEUE_SIZE: u16 = 2048;
 pub(crate) const VIRTIO_MAX_QUEUE_SIZE: u16 = 1024;
 
 /// Default keep alive interval in milliseconds
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) const DEFAULT_KEEP_ALIVE_INTERVAL: u64 = 75000;

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -1,2 +1,2 @@
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) use crate::arch::kernel::mmio::get_network_driver;

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -4,11 +4,14 @@
 pub mod fs;
 #[cfg(not(feature = "pci"))]
 pub mod mmio;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub mod net;
 #[cfg(feature = "pci")]
 pub mod pci;
-#[cfg(any(all(feature = "tcp", not(feature = "rtl8139")), feature = "fs"))]
+#[cfg(any(
+	all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+	feature = "fs"
+))]
 pub mod virtio;
 
 /// A common error module for drivers.
@@ -19,18 +22,27 @@ pub mod error {
 
 	#[cfg(feature = "rtl8139")]
 	use crate::drivers::net::rtl8139::RTL8139Error;
-	#[cfg(any(all(feature = "tcp", not(feature = "rtl8139")), feature = "fs"))]
+	#[cfg(any(
+		all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+		feature = "fs"
+	))]
 	use crate::drivers::virtio::error::VirtioError;
 
 	#[derive(Debug)]
 	pub enum DriverError {
-		#[cfg(any(all(feature = "tcp", not(feature = "rtl8139")), feature = "fs"))]
+		#[cfg(any(
+			all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+			feature = "fs"
+		))]
 		InitVirtioDevFail(VirtioError),
 		#[cfg(feature = "rtl8139")]
 		InitRTL8139DevFail(RTL8139Error),
 	}
 
-	#[cfg(any(all(feature = "tcp", not(feature = "rtl8139")), feature = "fs"))]
+	#[cfg(any(
+		all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+		feature = "fs"
+	))]
 	impl From<VirtioError> for DriverError {
 		fn from(err: VirtioError) -> Self {
 			DriverError::InitVirtioDevFail(err)
@@ -48,7 +60,10 @@ pub mod error {
 		#[allow(unused_variables)]
 		fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 			match *self {
-				#[cfg(any(all(feature = "tcp", not(feature = "rtl8139")), feature = "fs"))]
+				#[cfg(any(
+					all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+					feature = "fs"
+				))]
 				DriverError::InitVirtioDevFail(ref err) => {
 					write!(f, "Virtio driver failed: {err:?}")
 				}

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -10,7 +10,7 @@ pub mod error {
 
 	#[cfg(feature = "fs")]
 	pub use crate::drivers::fs::virtio_fs::error::VirtioFsError;
-	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+	#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 	pub use crate::drivers::net::virtio_net::error::VirtioNetError;
 	#[cfg(feature = "pci")]
 	use crate::drivers::pci::error::PciError;
@@ -21,7 +21,7 @@ pub mod error {
 		#[cfg(feature = "pci")]
 		FromPci(PciError),
 		DevNotSupported(u16),
-		#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+		#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 		NetDriver(VirtioNetError),
 		#[cfg(feature = "fs")]
 		FsDriver(VirtioFsError),
@@ -43,7 +43,7 @@ pub mod error {
                     PciError::NoVirtioCaps(id) => write!(f, "Driver failed to initialize device with id: {id:#x}. Reason: No Virtio capabilities were found."),
                 },
                 VirtioError::DevNotSupported(id) => write!(f, "Device with id {id:#x} not supported."),
-				#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+				#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
                 VirtioError::NetDriver(net_error) => match net_error {
                     VirtioNetError::General => write!(f, "Virtio network driver failed due to unknown reasons!"),
                     VirtioNetError::NoDevCfg(id) => write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed device config!"),

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -10,13 +10,13 @@ use core::result::Result;
 use core::sync::atomic::{fence, Ordering};
 use core::u8;
 
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 use crate::arch::kernel::interrupts::*;
 use crate::arch::mm::PhysAddr;
 use crate::drivers::error::DriverError;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 use crate::drivers::net::network_irqhandler;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 use crate::drivers::net::virtio_net::VirtioNetDriver;
 use crate::drivers::virtio::device;
 use crate::drivers::virtio::error::VirtioError;
@@ -367,7 +367,7 @@ struct IsrStatusRaw {
 }
 
 pub(crate) enum VirtioDriver {
-	#[cfg(feature = "tcp")]
+	#[cfg(any(feature = "tcp", feature = "udp"))]
 	Network(VirtioNetDriver),
 }
 
@@ -387,7 +387,7 @@ pub(crate) fn init_device(
 
 	// Verify the device-ID to find the network card
 	match registers.device_id {
-		#[cfg(feature = "tcp")]
+		#[cfg(any(feature = "tcp", feature = "udp"))]
 		DevId::VIRTIO_DEV_ID_NET => {
 			match VirtioNetDriver::init(dev_id, registers, irq_no) {
 				Ok(virt_net_drv) => {

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -9,7 +9,7 @@ use core::mem;
 use core::result::Result;
 use core::sync::atomic::{fence, Ordering};
 
-#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 use crate::arch::kernel::interrupts::*;
 use crate::arch::memory_barrier;
 use crate::arch::mm::PhysAddr;
@@ -17,9 +17,9 @@ use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
 #[cfg(feature = "fs")]
 use crate::drivers::fs::virtio_fs::VirtioFsDriver;
-#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 use crate::drivers::net::network_irqhandler;
-#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 use crate::drivers::net::virtio_net::VirtioNetDriver;
 use crate::drivers::pci::error::PciError;
 use crate::drivers::pci::{DeviceHeader, Masks, PciDevice};
@@ -1259,7 +1259,7 @@ pub(crate) fn init_device(
 				VirtioError::DevNotSupported(device_id),
 			))
 		}
-		#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+		#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 		DevId::VIRTIO_DEV_ID_NET => match VirtioNetDriver::init(device) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");
@@ -1307,7 +1307,7 @@ pub(crate) fn init_device(
 	match virt_drv {
 		Ok(drv) => {
 			match &drv {
-				#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+				#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 				VirtioDriver::Network(_) => {
 					let irq = device.get_irq().unwrap();
 					info!("Install virtio interrupt handler at line {}", irq);
@@ -1326,7 +1326,7 @@ pub(crate) fn init_device(
 }
 
 pub(crate) enum VirtioDriver {
-	#[cfg(all(not(feature = "rtl8139"), feature = "tcp"))]
+	#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 	Network(VirtioNetDriver),
 	#[cfg(feature = "fs")]
 	FileSystem(VirtioFsDriver),

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) mod device;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) mod network;
 pub(crate) mod task;
 
@@ -74,6 +74,6 @@ where
 }
 
 pub fn init() {
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	crate::executor::network::init();
 }

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -14,11 +14,11 @@ use crate::errno::*;
 use crate::fd::file::{GenericFile, UhyveFile};
 use crate::fd::stdio::*;
 use crate::syscalls::fs::{self, FilePerms, SeekWhence};
-#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 use crate::syscalls::net::*;
 
 mod file;
-#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 pub mod socket;
 mod stdio;
 
@@ -205,31 +205,31 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	}
 
 	/// `accept` a connection on a socket
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn accept(&self, _addr: *mut sockaddr, _addrlen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// initiate a connection on a socket
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn connect(&self, _name: *const sockaddr, _namelen: socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `bind` a name to a socket
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn bind(&self, _name: *const sockaddr, _namelen: socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `listen` for connections on a socket
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn listen(&self, _backlog: i32) -> i32 {
 		-EINVAL
 	}
 
 	/// `setsockopt` sets options on sockets
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn setsockopt(
 		&self,
 		_level: i32,
@@ -241,7 +241,7 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	}
 
 	/// `getsockopt` gets options on sockets
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn getsockopt(
 		&self,
 		_level: i32,
@@ -253,19 +253,19 @@ pub trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	}
 
 	/// `getsockname` gets socket name
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn getsockname(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// `getpeername` get address of connected peer
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn getpeername(&self, _name: *mut sockaddr, _namelen: *mut socklen_t) -> i32 {
 		-EINVAL
 	}
 
 	/// shut down part of a full-duplex connection
-	#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	fn shutdown(&self, _how: i32) -> i32 {
 		-EINVAL
 	}
@@ -323,7 +323,7 @@ pub(crate) fn get_object(fd: FileDescriptor) -> Result<Arc<dyn ObjectInterface>,
 	Ok((*(OBJECT_MAP.read().get(&fd).ok_or(-EINVAL)?)).clone())
 }
 
-#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 pub(crate) fn insert_object(
 	fd: FileDescriptor,
 	obj: Arc<dyn ObjectInterface>,

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,13 +1,339 @@
-use crate::executor::network::Handle;
+use core::ffi::c_void;
+use core::future;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::DerefMut;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
+
+use crossbeam_utils::atomic::AtomicCell;
+use smoltcp::socket::udp;
+use smoltcp::time::Duration;
+use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
+
+use crate::errno::*;
+use crate::executor::network::{block_on, now, poll_on, Handle, NetworkState, NIC};
 use crate::fd::ObjectInterface;
+use crate::syscalls::net::*;
 
-#[derive(Debug, Clone)]
-pub struct Socket(Handle);
+#[derive(Debug)]
+pub struct IPv4;
 
-impl Socket {
+#[derive(Debug)]
+pub struct IPv6;
+
+#[derive(Debug)]
+pub struct Socket<T> {
+	handle: Handle,
+	nonblocking: AtomicBool,
+	endpoint: AtomicCell<Option<IpEndpoint>>,
+	phantom: PhantomData<T>,
+}
+
+impl<T> Socket<T> {
 	pub fn new(handle: Handle) -> Self {
-		Self(handle)
+		Self {
+			handle,
+			nonblocking: AtomicBool::new(false),
+			endpoint: AtomicCell::new(None),
+			phantom: PhantomData,
+		}
+	}
+
+	fn with<R>(&self, f: impl FnOnce(&mut udp::Socket<'_>) -> R) -> R {
+		let mut guard = NIC.lock();
+		let nic = guard.as_nic_mut().unwrap();
+		let result = f(nic.get_mut_socket::<udp::Socket<'_>>(self.handle));
+		nic.poll_common(now());
+
+		result
+	}
+
+	async fn async_close(&self) -> Result<(), i32> {
+		future::poll_fn(|_cx| {
+			self.with(|socket| {
+				socket.close();
+				Poll::Ready(Ok(()))
+			})
+		})
+		.await
+	}
+
+	async fn async_read(&self, buffer: &mut [u8]) -> Result<isize, i32> {
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.is_open() {
+					if socket.can_recv() {
+						match socket.recv_slice(buffer) {
+							Ok((len, meta)) => match self.endpoint.load() {
+								Some(ep) => {
+									if meta.endpoint == ep {
+										Poll::Ready(Ok(len.try_into().unwrap()))
+									} else {
+										buffer[..len].iter_mut().for_each(|x| *x = 0);
+										socket.register_recv_waker(cx.waker());
+										Poll::Pending
+									}
+								}
+								None => Poll::Ready(Ok(len.try_into().unwrap())),
+							},
+							_ => Poll::Ready(Err(-crate::errno::EIO)),
+						}
+					} else {
+						socket.register_recv_waker(cx.waker());
+						Poll::Pending
+					}
+				} else {
+					Poll::Ready(Err(-crate::errno::EIO))
+				}
+			})
+		})
+		.await
+	}
+
+	async fn async_write(&self, buffer: &[u8]) -> Result<isize, i32> {
+		let endpoint = self.endpoint.load();
+		if endpoint.is_none() {
+			return Err(-crate::errno::EINVAL);
+		}
+
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.is_open() {
+					if socket.can_send() {
+						let meta = udp::UdpMetadata::from(endpoint.unwrap());
+						Poll::Ready(
+							socket
+								.send_slice(buffer, meta)
+								.map(|_| buffer.len() as isize)
+								.map_err(|_| -crate::errno::EIO),
+						)
+					} else {
+						socket.register_recv_waker(cx.waker());
+						Poll::Pending
+					}
+				} else {
+					Poll::Ready(Err(-crate::errno::EIO))
+				}
+			})
+		})
+		.await
+	}
+
+	fn read(&self, buf: *mut u8, len: usize) -> isize {
+		if len == 0 {
+			return 0;
+		}
+
+		let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+
+		if self.nonblocking.load(Ordering::Acquire) {
+			poll_on(self.async_read(slice), Some(Duration::ZERO)).unwrap_or_else(|x| {
+				if x == -ETIME {
+					(-EAGAIN).try_into().unwrap()
+				} else {
+					x.try_into().unwrap()
+				}
+			})
+		} else {
+			poll_on(self.async_read(slice), Some(Duration::from_secs(2))).unwrap_or_else(|x| {
+				if x == -ETIME {
+					block_on(self.async_read(slice), None).unwrap_or_else(|y| y.try_into().unwrap())
+				} else {
+					x.try_into().unwrap()
+				}
+			})
+		}
+	}
+
+	fn write(&self, buf: *const u8, len: usize) -> isize {
+		if len == 0 {
+			return 0;
+		}
+
+		let slice = unsafe { core::slice::from_raw_parts(buf, len) };
+
+		if self.nonblocking.load(Ordering::Acquire) {
+			poll_on(self.async_write(slice), Some(Duration::ZERO)).unwrap_or_else(|x| {
+				if x == -ETIME {
+					(-EAGAIN).try_into().unwrap()
+				} else {
+					x.try_into().unwrap()
+				}
+			})
+		} else {
+			poll_on(self.async_write(slice), None).unwrap_or_else(|x| x.try_into().unwrap())
+		}
+	}
+
+	fn ioctl(&self, cmd: i32, argp: *mut c_void) -> i32 {
+		if cmd == FIONBIO {
+			let value = unsafe { *(argp as *const i32) };
+			if value != 0 {
+				info!("set device to nonblocking mode");
+				self.nonblocking.store(true, Ordering::Release);
+			} else {
+				info!("set device to blocking mode");
+				self.nonblocking.store(false, Ordering::Release);
+			}
+
+			0
+		} else {
+			-EINVAL
+		}
 	}
 }
 
-impl ObjectInterface for Socket {}
+impl<T> Clone for Socket<T> {
+	fn clone(&self) -> Self {
+		let mut guard = NIC.lock();
+
+		let handle = if let NetworkState::Initialized(nic) = guard.deref_mut() {
+			nic.create_udp_handle().unwrap()
+		} else {
+			panic!("Unable to create handle");
+		};
+
+		Self {
+			handle,
+			nonblocking: AtomicBool::new(self.nonblocking.load(Ordering::Acquire)),
+			endpoint: AtomicCell::new(self.endpoint.load()),
+			phantom: PhantomData,
+		}
+	}
+}
+
+impl<T> Drop for Socket<T> {
+	fn drop(&mut self) {
+		let _ = block_on(self.async_close(), None);
+	}
+}
+
+impl ObjectInterface for Socket<IPv4> {
+	fn bind(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in>().try_into().unwrap() {
+			let addr = unsafe { *(name as *const sockaddr_in) };
+			let s_addr = addr.sin_addr.s_addr;
+			let port = u16::from_be(addr.sin_port);
+			let endpoint = if s_addr.into_iter().all(|b| b == 0) {
+				IpListenEndpoint { addr: None, port }
+			} else {
+				IpListenEndpoint {
+					addr: Some(IpAddress::v4(s_addr[0], s_addr[1], s_addr[2], s_addr[3])),
+					port,
+				}
+			};
+			self.with(|socket| {
+				if !socket.is_open() {
+					let _ = socket.bind(endpoint).unwrap();
+					info!("{:?}", endpoint);
+				}
+			});
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn connect(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in>().try_into().unwrap() {
+			let saddr = unsafe { *(name as *const sockaddr_in) };
+			let port = u16::from_be(saddr.sin_port);
+			let address = IpAddress::v4(
+				saddr.sin_addr.s_addr[0],
+				saddr.sin_addr.s_addr[1],
+				saddr.sin_addr.s_addr[2],
+				saddr.sin_addr.s_addr[3],
+			);
+
+			self.endpoint.store(Some(IpEndpoint::new(address, port)));
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn read(&self, buf: *mut u8, len: usize) -> isize {
+		self.read(buf, len)
+	}
+
+	fn write(&self, buf: *const u8, len: usize) -> isize {
+		self.write(buf, len)
+	}
+}
+
+impl ObjectInterface for Socket<IPv6> {
+	fn bind(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in6>().try_into().unwrap() {
+			let addr = unsafe { *(name as *const sockaddr_in6) };
+			let s6_addr = addr.sin6_addr.s6_addr;
+			let port = u16::from_be(addr.sin6_port);
+			let endpoint = if s6_addr.into_iter().all(|b| b == 0) {
+				IpListenEndpoint { addr: None, port }
+			} else {
+				let addr = IpAddress::v6(
+					u16::from_ne_bytes(s6_addr[0..1].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[2..3].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[4..5].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[6..7].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[8..9].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[10..11].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[12..13].try_into().unwrap()),
+					u16::from_ne_bytes(s6_addr[14..15].try_into().unwrap()),
+				);
+
+				IpListenEndpoint {
+					addr: Some(addr),
+					port,
+				}
+			};
+			self.with(|socket| {
+				if !socket.is_open() {
+					let _ = socket.bind(endpoint).unwrap();
+				}
+			});
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn connect(&self, name: *const sockaddr, namelen: socklen_t) -> i32 {
+		if namelen == size_of::<sockaddr_in6>().try_into().unwrap() {
+			let saddr = unsafe { *(name as *const sockaddr_in6) };
+			let s6_addr = saddr.sin6_addr.s6_addr;
+			let port = u16::from_be(saddr.sin6_port);
+			let address = IpAddress::v6(
+				u16::from_ne_bytes(s6_addr[0..1].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[2..3].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[4..5].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[6..7].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[8..9].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[10..11].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[12..13].try_into().unwrap()),
+				u16::from_ne_bytes(s6_addr[14..15].try_into().unwrap()),
+			);
+
+			self.endpoint.store(Some(IpEndpoint::new(address, port)));
+
+			0
+		} else {
+			-EINVAL
+		}
+	}
+
+	fn read(&self, buf: *mut u8, len: usize) -> isize {
+		self.read(buf, len)
+	}
+
+	fn write(&self, buf: *const u8, len: usize) -> isize {
+		self.write(buf, len)
+	}
+
+	fn ioctl(&self, cmd: i32, argp: *mut c_void) -> i32 {
+		self.ioctl(cmd, argp)
+	}
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -329,7 +329,7 @@ impl PerCoreScheduler {
 		});
 	}
 
-	#[cfg(feature = "tcp")]
+	#[cfg(any(feature = "tcp", feature = "udp"))]
 	#[inline]
 	pub fn add_network_timer(&mut self, wakeup_time: Option<u64>) {
 		without_interrupts(|| self.blocked_tasks.add_network_timer(wakeup_time))

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -28,7 +28,7 @@ mod futex;
 mod interfaces;
 #[cfg(feature = "newlib")]
 mod lwip;
-#[cfg(all(feature = "tcp", not(feature = "newlib")))]
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 pub mod net;
 mod processor;
 #[cfg(feature = "newlib")]


### PR DESCRIPTION
In addition, the feature `udp` is added to enable/disable UDP support. The UDP support is only tested by the example `testudp` of hermit-rs.

This PR includes also #881.