### PR TITLE
collect configuration of mmio devices

### DIFF
--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::{ptr, str};
 
@@ -11,6 +12,7 @@ use crate::arch::x86_64::mm::{paging, PhysAddr};
 use crate::drivers::net::virtio_net::VirtioNetDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 use crate::drivers::virtio::transport::mmio::{DevId, MmioRegisterLayout, VirtioDriver};
+use crate::env;
 
 pub const MAGIC_VALUE: u32 = 0x74726976;
 
@@ -34,9 +36,90 @@ impl MmioDriver {
 	}
 }
 
-/// Tries to find the network device within the specified address range.
-/// Returns a reference to it within the Ok() if successful or an Err() on failure.
-pub fn detect_network() -> Result<&'static mut MmioRegisterLayout, &'static str> {
+fn check_linux_args(
+	linux_mmio: &'static [String],
+) -> Result<&'static mut MmioRegisterLayout, &'static str> {
+	let virtual_address =
+		crate::arch::mm::virtualmem::allocate(BasePageSize::SIZE as usize).unwrap();
+
+	for arg in linux_mmio {
+		trace!("check linux parameter: {}", arg);
+
+		match arg.trim().trim_matches(char::from(0)).strip_prefix("4K@") {
+			Some(arg) => {
+				let v: Vec<&str> = arg.trim().split(':').collect();
+				let without_prefix = v[0].trim_start_matches("0x");
+				let current_address = usize::from_str_radix(without_prefix, 16).unwrap();
+				let irq: u32 = v[1].parse::<u32>().unwrap();
+
+				trace!(
+					"try to detect MMIO device at physical address {:#X}",
+					current_address
+				);
+
+				let mut flags = PageTableEntryFlags::empty();
+				flags.normal().writable();
+				paging::map::<BasePageSize>(
+					virtual_address,
+					PhysAddr::from(current_address.align_down(BasePageSize::SIZE as usize)),
+					1,
+					flags,
+				);
+
+				// Verify the first register value to find out if this is really an MMIO magic-value.
+				let mmio = unsafe {
+					&mut *(ptr::from_exposed_addr_mut::<MmioRegisterLayout>(
+						virtual_address.as_usize()
+							| (current_address & (BasePageSize::SIZE as usize - 1)),
+					))
+				};
+
+				let magic = mmio.get_magic_value();
+				let version = mmio.get_version();
+
+				if magic != MAGIC_VALUE {
+					trace!("It's not a MMIO-device at {mmio:p}");
+					continue;
+				}
+
+				if version != 2 {
+					trace!("Found a legacy device, which isn't supported");
+					continue;
+				}
+
+				// We found a MMIO-device (whose 512-bit address in this structure).
+				trace!("Found a MMIO-device at {mmio:p}");
+
+				// Verify the device-ID to find the network card
+				let id = mmio.get_device_id();
+
+				if id != DevId::VIRTIO_DEV_ID_NET {
+					trace!("It's not a network card at {mmio:p}");
+					continue;
+				}
+
+				info!("Found network card at {mmio:p}, irq {}", irq);
+
+				crate::arch::mm::physicalmem::reserve(
+					PhysAddr::from(current_address.align_down(BasePageSize::SIZE as usize)),
+					BasePageSize::SIZE as usize,
+				);
+
+				return Ok(mmio);
+			}
+			_ => {
+				warn!("Inavlid prefix in {}", arg);
+			}
+		}
+	}
+
+	// frees obsolete virtual memory region for MMIO devices
+	crate::arch::mm::virtualmem::deallocate(virtual_address, BasePageSize::SIZE as usize);
+
+	Err("Network card not found!")
+}
+
+fn guess_mmio() -> Result<&'static mut MmioRegisterLayout, &'static str> {
 	// Trigger page mapping in the first iteration!
 	let mut current_page = 0;
 	let virtual_address =
@@ -110,6 +193,18 @@ pub fn detect_network() -> Result<&'static mut MmioRegisterLayout, &'static str>
 	crate::arch::mm::virtualmem::deallocate(virtual_address, BasePageSize::SIZE as usize);
 
 	Err("Network card not found!")
+}
+
+/// Tries to find the network device within the specified address range.
+/// Returns a reference to it within the Ok() if successful or an Err() on failure.
+pub fn detect_network() -> Result<&'static mut MmioRegisterLayout, &'static str> {
+	let linux_mmio = env::mmio();
+
+	if linux_mmio.len() > 0 {
+		check_linux_args(linux_mmio)
+	} else {
+		guess_mmio()
+	}
 }
 
 pub(crate) fn register_driver(drv: MmioDriver) {

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -98,8 +98,6 @@ fn check_linux_args(
 					continue;
 				}
 
-				info!("Found network card at {mmio:p}, irq {}", irq);
-
 				crate::arch::mm::physicalmem::reserve(
 					PhysAddr::from(current_address.align_down(BasePageSize::SIZE as usize)),
 					BasePageSize::SIZE as usize,

--- a/src/drivers/net/virtio_net.rs
+++ b/src/drivers/net/virtio_net.rs
@@ -681,7 +681,7 @@ impl VirtioNetDriver {
 	}
 
 	/// Returns the current status of the device, if VIRTIO_NET_F_STATUS
-	/// has been negotiated. Otherwise returns zero.
+	/// has been negotiated. Otherwise assumes an active device.
 	#[cfg(not(feature = "pci"))]
 	pub fn dev_status(&self) -> u16 {
 		if self
@@ -691,7 +691,7 @@ impl VirtioNetDriver {
 		{
 			self.dev_cfg.raw.get_status()
 		} else {
-			0
+			u16::from(Status::VIRTIO_NET_S_LINK_UP)
 		}
 	}
 
@@ -767,11 +767,8 @@ impl VirtioNetDriver {
 		self.com_cfg.set_drv();
 
 		// Define minimal feature set
-		let min_feats: Vec<Features> = vec![
-			Features::VIRTIO_F_VERSION_1,
-			Features::VIRTIO_NET_F_MAC,
-			Features::VIRTIO_NET_F_STATUS,
-		];
+		let min_feats: Vec<Features> =
+			vec![Features::VIRTIO_F_VERSION_1, Features::VIRTIO_NET_F_MAC];
 
 		let mut min_feat_set = FeatureSet::new(0);
 		min_feat_set.set_features(&min_feats);
@@ -779,6 +776,8 @@ impl VirtioNetDriver {
 
 		// If wanted, push new features into feats here:
 		//
+		// the link status can be announced
+		feats.push(Features::VIRTIO_NET_F_STATUS);
 		// Indirect descriptors can be used
 		feats.push(Features::VIRTIO_F_RING_INDIRECT_DESC);
 		// MTU setting can be used

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -81,7 +81,7 @@ pub(crate) fn init() {
 		npage_2tables / (BasePageSize::SIZE as usize / mem::align_of::<usize>()) + 1;
 	let reserved_space = (npage_3tables + npage_2tables + npage_1tables)
 		* BasePageSize::SIZE as usize
-		+ LargePageSize::SIZE as usize;
+		+ 2 * LargePageSize::SIZE as usize;
 	#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 	let has_1gib_pages = arch::processor::supports_1gib_pages();
 	let has_2mib_pages = arch::processor::supports_2mib_pages();


### PR DESCRIPTION
Firecracker pass the configuration of all mmio device by a Linux kernel parameter This parameter is defined as followd:

> virtio_mmio.device=
>    [VMMIO] Memory mapped virtio (platform) device.
> 
>       <size>@<baseaddr>:<irq>[:<id>]
>    where:
>       <size>     := size (can use standard suffixes like K, M and G)
>       <baseaddr> := physical base address
>       <irq>      := interrupt number (as passed to request_irq())
>       <id>       := (optional) platform device id
>    example:
>                  virtio_mmio.device=1K@0x100b0000:48:7
>    Can be used multiple times for multiple devices.

This patch parse the command line and store the string `<size>@<baseaddr>:<irq>[:<id>]` in a vector, which is part of CLI. The vector is used to find the network device on a microVM.

In addition, the network driver support devices, which doesn't support VIRTIO_NET_F_STATUS.

This PR based on preliminary work from @duanyu-yu