### PR TITLE
perf: forward default allocator methods and remove memory overprovisioning

### DIFF
--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -45,6 +45,11 @@ unsafe impl GlobalAlloc for LockedAllocator {
 		let layout = Self::align_layout(layout);
 		unsafe { self.0.dealloc(ptr, layout) }
 	}
+
+	unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+		let layout = Self::align_layout(layout);
+		unsafe { self.0.alloc_zeroed(layout) }
+	}
 }
 
 #[cfg(all(test, not(target_os = "none")))]

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -50,6 +50,12 @@ unsafe impl GlobalAlloc for LockedAllocator {
 		let layout = Self::align_layout(layout);
 		unsafe { self.0.alloc_zeroed(layout) }
 	}
+
+	unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+		let layout = Self::align_layout(layout);
+		let new_size = new_size.align_up(core::mem::size_of::<crossbeam_utils::CachePadded<u8>>());
+		unsafe { self.0.realloc(ptr, layout, new_size) }
+	}
 }
 
 #[cfg(all(test, not(target_os = "none")))]

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -3,7 +3,6 @@
 
 use core::alloc::{GlobalAlloc, Layout};
 
-use align_address::Align;
 use hermit_sync::RawInterruptTicketMutex;
 use talc::{ErrOnOom, Span, Talc, Talck};
 
@@ -16,13 +15,10 @@ impl LockedAllocator {
 
 	#[inline]
 	fn align_layout(layout: Layout) -> Layout {
-		let size = layout
-			.size()
-			.align_up(core::mem::size_of::<crossbeam_utils::CachePadded<u8>>());
 		let align = layout
 			.align()
 			.max(core::mem::align_of::<crossbeam_utils::CachePadded<u8>>());
-		Layout::from_size_align(size, align).unwrap()
+		Layout::from_size_align(layout.size(), align).unwrap()
 	}
 
 	pub unsafe fn init(&self, heap_bottom: *mut u8, heap_size: usize) {
@@ -53,7 +49,6 @@ unsafe impl GlobalAlloc for LockedAllocator {
 
 	unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
 		let layout = Self::align_layout(layout);
-		let new_size = new_size.align_up(core::mem::size_of::<crossbeam_utils::CachePadded<u8>>());
 		unsafe { self.0.realloc(ptr, layout, new_size) }
 	}
 }


### PR DESCRIPTION
Thought I'd check up on how people were using talc in the wild :)

There are two ideas here:
1. Use `talc`'s reallocation mechanisms. This is recommended for faster in-place reallocation (avoiding the much-more-expensive memcpy that default-reallocation _always_ invokes) and also allows for interleaving some allocator operations as introduced in v4.2 to somewhat improve allocation concurrency.
2. Avoid padding the size of allocations. Increasing the alignment of an allocation is sufficient to avoid false sharing. Talc needs a little bit of metadata next to each allocation, and this would create `N-8` sized holes in between every allocation due to the demands placed on it. By removing the size requirement, false sharing avoidance is unhindered, but this allows Talc to minimize the overhead of high-alignments. (Talc is designed to automatically place the metadata in a way that minimized false sharing, but this only helps if Talc can sneak it in within the same cache line, which is impossible if Talc thinks you want the whole cache line for user data.)

Word salad aside, the changes are quite trivial.

Closes https://github.com/hermit-os/kernel/issues/1059