### PR TITLE
ci: use a matrix for test configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,58 @@ jobs:
         env:
           RUSTFLAGS:
 
-  run-x86_64:
-    name: Run Hermit for Rust (x86_64)
+  run-hermit:
+    name: Run Hermit for Rust
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: kernel
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+        profile: [dev, release]
+        package: [rusty_demo, httpd, testudp, hello_world]
+        netdev: [none, virtio-net-pci, rtl8139]
+        exclude:
+          # microvm (Firecracker) test does not run on aarch64
+          - package: hello_world
+            arch: aarch64
+          # rtl8139 support does not build on aarch64
+          - arch: aarch64
+            netdev: rtl8139
+          # Following packages do not depend on the netdev
+          - package: rusty_demo
+            netdev: virtio-net-pci
+          - package: rusty_demo
+            netdev: rtl8139
+          - package: hello_world
+            netdev: virtio-net-pci
+          - package: hello_world
+            netdev: rtl8139
+          # Following packages require a netdev
+          - package: httpd
+            netdev: none
+          - package: testudp
+            netdev: none
+        include:
+          - arch: x86_64
+            packages: qemu-system-x86 libcap-ng-dev libseccomp-dev socat
+          - arch: aarch64
+            packages: qemu-system-aarch64
+
+          - arch: x86_64
+            package: rusty_demo
+            flags: --features pci-ids --virtiofsd
+          - arch: aarch64
+            package: rusty_demo
+            flags: --features pci-ids
+          - package: httpd
+            flags: --features ci,dhcpv4
+          - package: testudp
+            flags: --features udp,dhcpv4
+          - package: hello_world
+            flags: --no-default-features --microvm
+
     steps:
       - name: Checkout hermit-rs
         uses: actions/checkout@v4
@@ -130,7 +176,7 @@ jobs:
       - name: Install QEMU
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-system-x86 libcap-ng-dev libseccomp-dev socat
+          sudo apt-get install ${{ matrix.packages }}
       - uses: mkroening/rust-toolchain-toml@main
       - uses: mkroening/rust-toolchain-toml@main
         with:
@@ -145,75 +191,21 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: hermit-os/loader
-          file: rusty-loader-x86_64
+          file: rusty-loader-${{ matrix.arch }}
       - name: Install virtiofsd
+        if: ${{ matrix.arch == 'x86_64' && matrix.package == 'rusty_demo' }}
         run: cargo install virtiofsd
-      - name: rusty_demo with pci-ids and virtiofsd
-        run: cargo xtask ci qemu --arch x86_64 --package rusty_demo --features pci-ids --virtiofsd
-      - name: rusty_demo with pci-ids and virtiofsd (release)
-        run: cargo xtask ci qemu --arch x86_64 --package rusty_demo --features pci-ids --virtiofsd --release
-      - name: httpd with virtio-net-pci and dhcpv4
-        run: cargo xtask ci qemu --arch x86_64 --package httpd --features ci,dhcpv4 --netdev virtio-net-pci
-      - name: httpd with virtio-net-pci and dhcpv4 (release)
-        run: cargo xtask ci qemu --arch x86_64 --package httpd --features ci,dhcpv4 --netdev virtio-net-pci --release
-      - name: httpd with rtl8139 and dhcpv4
-        run: cargo xtask ci qemu --arch x86_64 --package httpd --features ci,dhcpv4,rtl8139 --netdev rtl8139
-      - name: httpd with rtl8139 and dhcpv4 (release)
-        run: cargo xtask ci qemu --arch x86_64 --package httpd --features ci,dhcpv4,rtl8139 --netdev rtl8139 --release
-      - name: hello_world on microVM (release)
-        run: cargo xtask ci qemu --arch x86_64 --package hello_world --no-default-features --microvm --release
-      - name: testudp with virtio-net-pci and dhcpv4
-        run: cargo xtask ci qemu --arch x86_64 --package testudp --features udp,dhcpv4 --netdev virtio-net-pci
-      - name: testudp with virtio-net-pci and dhcpv4 (release)
-        run: cargo xtask ci qemu --arch x86_64 --package testudp --features udp,dhcpv4 --netdev virtio-net-pci --release
-  
-  run-aarch64:
-    name: Run Hermit for Rust (aarch64)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: kernel
-    steps:
-      - name: Checkout hermit-rs
-        uses: actions/checkout@v4
-        with:
-          repository: hermit-os/hermit-rs
-          submodules: true
-      - name: Remove hermit-kernel submodule
-        run: git rm -r kernel
-        working-directory: .
-      - name: Checkout hermit-kernel
-        uses: actions/checkout@v4
-        with:
-          path: kernel
-      - name: Download loader
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: hermit-os/loader
-          file: rusty-loader-aarch64
-      - uses: mkroening/rust-toolchain-toml@main
-      - uses: mkroening/rust-toolchain-toml@main
-        with:
-          toolchain-file: 'kernel/rust-toolchain.toml'
-      - name: Install QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu-system-aarch64
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: |
-            .
-            kernel
-            kernel/hermit-builtins
-      - name: rusty_demo with pci-ids
-        run: cargo xtask ci qemu --arch aarch64 --package rusty_demo --features pci-ids
-      - name: rusty_demo with pci-ids (release)
-        run: cargo xtask ci qemu --arch aarch64 --package rusty_demo --features pci-ids --release
-      - name: httpd with dhcpv4
-        run: cargo xtask ci qemu --arch aarch64 --package httpd --features ci,dhcpv4 --netdev virtio-net-pci
-      - name: httpd with dhcpv4 (release)
-        run: cargo xtask ci qemu --arch aarch64 --package httpd --features ci,dhcpv4 --netdev virtio-net-pci --release
+      - name: Run VM
+        # cargo accepts multiple 'features' flags
+        # The '… && … || …' expression is like a ternary operator
+        run: >
+              cargo xtask ci qemu
+              --arch ${{ matrix.arch }}
+              --package ${{ matrix.package }}
+              ${{ matrix.flags }}
+              ${{ matrix.netdev == 'rtl8139' && '--features rtl8139' || '' }}
+              ${{ matrix.netdev != 'none' && format('--netdev {0}', matrix.netdev) || '' }}
+              --profile ${{ matrix.profile }}
 
   run-x86_64-kvm:
     name: Run Hermit for Rust (x86_64 + kvm)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           RUSTFLAGS:
 
   run-hermit:
-    name: Run Hermit for Rust
+    name: Run
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        profile: [dev, release]
         package: [rusty_demo, httpd, testudp, hello_world]
         netdev: [none, virtio-net-pci, rtl8139]
+        profile: [dev, release]
         exclude:
           # microvm (Firecracker) test does not run on aarch64
           - package: hello_world


### PR DESCRIPTION
Use a test configuration matrix to increase architecture testing parity, decrease CI configuration duplication and run tests at parallel, at the cost of increased compute and storage usage.