### PR TITLE
doc: fix broken internal links

### DIFF
--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -15,7 +15,7 @@ pub mod pci;
 pub mod virtio;
 
 /// A common error module for drivers.
-/// [DriverError](enums.drivererror.html) values will be
+/// [DriverError](error::DriverError) values will be
 /// passed on to higher layers.
 pub mod error {
 	use core::fmt;

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -98,10 +98,10 @@ impl<'a> VqCfgHandler<'a> {
 	}
 }
 
-/// Wraps a [ComCfgRaw](structs.comcfgraw.html) in order to preserve
+/// Wraps a [MmioRegisterLayout] in order to preserve
 /// the original structure.
 ///
-/// Provides a safe API for Raw structure and allows interaction with the device via
+/// Provides a safe API for the raw structure and allows interaction with the device via
 /// the structure.
 pub struct ComCfg {
 	// References the raw structure in PCI memory space. Is static as
@@ -313,7 +313,7 @@ impl NotifCtrl {
 	}
 }
 
-/// Wraps a [IsrStatusRaw](structs.isrstatusraw.html) in order to preserve
+/// Wraps a [IsrStatusRaw] in order to preserve
 /// the original structure and allow interaction with the device via
 /// the structure.
 ///

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -182,7 +182,7 @@ pub fn map_dev_cfg<T>(cap: &PciCap) -> Option<&'static mut T> {
 /// as it is not directly mapped into address space from PCI device
 /// configuration space.
 /// Therefore the struct only contains necessary information to map
-/// corresponding [CfgType](enums.CfgType.html) into address space.
+/// corresponding [CfgType] into address space.
 #[derive(Clone)]
 pub struct PciCap {
 	cfg_type: CfgType,
@@ -262,11 +262,11 @@ impl PartialEq for PciCapRaw {
 /// a given Virtio PCI device.
 ///
 /// As Virtio's PCI devices are allowed to present multiple capability
-/// structures of the same [CfgType](enums.cfgtype.html), the structure
+/// structures of the same [CfgType], the structure
 /// provides a driver with all capabilities, sorted in descending priority,
 /// allowing the driver to choose.
 /// The structure contains a special dev_cfg_list field, a vector holding
-/// [PciCap](structs.pcicap.html) objects, to allow the driver to map its
+/// [PciCap] objects, to allow the driver to map its
 /// device specific configurations independently.
 pub struct UniCapsColl {
 	com_cfg_list: Vec<ComCfg>,
@@ -378,7 +378,7 @@ impl UniCapsColl {
 	}
 }
 
-/// Wraps a [ComCfgRaw](structs.comcfgraw.html) in order to preserve
+/// Wraps a [ComCfgRaw] in order to preserve
 /// the original structure.
 ///
 /// Provides a safe API for Raw structure and allows interaction with the device via
@@ -736,7 +736,7 @@ impl NotifCtrl {
 	}
 }
 
-/// Wraps a [IsrStatusRaw](structs.isrstatusraw.html) in order to preserve
+/// Wraps a [IsrStatusRaw] in order to preserve
 /// the original structure and allow interaction with the device via
 /// the structure.
 ///
@@ -1000,7 +1000,7 @@ impl PciBar {
 	}
 }
 
-/// Reads a raw capability struct [PciCapRaw](structs.PcicapRaw.html) out of a PCI device's configuration space.
+/// Reads a raw capability struct [PciCapRaw] out of a PCI device's configuration space.
 fn read_cap_raw(device: &PciDevice<PciConfigRegion>, register: u32) -> PciCapRaw {
 	let mut quadruple_word: [u8; 16] = [0; 16];
 
@@ -1228,8 +1228,8 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 }
 
 /// Checks existing drivers for support of given device. Upon match, provides
-/// driver with a [Caplist](struct.Caplist.html) struct, holding the structures of the capabilities
-/// list of the given device.
+/// driver with a [`PciDevice<PciConfigRegion>`] reference, allowing access to the capabilities
+/// list of the given device through [map_caps].
 pub(crate) fn init_device(
 	device: &PciDevice<PciConfigRegion>,
 ) -> Result<VirtioDriver, DriverError> {

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -1,8 +1,8 @@
 //! This module contains Virtio's virtqueue.
 //!
 //! The virtqueue is available in two forms.
-//! [Split](structs.SplitVqueue.html) and [Packed](structs.PackedVqueue.html).
-//! Both queues are wrapped inside an enum [Virtqueue](enums.Virtqueue.html) in
+//! [SplitVq] and [PackedVq].
+//! Both queues are wrapped inside an enum [Virtq] in
 //! order to provide an unified interface.
 //!
 //! Drivers who need a more fine grained access to the specific queues must
@@ -108,7 +108,7 @@ struct Descriptor {
 }
 
 /// The Virtq enum unifies access to the two different Virtqueue types
-/// [PackedVq](structs.PackedVq.html) and [SplitVq](structs.SplitVq.html).
+/// [PackedVq] and [SplitVq].
 ///
 /// The enum provides a common interface for both types. Which in some case
 /// might not provide the complete feature set of each queue. Drivers who
@@ -2584,7 +2584,7 @@ pub mod error {
 		/// "unsend" `TransferToken` to the queue (see Docs for details)
 		/// or the device needs to process available descriptors in the queue.
 		NoDescrAvail,
-		/// Indicates that a [BuffSpec](super.BuffSpec) does have the right size
+		/// Indicates that a [BuffSpec](super::BuffSpec) does have the right size
 		/// for a given structure. Returns the structures size in bytes.
 		///
 		/// E.g: A struct `T` with size of `4 bytes` must have a `BuffSpec`, which

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -989,7 +989,7 @@ pub struct PackedVq {
 	/// Actually notify device about avail buffers
 	notif_ctrl: NotifCtrl,
 	/// Memory pool controls the amount of "free floating" descriptors
-	/// See [MemPool](super.MemPool) docs for detail.
+	/// See [MemPool] docs for detail.
 	mem_pool: Rc<MemPool>,
 	/// The size of the queue, equals the number of descriptors which can
 	/// be used


### PR DESCRIPTION
Changes broken explicit links to intradoc links.
Related to  #353.