### PR TITLE
feat: make hermit-builtins a workspace root

### DIFF
--- a/hermit-builtins/Cargo.toml
+++ b/hermit-builtins/Cargo.toml
@@ -8,3 +8,5 @@ libm = "0.2"
 
 [lib]
 crate-type = ["staticlib"]
+
+[workspace]


### PR DESCRIPTION
This fixes compilation inside workspaces without explicit exclude.

Closes https://github.com/hermit-os/hermit-rs/issues/511