### PR TITLE
ci: improve caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.arch }}-${{ matrix.profile }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.package == 'rusty_demo' }}
           workspaces: |
             .
             kernel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            hermit-builtins
       - run: cargo xtask clippy
 
   format:
@@ -76,6 +79,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            hermit-builtins
       - name: Build minimal kernel
         run: |
           cargo xtask build --arch x86_64 --no-default-features
@@ -94,6 +100,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            hermit-builtins
       - name: Unit tests
         run: cargo test --lib
         env:
@@ -187,6 +196,7 @@ jobs:
           workspaces: |
             .
             kernel
+            kernel/hermit-builtins
       - name: Download loader
         uses: dsaltares/fetch-gh-release-asset@master
         with:
@@ -266,6 +276,10 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        workspaces: |
+          .
+          kernel
+          kernel/hermit-builtins
     - name: rusty_demo on Uhyve
       run: cargo xtask ci uhyve --arch x86_64 --package rusty_demo
     - name: rusty_demo on Uhyve (release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
           toolchain-file: 'kernel/rust-toolchain.toml'
       - uses: Swatinem/rust-cache@v2
         with:
+          key: ${{ matrix.arch }}-${{ matrix.profile }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             .


### PR DESCRIPTION
We currently have only one cache for the whole matrix. Which one is saved is random.

This PR
1. adds more workspaces to the cache
2. creates one cache per arch and profile
3. only saves the cache on `rusty_demo`

CC: @cagatay-y 