### PR TITLE
fix(aarch64): properly disable interrupts on mutexes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,8 +327,6 @@ jobs:
         run:
           cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package httpd --features ci,dhcpv4
       - name: Test httpd with DHCP support (debug, virtio-net)
-        # FIXME: Make test less flaky and remove continue-on-error
-        continue-on-error: true
         run: |
           qemu-system-aarch64 -semihosting \
             -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \
@@ -343,8 +341,6 @@ jobs:
         run:
           cargo build -Zbuild-std=std,panic_abort --target aarch64-unknown-hermit --package httpd --release --features ci,dhcpv4
       - name: Test httpd with DHCP support (release, virtio-net)
-        # FIXME: Make test less flaky and remove continue-on-error
-        continue-on-error: true
         run: |
           qemu-system-aarch64 -semihosting \
             -kernel rusty-loader-aarch64 -machine virt,gic-version=3 \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-sync"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645fad6b0a6c72039c4b2741c8f8e82731f47b6773a87b2a74269be8672f9f20"
+checksum = "ff009f072428c6d076906c6ae80b71d6e2adda8e4dc5edba81f3fdb0a74d4e57"
 dependencies = [
  "aarch64-cpu",
  "exclusive_cell",


### PR DESCRIPTION
Closes https://github.com/hermit-os/kernel/issues/846

This should fix deadlocks by updating hermit-sync to 0.1.4 (https://github.com/hermit-os/hermit-sync/pull/16).