### PR TITLE
rename the feature "syscall" to "common-os"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tcp = ["smoltcp", "smoltcp/socket-tcp"]
 udp = ["smoltcp", "smoltcp/socket-udp"]
 trace = []
 vga = []
-syscall = []
+common-os = []
 
 [dependencies]
 ahash = { version = "0.8", default-features = false }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -75,7 +75,7 @@ macro_rules! dbg {
 #[cfg(not(any(
 	target_arch = "riscv64",
 	all(target_arch = "x86_64", feature = "newlib"),
-	feature = "syscall"
+	feature = "common-os"
 )))]
 macro_rules! kernel_function {
 	($f:ident()) => {
@@ -113,7 +113,7 @@ macro_rules! kernel_function {
 #[cfg(any(
 	target_arch = "riscv64",
 	all(target_arch = "x86_64", feature = "newlib"),
-	feature = "syscall"
+	feature = "common-os"
 ))]
 macro_rules! kernel_function {
 	($f:ident($($x:tt)*)) => {{


### PR DESCRIPTION
The feature currently has no meaning. "common-os" will later enable a classical monolithic kernel.