### PR TITLE
fix(net): deallocate network buffers

### DIFF
--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -215,6 +215,11 @@ impl<'a> NetworkInterface<'a> {
 	) -> (&mut T, &mut smoltcp::iface::Context) {
 		(self.sockets.get_mut(handle), self.iface.context())
 	}
+
+	pub(crate) fn destroy_socket(&mut self, handle: Handle) {
+		// This deallocates the socket's buffers
+		self.sockets.remove(handle);
+	}
 }
 
 #[inline]

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -66,6 +66,9 @@ impl<T> Socket<T> {
 		result
 	}
 
+	// TODO: Remove allow once fixed:
+	// https://github.com/rust-lang/rust-clippy/issues/11380
+	#[allow(clippy::needless_pass_by_ref_mut)]
 	async fn async_read(&self, buffer: &mut [u8]) -> Result<isize, i32> {
 		future::poll_fn(|cx| {
 			self.with(|socket| match socket.state() {

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -425,6 +425,7 @@ impl<T> Clone for Socket<T> {
 impl<T> Drop for Socket<T> {
 	fn drop(&mut self) {
 		let _ = block_on(self.async_close(), None);
+		NIC.lock().as_nic_mut().unwrap().destroy_socket(self.handle);
 	}
 }
 


### PR DESCRIPTION
Previously, network buffers were never deallocated again, resulting in quick out-of-memory situations if many connections are created.

Closes https://github.com/hermit-os/kernel/issues/899