### PR TITLE
add support of a unix-like poll function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +504,7 @@ dependencies = [
  "align-address",
  "anyhow",
  "arm-gic",
+ "async-trait",
  "bit_field",
  "bitflags 2.4.2",
  "build-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +396,26 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "exclusive_cell"
@@ -504,6 +544,7 @@ dependencies = [
  "align-address",
  "anyhow",
  "arm-gic",
+ "async-lock",
  "async-trait",
  "bit_field",
  "bitflags 2.4.2",
@@ -873,6 +914,12 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "plain"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,6 @@ dependencies = [
  "num-traits",
  "pci-ids",
  "pci_types",
- "pflock",
  "qemu-exit",
  "rand_chacha",
  "riscv",
@@ -867,15 +866,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pflock"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb30d7f84b469117e8b95025621135ec4b32c8a987e7e40e38d3654e0b2e47e"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "phf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 pci-ids = { version = "0.2", optional = true }
 pci_types = { version = "0.6" }
-pflock = "0.2"
 rand_chacha = { version = "0.3", default-features = false }
 shell-words = { version = "1.1", default-features = false }
 smallvec = { version = "1", features = ["const_new"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ talc = { version = "4" }
 time = { version = "0.3", default-features = false }
 zerocopy = { version = "0.7", features = ["derive"] }
 build-time = "0.1.3"
+async-trait = "0.1.48"
 
 [dependencies.smoltcp]
 version = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ time = { version = "0.3", default-features = false }
 zerocopy = { version = "0.7", features = ["derive"] }
 build-time = "0.1.3"
 async-trait = "0.1.48"
+async-lock = { version = "3.3.0", default-features = false }
 
 [dependencies.smoltcp]
 version = "0.11"

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -103,8 +103,6 @@ pub fn init() {
 #[inline]
 pub(crate) fn now() -> u64 {
 	crate::arch::kernel::systemtime::now_micros()
-		.try_into()
-		.unwrap()
 }
 
 /// Blocks the current thread on `f`, running the executor when idling.
@@ -233,9 +231,8 @@ where
 		let delay = None;
 
 		if backoff.is_completed() && delay.unwrap_or(10_000_000) > 10_000 {
-			let wakeup_time = timeout.map(|duration| {
-				u64::try_from(start).unwrap() + u64::try_from(duration.as_micros()).unwrap()
-			});
+			let wakeup_time =
+				timeout.map(|duration| start + u64::try_from(duration.as_micros()).unwrap());
 			#[cfg(any(feature = "tcp", feature = "udp"))]
 			if !no_retransmission {
 				let ticks = crate::arch::processor::get_timer_ticks();

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -11,11 +11,33 @@ use alloc::task::Wake;
 use core::future::Future;
 use core::sync::atomic::AtomicU32;
 use core::task::{Context, Poll, Waker};
+use core::time::Duration;
 
+use crossbeam_utils::Backoff;
 use hermit_sync::without_interrupts;
+#[cfg(any(feature = "tcp", feature = "udp"))]
+use smoltcp::time::Instant;
 
 use crate::arch::core_local::*;
+#[cfg(all(
+	any(feature = "tcp", feature = "udp"),
+	not(feature = "pci"),
+	not(feature = "newlib")
+))]
+use crate::drivers::mmio::get_network_driver;
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
+use crate::drivers::net::NetworkDriver;
+#[cfg(all(
+	any(feature = "tcp", feature = "udp"),
+	feature = "pci",
+	not(feature = "newlib")
+))]
+use crate::drivers::pci::get_network_driver;
+#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
+use crate::executor::network::network_delay;
 use crate::executor::task::AsyncTask;
+use crate::fd::IoError;
+use crate::scheduler::PerCoreSchedulerExt;
 use crate::synch::futex::*;
 
 struct TaskNotify {
@@ -76,4 +98,164 @@ where
 pub fn init() {
 	#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "newlib")))]
 	crate::executor::network::init();
+}
+
+#[inline]
+pub(crate) fn now() -> u64 {
+	crate::arch::kernel::systemtime::now_micros()
+		.try_into()
+		.unwrap()
+}
+
+/// Blocks the current thread on `f`, running the executor when idling.
+pub(crate) fn poll_on<F, T>(future: F, timeout: Option<Duration>) -> Result<T, IoError>
+where
+	F: Future<Output = Result<T, IoError>>,
+{
+	// disable network interrupts
+	#[cfg(any(feature = "tcp", feature = "udp"))]
+	let no_retransmission = {
+		let mut guard = get_network_driver().unwrap().lock();
+		guard.set_polling_mode(true);
+		guard.get_checksums().tcp.tx()
+	};
+
+	let start = now();
+	let waker = core::task::Waker::noop();
+	let mut cx = Context::from_waker(&waker);
+	let mut future = future;
+	let mut future = unsafe { core::pin::Pin::new_unchecked(&mut future) };
+
+	loop {
+		// run background tasks
+		run();
+
+		if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			if !no_retransmission {
+				let wakeup_time =
+					network_delay(Instant::from_micros_const(now().try_into().unwrap()))
+						.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+				core_scheduler().add_network_timer(wakeup_time);
+			}
+
+			// allow network interrupts
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			get_network_driver().unwrap().lock().set_polling_mode(false);
+
+			return t;
+		}
+
+		if let Some(duration) = timeout {
+			if Duration::from_micros(now() - start) >= duration {
+				#[cfg(any(feature = "tcp", feature = "udp"))]
+				if !no_retransmission {
+					let wakeup_time =
+						network_delay(Instant::from_micros_const(now().try_into().unwrap()))
+							.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+					core_scheduler().add_network_timer(wakeup_time);
+				}
+
+				// allow network interrupts
+				#[cfg(any(feature = "tcp", feature = "udp"))]
+				get_network_driver().unwrap().lock().set_polling_mode(false);
+
+				return Err(IoError::ETIME);
+			}
+		}
+	}
+}
+
+/// Blocks the current thread on `f`, running the executor when idling.
+pub(crate) fn block_on<F, T>(future: F, timeout: Option<Duration>) -> Result<T, IoError>
+where
+	F: Future<Output = Result<T, IoError>>,
+{
+	// disable network interrupts
+	#[cfg(any(feature = "tcp", feature = "udp"))]
+	let no_retransmission = {
+		let mut guard = get_network_driver().unwrap().lock();
+		guard.set_polling_mode(true);
+		!guard.get_checksums().tcp.tx()
+	};
+
+	let backoff = Backoff::new();
+	let start = now();
+	let task_notify = Arc::new(TaskNotify::new());
+	let waker = task_notify.clone().into();
+	let mut cx = Context::from_waker(&waker);
+	let mut future = future;
+	let mut future = unsafe { core::pin::Pin::new_unchecked(&mut future) };
+
+	loop {
+		// run background tasks
+		run();
+
+		let now = now();
+		if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			if !no_retransmission {
+				let network_timer =
+					network_delay(Instant::from_micros_const(now.try_into().unwrap()))
+						.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+				core_scheduler().add_network_timer(network_timer);
+			}
+
+			// allow network interrupts
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			get_network_driver().unwrap().lock().set_polling_mode(false);
+
+			return t;
+		}
+
+		if let Some(duration) = timeout {
+			if Duration::from_micros(now - start) >= duration {
+				#[cfg(any(feature = "tcp", feature = "udp"))]
+				if !no_retransmission {
+					let network_timer =
+						network_delay(Instant::from_micros_const(now.try_into().unwrap()))
+							.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
+					core_scheduler().add_network_timer(network_timer);
+				}
+
+				// allow network interrupts
+				#[cfg(any(feature = "tcp", feature = "udp"))]
+				get_network_driver().unwrap().lock().set_polling_mode(false);
+
+				return Err(IoError::ETIME);
+			}
+		}
+
+		#[cfg(any(feature = "tcp", feature = "udp"))]
+		let delay = network_delay(Instant::from_micros_const(now.try_into().unwrap()))
+			.map(|d| d.total_micros());
+		#[cfg(not(any(feature = "tcp", feature = "udp")))]
+		let delay = None;
+
+		if backoff.is_completed() && delay.unwrap_or(10_000_000) > 10_000 {
+			let wakeup_time = timeout.map(|duration| {
+				u64::try_from(start).unwrap() + u64::try_from(duration.as_micros()).unwrap()
+			});
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			if !no_retransmission {
+				let ticks = crate::arch::processor::get_timer_ticks();
+				let network_timer = delay.map(|d| ticks + d);
+				core_scheduler().add_network_timer(network_timer);
+			}
+
+			// allow network interrupts
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			get_network_driver().unwrap().lock().set_polling_mode(false);
+
+			// switch to another task
+			task_notify.wait(wakeup_time);
+
+			// restore default values
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			get_network_driver().unwrap().lock().set_polling_mode(true);
+			backoff.reset();
+		} else {
+			backoff.snooze();
+		}
+	}
 }

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -154,16 +154,28 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 		Ok(PollEvent::EMPTY)
 	}
 
+	/// `async_read` attempts to read `len` bytes from the object references
+	/// by the descriptor
+	async fn async_read(&self, _buf: &mut [u8]) -> Result<usize, IoError> {
+		Err(IoError::ENOSYS)
+	}
+
 	/// `read` attempts to read `len` bytes from the object references
 	/// by the descriptor
-	fn read(&self, _buf: &mut [u8]) -> Result<usize, IoError> {
+	fn read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
+		block_on(self.async_read(buf), None)
+	}
+
+	/// `async_write` attempts to write `len` bytes to the object references
+	/// by the descriptor
+	async fn async_write(&self, _buf: &[u8]) -> Result<usize, IoError> {
 		Err(IoError::ENOSYS)
 	}
 
 	/// `write` attempts to write `len` bytes to the object references
 	/// by the descriptor
-	fn write(&self, _buf: &[u8]) -> Result<usize, IoError> {
-		Err(IoError::ENOSYS)
+	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+		block_on(self.async_write(buf), None)
 	}
 
 	/// `lseek` function repositions the offset of the file descriptor fildes

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -328,7 +328,7 @@ pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<usize, IoError>
 	}
 
 	if obj.is_nonblocking() {
-		poll_on(obj.async_read(buf), Some(Duration::ZERO.into())).map_err(|x| {
+		poll_on(obj.async_read(buf), Some(Duration::ZERO)).map_err(|x| {
 			if x == IoError::ETIME {
 				IoError::EAGAIN
 			} else {
@@ -336,7 +336,7 @@ pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<usize, IoError>
 			}
 		})
 	} else {
-		match poll_on(obj.async_read(buf), Some(Duration::from_secs(2).into())) {
+		match poll_on(obj.async_read(buf), Some(Duration::from_secs(2))) {
 			Err(IoError::ETIME) => block_on(obj.async_read(buf), None),
 			Err(x) => Err(x),
 			Ok(x) => Ok(x),
@@ -352,7 +352,7 @@ pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> Result<usize, IoError> {
 	}
 
 	if obj.is_nonblocking() {
-		poll_on(obj.async_write(buf), Some(Duration::ZERO.into())).map_err(|x| {
+		poll_on(obj.async_write(buf), Some(Duration::ZERO)).map_err(|x| {
 			if x == IoError::ETIME {
 				IoError::EAGAIN
 			} else {
@@ -360,7 +360,7 @@ pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> Result<usize, IoError> {
 			}
 		})
 	} else {
-		match poll_on(obj.async_write(buf), Some(Duration::from_secs(2).into())) {
+		match poll_on(obj.async_write(buf), Some(Duration::from_secs(2))) {
 			Err(IoError::ETIME) => block_on(obj.async_write(buf), None),
 			Err(x) => Err(x),
 			Ok(x) => Ok(x),

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -253,7 +253,10 @@ impl ObjectInterface for Socket {
 				| tcp::State::FinWait1
 				| tcp::State::FinWait2
 				| tcp::State::Listen
-				| tcp::State::TimeWait => Poll::Ready(Err(IoError::EIO)),
+				| tcp::State::TimeWait => {
+					result.insert(PollEvent::POLLNVAL);
+					Poll::Ready(Ok(result))
+				}
 				_ => {
 					if socket.can_send() {
 						if event.contains(PollEvent::POLLOUT) {

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -1,8 +1,10 @@
+use alloc::boxed::Box;
 use core::future;
 use core::ops::DerefMut;
 use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use core::task::Poll;
 
+use async_trait::async_trait;
 use smoltcp::iface;
 use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
@@ -10,7 +12,7 @@ use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 
 use crate::executor::network::{now, Handle, NetworkState, NIC};
 use crate::executor::{block_on, poll_on};
-use crate::fd::{IoCtl, IoError, ObjectInterface, SocketOption};
+use crate::fd::{IoCtl, IoError, ObjectInterface, PollEvent, SocketOption};
 use crate::syscalls::net::*;
 use crate::DEFAULT_KEEP_ALIVE_INTERVAL;
 
@@ -238,7 +240,53 @@ impl Socket {
 	}
 }
 
+#[async_trait]
 impl ObjectInterface for Socket {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
+		future::poll_fn(|cx| {
+			self.with(|socket| match socket.state() {
+				tcp::State::Closed
+				| tcp::State::Closing
+				| tcp::State::CloseWait
+				| tcp::State::FinWait1
+				| tcp::State::FinWait2
+				| tcp::State::Listen
+				| tcp::State::TimeWait => Poll::Ready(Err(IoError::EIO)),
+				_ => {
+					if socket.can_send() {
+						if event.contains(PollEvent::POLLOUT) {
+							result.insert(PollEvent::POLLOUT);
+						} else if event.contains(PollEvent::POLLWRNORM) {
+							result.insert(PollEvent::POLLWRNORM);
+						} else if event.contains(PollEvent::POLLWRBAND) {
+							result.insert(PollEvent::POLLWRBAND);
+						}
+					}
+
+					if socket.can_recv() {
+						if event.contains(PollEvent::POLLIN) {
+							result.insert(PollEvent::POLLIN);
+						} else if event.contains(PollEvent::POLLRDNORM) {
+							result.insert(PollEvent::POLLRDNORM);
+						} else if event.contains(PollEvent::POLLRDBAND) {
+							result.insert(PollEvent::POLLRDBAND);
+						}
+					}
+
+					if result.is_empty() {
+						socket.register_recv_waker(cx.waker());
+						Poll::Pending
+					} else {
+						Poll::Ready(Ok(result))
+					}
+				}
+			})
+		})
+		.await
+	}
+
 	fn bind(&self, endpoint: IpListenEndpoint) -> Result<(), IoError> {
 		self.port.store(endpoint.port, Ordering::Release);
 		Ok(())

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -9,8 +9,8 @@ use smoltcp::socket::udp::UdpMetadata;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 
-use crate::executor::network::{block_on, now, poll_on, Handle, NetworkState, NIC};
-use crate::executor::poll_on;
+use crate::executor::network::{now, Handle, NetworkState, NIC};
+use crate::executor::{block_on, poll_on};
 use crate::fd::{IoCtl, IoError, ObjectInterface};
 
 #[derive(Debug)]

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -171,6 +171,8 @@ impl ObjectInterface for Socket {
 							result.insert(PollEvent::POLLRDBAND);
 						}
 					}
+				} else {
+					result.insert(PollEvent::POLLNVAL);
 				}
 
 				if result.is_empty() {

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,8 +1,10 @@
+use alloc::boxed::Box;
 use core::future;
 use core::ops::DerefMut;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::Poll;
 
+use async_trait::async_trait;
 use crossbeam_utils::atomic::AtomicCell;
 use smoltcp::socket::udp;
 use smoltcp::socket::udp::UdpMetadata;
@@ -11,7 +13,7 @@ use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 
 use crate::executor::network::{now, Handle, NetworkState, NIC};
 use crate::executor::{block_on, poll_on};
-use crate::fd::{IoCtl, IoError, ObjectInterface};
+use crate::fd::{IoCtl, IoError, ObjectInterface, PollEvent};
 
 #[derive(Debug)]
 pub struct IPv4;
@@ -142,7 +144,46 @@ impl Socket {
 	}
 }
 
+#[async_trait]
 impl ObjectInterface for Socket {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.is_open() {
+					if socket.can_send() {
+						if event.contains(PollEvent::POLLOUT) {
+							result.insert(PollEvent::POLLOUT);
+						} else if event.contains(PollEvent::POLLWRNORM) {
+							result.insert(PollEvent::POLLWRNORM);
+						} else if event.contains(PollEvent::POLLWRBAND) {
+							result.insert(PollEvent::POLLWRBAND);
+						}
+					}
+
+					if socket.can_recv() {
+						if event.contains(PollEvent::POLLIN) {
+							result.insert(PollEvent::POLLIN);
+						} else if event.contains(PollEvent::POLLRDNORM) {
+							result.insert(PollEvent::POLLRDNORM);
+						} else if event.contains(PollEvent::POLLRDBAND) {
+							result.insert(PollEvent::POLLRDBAND);
+						}
+					}
+				}
+
+				if result.is_empty() {
+					socket.register_recv_waker(cx.waker());
+					Poll::Pending
+				} else {
+					Poll::Ready(Ok(result))
+				}
+			})
+		})
+		.await
+	}
+
 	fn bind(&self, endpoint: IpListenEndpoint) -> Result<(), IoError> {
 		self.with(|socket| socket.bind(endpoint).map_err(|_| IoError::EADDRINUSE))
 	}

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -94,7 +94,7 @@ impl ObjectInterface for GenericStdout {
 		Ok(result)
 	}
 
-	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		// stdin/err/out all go to console
 		CONSOLE.lock().write_all(buf);
 
@@ -127,7 +127,7 @@ impl ObjectInterface for GenericStderr {
 		Ok(result)
 	}
 
-	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		// stdin/err/out all go to console
 		CONSOLE.lock().write_all(buf);
 
@@ -171,7 +171,7 @@ impl ObjectInterface for UhyveStdout {
 		Ok(result)
 	}
 
-	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		let mut syswrite = SysWrite::new(STDOUT_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
 
@@ -204,7 +204,7 @@ impl ObjectInterface for UhyveStderr {
 		Ok(result)
 	}
 
-	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		let mut syswrite = SysWrite::new(STDERR_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
 

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -1,13 +1,15 @@
+use alloc::boxed::Box;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use core::ptr;
 
+use async_trait::async_trait;
 #[cfg(target_arch = "x86_64")]
 use x86::io::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use crate::arch::mm::{paging, VirtAddr};
 use crate::console::CONSOLE;
-use crate::fd::{IoError, ObjectInterface, STDERR_FILENO, STDOUT_FILENO};
+use crate::fd::{IoError, ObjectInterface, PollEvent, STDERR_FILENO, STDOUT_FILENO};
 
 const UHYVE_PORT_WRITE: u16 = 0x400;
 
@@ -76,7 +78,20 @@ impl GenericStdin {
 #[derive(Debug, Clone)]
 pub struct GenericStdout;
 
+#[async_trait]
 impl ObjectInterface for GenericStdout {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		if event.contains(PollEvent::POLLOUT) {
+			Ok(PollEvent::POLLOUT)
+		} else if event.contains(PollEvent::POLLWRNORM) {
+			Ok(PollEvent::POLLWRNORM)
+		} else if event.contains(PollEvent::POLLWRBAND) {
+			Ok(PollEvent::POLLWRBAND)
+		} else {
+			Ok(PollEvent::EMPTY)
+		}
+	}
+
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		// stdin/err/out all go to console
 		CONSOLE.lock().write_all(buf);
@@ -94,7 +109,20 @@ impl GenericStdout {
 #[derive(Debug, Clone)]
 pub struct GenericStderr;
 
+#[async_trait]
 impl ObjectInterface for GenericStderr {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		if event.contains(PollEvent::POLLOUT) {
+			Ok(PollEvent::POLLOUT)
+		} else if event.contains(PollEvent::POLLWRNORM) {
+			Ok(PollEvent::POLLWRNORM)
+		} else if event.contains(PollEvent::POLLWRBAND) {
+			Ok(PollEvent::POLLWRBAND)
+		} else {
+			Ok(PollEvent::EMPTY)
+		}
+	}
+
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		// stdin/err/out all go to console
 		CONSOLE.lock().write_all(buf);
@@ -123,7 +151,20 @@ impl UhyveStdin {
 #[derive(Debug, Clone)]
 pub struct UhyveStdout;
 
+#[async_trait]
 impl ObjectInterface for UhyveStdout {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		if event.contains(PollEvent::POLLOUT) {
+			Ok(PollEvent::POLLOUT)
+		} else if event.contains(PollEvent::POLLWRNORM) {
+			Ok(PollEvent::POLLWRNORM)
+		} else if event.contains(PollEvent::POLLWRBAND) {
+			Ok(PollEvent::POLLWRBAND)
+		} else {
+			Ok(PollEvent::EMPTY)
+		}
+	}
+
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		let mut syswrite = SysWrite::new(STDOUT_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
@@ -141,7 +182,20 @@ impl UhyveStdout {
 #[derive(Debug, Clone)]
 pub struct UhyveStderr;
 
+#[async_trait]
 impl ObjectInterface for UhyveStderr {
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		if event.contains(PollEvent::POLLOUT) {
+			Ok(PollEvent::POLLOUT)
+		} else if event.contains(PollEvent::POLLWRNORM) {
+			Ok(PollEvent::POLLWRNORM)
+		} else if event.contains(PollEvent::POLLWRBAND) {
+			Ok(PollEvent::POLLWRBAND)
+		} else {
+			Ok(PollEvent::EMPTY)
+		}
+	}
+
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		let mut syswrite = SysWrite::new(STDERR_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -81,15 +81,17 @@ pub struct GenericStdout;
 #[async_trait]
 impl ObjectInterface for GenericStdout {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
 		if event.contains(PollEvent::POLLOUT) {
-			Ok(PollEvent::POLLOUT)
+			result.insert(PollEvent::POLLOUT);
 		} else if event.contains(PollEvent::POLLWRNORM) {
-			Ok(PollEvent::POLLWRNORM)
+			result.insert(PollEvent::POLLWRNORM);
 		} else if event.contains(PollEvent::POLLWRBAND) {
-			Ok(PollEvent::POLLWRBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLWRBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
@@ -112,15 +114,17 @@ pub struct GenericStderr;
 #[async_trait]
 impl ObjectInterface for GenericStderr {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
 		if event.contains(PollEvent::POLLOUT) {
-			Ok(PollEvent::POLLOUT)
+			result.insert(PollEvent::POLLOUT);
 		} else if event.contains(PollEvent::POLLWRNORM) {
-			Ok(PollEvent::POLLWRNORM)
+			result.insert(PollEvent::POLLWRNORM);
 		} else if event.contains(PollEvent::POLLWRBAND) {
-			Ok(PollEvent::POLLWRBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLWRBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
@@ -154,15 +158,17 @@ pub struct UhyveStdout;
 #[async_trait]
 impl ObjectInterface for UhyveStdout {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
 		if event.contains(PollEvent::POLLOUT) {
-			Ok(PollEvent::POLLOUT)
+			result.insert(PollEvent::POLLOUT);
 		} else if event.contains(PollEvent::POLLWRNORM) {
-			Ok(PollEvent::POLLWRNORM)
+			result.insert(PollEvent::POLLWRNORM);
 		} else if event.contains(PollEvent::POLLWRBAND) {
-			Ok(PollEvent::POLLWRBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLWRBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
@@ -185,15 +191,17 @@ pub struct UhyveStderr;
 #[async_trait]
 impl ObjectInterface for UhyveStderr {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
 		if event.contains(PollEvent::POLLOUT) {
-			Ok(PollEvent::POLLOUT)
+			result.insert(PollEvent::POLLOUT);
 		} else if event.contains(PollEvent::POLLWRNORM) {
-			Ok(PollEvent::POLLWRNORM)
+			result.insert(PollEvent::POLLWRNORM);
 		} else if event.contains(PollEvent::POLLWRBAND) {
-			Ok(PollEvent::POLLWRBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLWRBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -16,10 +16,11 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::slice;
 
+use async_lock::{Mutex, RwLock};
 use async_trait::async_trait;
-use hermit_sync::{RwSpinLock, SpinMutex};
 
 use crate::arch;
+use crate::executor::block_on;
 use crate::fd::{AccessPermission, IoError, ObjectInterface, OpenOption, PollEvent};
 use crate::fs::{DirectoryEntry, FileAttr, NodeKind, VfsNode};
 
@@ -41,17 +42,17 @@ impl RomFileInner {
 #[derive(Debug, Clone)]
 struct RomFileInterface {
 	/// Position within the file
-	pos: Arc<SpinMutex<usize>>,
+	pos: Arc<Mutex<usize>>,
 	/// File content
-	inner: Arc<RwSpinLock<RomFileInner>>,
+	inner: Arc<RwLock<RomFileInner>>,
 }
 
 #[async_trait]
 impl ObjectInterface for RomFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
 		let mut result: PollEvent = PollEvent::EMPTY;
-		let len = self.inner.read().data.len();
-		let pos_guard = self.pos.lock();
+		let len = self.inner.read().await.data.len();
+		let pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
@@ -65,16 +66,16 @@ impl ObjectInterface for RomFileInterface {
 		Ok(result)
 	}
 
-	fn read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
+	async fn async_read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
 		{
 			let microseconds = arch::kernel::systemtime::now_micros();
-			let mut guard = self.inner.write();
+			let mut guard = self.inner.write().await;
 			guard.attr.st_atime = microseconds / 1_000_000;
 			guard.attr.st_atime_nsec = (microseconds % 1_000_000) * 1000;
 		}
 
-		let vec = self.inner.read().data;
-		let mut pos_guard = self.pos.lock();
+		let vec = self.inner.read().await.data;
+		let mut pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if pos >= vec.len() {
@@ -95,15 +96,15 @@ impl ObjectInterface for RomFileInterface {
 }
 
 impl RomFileInterface {
-	pub fn new(inner: Arc<RwSpinLock<RomFileInner>>) -> Self {
+	pub fn new(inner: Arc<RwLock<RomFileInner>>) -> Self {
 		Self {
-			pos: Arc::new(SpinMutex::new(0)),
+			pos: Arc::new(Mutex::new(0)),
 			inner,
 		}
 	}
 
 	pub fn len(&self) -> usize {
-		self.inner.read().data.len()
+		block_on(async { Ok(self.inner.read().await.data.len()) }, None).unwrap()
 	}
 }
 
@@ -125,17 +126,17 @@ impl RamFileInner {
 #[derive(Debug, Clone)]
 pub struct RamFileInterface {
 	/// Position within the file
-	pos: Arc<SpinMutex<usize>>,
+	pos: Arc<Mutex<usize>>,
 	/// File content
-	inner: Arc<RwSpinLock<RamFileInner>>,
+	inner: Arc<RwLock<RamFileInner>>,
 }
 
 #[async_trait]
 impl ObjectInterface for RamFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
 		let mut result: PollEvent = PollEvent::EMPTY;
-		let len = self.inner.read().data.len();
-		let pos_guard = self.pos.lock();
+		let len = self.inner.read().await.data.len();
+		let pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
@@ -155,16 +156,16 @@ impl ObjectInterface for RamFileInterface {
 		Ok(result)
 	}
 
-	fn read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
+	async fn async_read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
 		{
 			let microseconds = arch::kernel::systemtime::now_micros();
-			let mut guard = self.inner.write();
+			let mut guard = self.inner.write().await;
 			guard.attr.st_atime = microseconds / 1_000_000;
 			guard.attr.st_atime_nsec = (microseconds % 1_000_000) * 1000;
 		}
 
-		let guard = self.inner.read();
-		let mut pos_guard = self.pos.lock();
+		let guard = self.inner.read().await;
+		let mut pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if pos >= guard.data.len() {
@@ -183,10 +184,10 @@ impl ObjectInterface for RamFileInterface {
 		Ok(len)
 	}
 
-	fn write(&self, buf: &[u8]) -> Result<usize, IoError> {
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
 		let microseconds = arch::kernel::systemtime::now_micros();
-		let mut guard = self.inner.write();
-		let mut pos_guard = self.pos.lock();
+		let mut guard = self.inner.write().await;
+		let mut pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if pos + buf.len() > guard.data.len() {
@@ -208,21 +209,21 @@ impl ObjectInterface for RamFileInterface {
 }
 
 impl RamFileInterface {
-	pub fn new(inner: Arc<RwSpinLock<RamFileInner>>) -> Self {
+	pub fn new(inner: Arc<RwLock<RamFileInner>>) -> Self {
 		Self {
-			pos: Arc::new(SpinMutex::new(0)),
+			pos: Arc::new(Mutex::new(0)),
 			inner,
 		}
 	}
 
 	pub fn len(&self) -> usize {
-		self.inner.read().data.len()
+		block_on(async { Ok(self.inner.read().await.data.len()) }, None).unwrap()
 	}
 }
 
 #[derive(Debug)]
 pub(crate) struct RomFile {
-	data: Arc<RwSpinLock<RomFileInner>>,
+	data: Arc<RwLock<RomFileInner>>,
 }
 
 impl VfsNode for RomFile {
@@ -235,7 +236,7 @@ impl VfsNode for RomFile {
 	}
 
 	fn get_file_attributes(&self) -> Result<FileAttr, IoError> {
-		Ok(self.data.read().attr)
+		block_on(async { Ok(self.data.read().await.attr) }, None)
 	}
 
 	fn traverse_lstat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
@@ -271,14 +272,14 @@ impl RomFile {
 		};
 
 		Self {
-			data: unsafe { Arc::new(RwSpinLock::new(RomFileInner::new(ptr, length, attr))) },
+			data: unsafe { Arc::new(RwLock::new(RomFileInner::new(ptr, length, attr))) },
 		}
 	}
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct RamFile {
-	data: Arc<RwSpinLock<RamFileInner>>,
+	data: Arc<RwLock<RamFileInner>>,
 }
 
 impl VfsNode for RamFile {
@@ -291,7 +292,7 @@ impl VfsNode for RamFile {
 	}
 
 	fn get_file_attributes(&self) -> Result<FileAttr, IoError> {
-		Ok(self.data.read().attr)
+		block_on(async { Ok(self.data.read().await.attr) }, None)
 	}
 
 	fn traverse_lstat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
@@ -326,16 +327,15 @@ impl RamFile {
 		};
 
 		Self {
-			data: Arc::new(RwSpinLock::new(RamFileInner::new(attr))),
+			data: Arc::new(RwLock::new(RamFileInner::new(attr))),
 		}
 	}
 }
 
 #[derive(Debug)]
 pub(crate) struct MemDirectory {
-	inner: Arc<
-		RwSpinLock<BTreeMap<String, Box<dyn VfsNode + core::marker::Send + core::marker::Sync>>>,
-	>,
+	inner:
+		Arc<RwLock<BTreeMap<String, Box<dyn VfsNode + core::marker::Send + core::marker::Sync>>>>,
 	attr: FileAttr,
 }
 
@@ -344,7 +344,7 @@ impl MemDirectory {
 		let microseconds = arch::kernel::systemtime::now_micros();
 
 		Self {
-			inner: Arc::new(RwSpinLock::new(BTreeMap::new())),
+			inner: Arc::new(RwLock::new(BTreeMap::new())),
 			attr: FileAttr {
 				st_mode: mode | AccessPermission::S_IFDIR,
 				st_atime: microseconds / 1_000_000,
@@ -357,165 +357,8 @@ impl MemDirectory {
 			},
 		}
 	}
-}
 
-impl VfsNode for MemDirectory {
-	fn get_kind(&self) -> NodeKind {
-		NodeKind::Directory
-	}
-
-	fn get_file_attributes(&self) -> Result<FileAttr, IoError> {
-		Ok(self.attr)
-	}
-
-	fn traverse_mkdir(
-		&self,
-		components: &mut Vec<&str>,
-		mode: AccessPermission,
-	) -> Result<(), IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if let Some(directory) = self.inner.read().get(&node_name) {
-				return directory.traverse_mkdir(components, mode);
-			}
-
-			if components.is_empty() {
-				self.inner
-					.write()
-					.insert(node_name, Box::new(MemDirectory::new(mode)));
-				return Ok(());
-			}
-		}
-
-		Err(IoError::EBADF)
-	}
-
-	fn traverse_rmdir(&self, components: &mut Vec<&str>) -> Result<(), IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if components.is_empty() {
-				let mut guard = self.inner.write();
-
-				let obj = guard.remove(&node_name).ok_or(IoError::ENOENT)?;
-				if obj.get_kind() == NodeKind::Directory {
-					return Ok(());
-				} else {
-					guard.insert(node_name, obj);
-					return Err(IoError::ENOTDIR);
-				}
-			} else if let Some(directory) = self.inner.read().get(&node_name) {
-				return directory.traverse_rmdir(components);
-			}
-		}
-
-		Err(IoError::EBADF)
-	}
-
-	fn traverse_unlink(&self, components: &mut Vec<&str>) -> Result<(), IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if components.is_empty() {
-				let mut guard = self.inner.write();
-
-				let obj = guard.remove(&node_name).ok_or(IoError::ENOENT)?;
-				if obj.get_kind() == NodeKind::File {
-					return Ok(());
-				} else {
-					guard.insert(node_name, obj);
-					return Err(IoError::ENOENT);
-				}
-			} else if let Some(directory) = self.inner.read().get(&node_name) {
-				return directory.traverse_unlink(components);
-			}
-		}
-
-		Err(IoError::EBADF)
-	}
-
-	fn traverse_readdir(&self, components: &mut Vec<&str>) -> Result<Vec<DirectoryEntry>, IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if let Some(directory) = self.inner.read().get(&node_name) {
-				directory.traverse_readdir(components)
-			} else {
-				Err(IoError::EBADF)
-			}
-		} else {
-			let mut entries: Vec<DirectoryEntry> = Vec::new();
-			for name in self.inner.read().keys() {
-				entries.push(DirectoryEntry::new(name.to_string()));
-			}
-
-			Ok(entries)
-		}
-	}
-
-	fn traverse_lstat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if components.is_empty() {
-				if let Some(node) = self.inner.read().get(&node_name) {
-					return node.get_file_attributes();
-				}
-			}
-
-			if let Some(directory) = self.inner.read().get(&node_name) {
-				directory.traverse_lstat(components)
-			} else {
-				Err(IoError::EBADF)
-			}
-		} else {
-			Err(IoError::ENOSYS)
-		}
-	}
-
-	fn traverse_stat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if components.is_empty() {
-				if let Some(node) = self.inner.read().get(&node_name) {
-					return node.get_file_attributes();
-				}
-			}
-
-			if let Some(directory) = self.inner.read().get(&node_name) {
-				directory.traverse_stat(components)
-			} else {
-				Err(IoError::EBADF)
-			}
-		} else {
-			Err(IoError::ENOSYS)
-		}
-	}
-
-	fn traverse_mount(
-		&self,
-		components: &mut Vec<&str>,
-		obj: Box<dyn VfsNode + core::marker::Send + core::marker::Sync>,
-	) -> Result<(), IoError> {
-		if let Some(component) = components.pop() {
-			let node_name = String::from(component);
-
-			if let Some(directory) = self.inner.read().get(&node_name) {
-				return directory.traverse_mount(components, obj);
-			}
-
-			if components.is_empty() {
-				self.inner.write().insert(node_name, obj);
-				return Ok(());
-			}
-		}
-
-		Err(IoError::EBADF)
-	}
-
-	fn traverse_open(
+	async fn async_traverse_open(
 		&self,
 		components: &mut Vec<&str>,
 		opt: OpenOption,
@@ -525,7 +368,7 @@ impl VfsNode for MemDirectory {
 			let node_name = String::from(component);
 
 			if components.is_empty() {
-				let mut guard = self.inner.write();
+				let mut guard = self.inner.write().await;
 				if opt.contains(OpenOption::O_CREAT) || opt.contains(OpenOption::O_CREAT) {
 					if guard.get(&node_name).is_some() {
 						return Err(IoError::EEXIST);
@@ -545,12 +388,218 @@ impl VfsNode for MemDirectory {
 				}
 			}
 
-			if let Some(directory) = self.inner.read().get(&node_name) {
+			if let Some(directory) = self.inner.read().await.get(&node_name) {
 				return directory.traverse_open(components, opt, mode);
 			}
 		}
 
 		Err(IoError::ENOENT)
+	}
+}
+
+impl VfsNode for MemDirectory {
+	fn get_kind(&self) -> NodeKind {
+		NodeKind::Directory
+	}
+
+	fn get_file_attributes(&self) -> Result<FileAttr, IoError> {
+		Ok(self.attr)
+	}
+
+	fn traverse_mkdir(
+		&self,
+		components: &mut Vec<&str>,
+		mode: AccessPermission,
+	) -> Result<(), IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						return directory.traverse_mkdir(components, mode);
+					}
+
+					if components.is_empty() {
+						self.inner
+							.write()
+							.await
+							.insert(node_name, Box::new(MemDirectory::new(mode)));
+						return Ok(());
+					}
+				}
+
+				Err(IoError::EBADF)
+			},
+			None,
+		)
+	}
+
+	fn traverse_rmdir(&self, components: &mut Vec<&str>) -> Result<(), IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						return directory.traverse_rmdir(components);
+					}
+
+					if components.is_empty() {
+						let mut guard = self.inner.write().await;
+
+						let obj = guard.remove(&node_name).ok_or(IoError::ENOENT)?;
+						if obj.get_kind() == NodeKind::Directory {
+							return Ok(());
+						} else {
+							guard.insert(node_name, obj);
+							return Err(IoError::ENOTDIR);
+						}
+					}
+				}
+
+				Err(IoError::EBADF)
+			},
+			None,
+		)
+	}
+
+	fn traverse_unlink(&self, components: &mut Vec<&str>) -> Result<(), IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						return directory.traverse_unlink(components);
+					}
+
+					if components.is_empty() {
+						let mut guard = self.inner.write().await;
+
+						let obj = guard.remove(&node_name).ok_or(IoError::ENOENT)?;
+						if obj.get_kind() == NodeKind::Directory {
+							guard.insert(node_name, obj);
+							return Err(IoError::EISDIR);
+						} else {
+							return Ok(());
+						}
+					}
+				}
+
+				Err(IoError::EBADF)
+			},
+			None,
+		)
+	}
+
+	fn traverse_readdir(&self, components: &mut Vec<&str>) -> Result<Vec<DirectoryEntry>, IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						directory.traverse_readdir(components)
+					} else {
+						Err(IoError::EBADF)
+					}
+				} else {
+					let mut entries: Vec<DirectoryEntry> = Vec::new();
+					for name in self.inner.read().await.keys() {
+						entries.push(DirectoryEntry::new(name.to_string()));
+					}
+
+					Ok(entries)
+				}
+			},
+			None,
+		)
+	}
+
+	fn traverse_lstat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if components.is_empty() {
+						if let Some(node) = self.inner.read().await.get(&node_name) {
+							return node.get_file_attributes();
+						}
+					}
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						directory.traverse_lstat(components)
+					} else {
+						Err(IoError::EBADF)
+					}
+				} else {
+					Err(IoError::ENOSYS)
+				}
+			},
+			None,
+		)
+	}
+
+	fn traverse_stat(&self, components: &mut Vec<&str>) -> Result<FileAttr, IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if components.is_empty() {
+						if let Some(node) = self.inner.read().await.get(&node_name) {
+							return node.get_file_attributes();
+						}
+					}
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						directory.traverse_stat(components)
+					} else {
+						Err(IoError::EBADF)
+					}
+				} else {
+					Err(IoError::ENOSYS)
+				}
+			},
+			None,
+		)
+	}
+
+	fn traverse_mount(
+		&self,
+		components: &mut Vec<&str>,
+		obj: Box<dyn VfsNode + core::marker::Send + core::marker::Sync>,
+	) -> Result<(), IoError> {
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let node_name = String::from(component);
+
+					if let Some(directory) = self.inner.read().await.get(&node_name) {
+						return directory.traverse_mount(components, obj);
+					}
+
+					if components.is_empty() {
+						self.inner.write().await.insert(node_name, obj);
+						return Ok(());
+					}
+				}
+
+				Err(IoError::EBADF)
+			},
+			None,
+		)
+	}
+
+	fn traverse_open(
+		&self,
+		components: &mut Vec<&str>,
+		opt: OpenOption,
+		mode: AccessPermission,
+	) -> Result<Arc<dyn ObjectInterface>, IoError> {
+		block_on(self.async_traverse_open(components, opt, mode), None)
 	}
 
 	fn traverse_create_file(
@@ -560,20 +609,28 @@ impl VfsNode for MemDirectory {
 		length: usize,
 		mode: AccessPermission,
 	) -> Result<(), IoError> {
-		if let Some(component) = components.pop() {
-			let name = String::from(component);
+		block_on(
+			async {
+				if let Some(component) = components.pop() {
+					let name = String::from(component);
 
-			if components.is_empty() {
-				let file = unsafe { RomFile::new(ptr, length, mode) };
-				self.inner.write().insert(name.to_string(), Box::new(file));
-				return Ok(());
-			}
+					if components.is_empty() {
+						let file = unsafe { RomFile::new(ptr, length, mode) };
+						self.inner
+							.write()
+							.await
+							.insert(name.to_string(), Box::new(file));
+						return Ok(());
+					}
 
-			if let Some(directory) = self.inner.read().get(&name) {
-				return directory.traverse_create_file(components, ptr, length, mode);
-			}
-		}
+					if let Some(directory) = self.inner.read().await.get(&name) {
+						return directory.traverse_create_file(components, ptr, length, mode);
+					}
+				}
 
-		Err(IoError::ENOENT)
+				Err(IoError::ENOENT)
+			},
+			None,
+		)
 	}
 }

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -49,19 +49,20 @@ struct RomFileInterface {
 #[async_trait]
 impl ObjectInterface for RomFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
 		let len = self.inner.read().data.len();
 		let pos_guard = self.pos.lock();
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
-			Ok(PollEvent::POLLIN)
+			result.insert(PollEvent::POLLIN);
 		} else if event.contains(PollEvent::POLLRDNORM) && pos < len {
-			Ok(PollEvent::POLLRDNORM)
+			result.insert(PollEvent::POLLRDNORM);
 		} else if event.contains(PollEvent::POLLRDBAND) && pos < len {
-			Ok(PollEvent::POLLRDBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLRDBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
@@ -132,25 +133,26 @@ pub struct RamFileInterface {
 #[async_trait]
 impl ObjectInterface for RamFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
 		let len = self.inner.read().data.len();
 		let pos_guard = self.pos.lock();
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
-			Ok(PollEvent::POLLIN)
+			result.insert(PollEvent::POLLIN);
 		} else if event.contains(PollEvent::POLLRDNORM) && pos < len {
-			Ok(PollEvent::POLLRDNORM)
+			result.insert(PollEvent::POLLRDNORM);
 		} else if event.contains(PollEvent::POLLRDBAND) && pos < len {
-			Ok(PollEvent::POLLRDBAND)
+			result.insert(PollEvent::POLLRDBAND);
 		} else if event.contains(PollEvent::POLLOUT) {
-			Ok(PollEvent::POLLOUT)
+			result.insert(PollEvent::POLLOUT);
 		} else if event.contains(PollEvent::POLLWRNORM) {
-			Ok(PollEvent::POLLWRNORM)
+			result.insert(PollEvent::POLLWRNORM);
 		} else if event.contains(PollEvent::POLLWRBAND) {
-			Ok(PollEvent::POLLWRBAND)
-		} else {
-			Ok(PollEvent::EMPTY)
+			result.insert(PollEvent::POLLWRBAND);
 		}
+
+		Ok(result)
 	}
 
 	fn read(&self, buf: &mut [u8]) -> Result<usize, IoError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ extern "C" fn initd(_arg: usize) {
 	riscv64::kernel::init_drivers();
 
 	syscalls::init();
-	fd::init().unwrap();
+	fd::init().expect("Unable to initialized standard file descriptors");
 	fs::init();
 
 	// Get the application arguments and environment variables.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod logging;
 
 mod arch;
 mod config;
-mod console;
+pub mod console;
 mod drivers;
 mod entropy;
 mod env;
@@ -94,12 +94,6 @@ pub mod time;
 
 #[cfg(target_os = "none")]
 hermit_entry::define_entry_version!();
-
-#[doc(hidden)]
-pub fn _print(args: ::core::fmt::Arguments<'_>) {
-	use core::fmt::Write;
-	crate::console::CONSOLE.lock().write_fmt(args).unwrap();
-}
 
 #[cfg(test)]
 #[cfg(target_os = "none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ extern "C" fn initd(_arg: usize) {
 	riscv64::kernel::init_drivers();
 
 	syscalls::init();
-	fd::init();
+	fd::init().unwrap();
 	fs::init();
 
 	// Get the application arguments and environment variables.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,7 +7,7 @@
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {{
-        $crate::_print(::core::format_args!($($arg)*));
+        $crate::console::_print(::core::format_args!($($arg)*));
     }};
 }
 
@@ -23,7 +23,7 @@ macro_rules! println {
         $crate::print!("\n")
     };
     ($($arg:tt)*) => {{
-        $crate::_print(::core::format_args!("{}\n", format_args!($($arg)*)));
+        $crate::console::_print(::core::format_args!("{}\n", format_args!($($arg)*)));
     }};
 }
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -261,15 +261,9 @@ pub extern "C" fn sys_close(fd: FileDescriptor) -> i32 {
 
 extern "C" fn __sys_read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isize {
 	let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
-	let obj = get_object(fd);
-	obj.map_or_else(
+	crate::fd::read(fd, slice).map_or_else(
 		|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-		|v| {
-			(*v).read(slice).map_or_else(
-				|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-				|v| v.try_into().unwrap(),
-			)
-		},
+		|v| v.try_into().unwrap(),
 	)
 }
 
@@ -280,15 +274,9 @@ pub extern "C" fn sys_read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isiz
 
 extern "C" fn __sys_write(fd: FileDescriptor, buf: *const u8, len: usize) -> isize {
 	let slice = unsafe { core::slice::from_raw_parts(buf, len) };
-	let obj = get_object(fd);
-	obj.map_or_else(
+	crate::fd::write(fd, slice).map_or_else(
 		|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-		|v| {
-			(*v).write(slice).map_or_else(
-				|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-				|v| v.try_into().unwrap(),
-			)
-		},
+		|v| v.try_into().unwrap(),
 	)
 }
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -21,6 +21,7 @@ pub use self::timer::*;
 use crate::env;
 use crate::fd::{
 	dup_object, get_object, remove_object, AccessPermission, FileDescriptor, IoCtl, OpenOption,
+	PollFd,
 };
 use crate::fs::{self, FileAttr};
 use crate::syscalls::interfaces::SyscallInterface;
@@ -413,6 +414,17 @@ extern "C" fn __sys_dup(fd: i32) -> i32 {
 #[no_mangle]
 pub extern "C" fn sys_dup(fd: i32) -> i32 {
 	kernel_function!(__sys_dup(fd))
+}
+
+extern "C" fn __sys_poll(fds: *mut PollFd, nfds: usize, timeout: i32) -> i32 {
+	let slice = unsafe { core::slice::from_raw_parts_mut(fds, nfds) };
+
+	crate::fd::poll(slice, timeout).map_or_else(|e| -num::ToPrimitive::to_i32(&e).unwrap(), |_| 0)
+}
+
+#[no_mangle]
+pub extern "C" fn sys_poll(fds: *mut PollFd, nfds: usize, timeout: i32) -> i32 {
+	kernel_function!(__sys_poll(fds, nfds, timeout))
 }
 
 extern "C" fn __sys_image_start_addr() -> usize {

--- a/src/syscalls/net.rs
+++ b/src/syscalls/net.rs
@@ -270,7 +270,7 @@ extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 				drop(guard);
 				let socket = udp::Socket::new(handle);
 
-				insert_object(fd, Arc::new(socket));
+				insert_object(fd, Arc::new(socket)).expect("FD is already used");
 
 				return fd;
 			}
@@ -281,7 +281,7 @@ extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 				drop(guard);
 				let socket = tcp::Socket::new(handle);
 
-				insert_object(fd, Arc::new(socket));
+				insert_object(fd, Arc::new(socket)).expect("FD is already used");
 
 				return fd;
 			}
@@ -302,9 +302,9 @@ extern "C" fn __sys_accept(fd: i32, addr: *mut sockaddr, addrlen: *mut socklen_t
 				|e| -num::ToPrimitive::to_i32(&e).unwrap(),
 				|endpoint| {
 					let new_obj = dyn_clone::clone_box(&*v);
-					insert_object(fd, Arc::from(new_obj));
+					insert_object(fd, Arc::from(new_obj)).expect("FD is already used");
 					let new_fd = FD_COUNTER.fetch_add(1, Ordering::SeqCst);
-					insert_object(new_fd, v.clone());
+					insert_object(new_fd, v.clone()).expect("FD is already used");
 
 					if !addr.is_null() && !addrlen.is_null() {
 						let addrlen = unsafe { &mut *addrlen };

--- a/src/syscalls/net.rs
+++ b/src/syscalls/net.rs
@@ -267,6 +267,7 @@ extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 			#[cfg(feature = "udp")]
 			if type_ == SOCK_DGRAM {
 				let handle = nic.create_udp_handle().unwrap();
+				drop(guard);
 				let socket = udp::Socket::new(handle);
 
 				insert_object(fd, Arc::new(socket));
@@ -277,7 +278,9 @@ extern "C" fn __sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 			#[cfg(feature = "tcp")]
 			if type_ == SOCK_STREAM {
 				let handle = nic.create_tcp_handle().unwrap();
+				drop(guard);
 				let socket = tcp::Socket::new(handle);
+
 				insert_object(fd, Arc::new(socket));
 
 				return fd;

--- a/src/syscalls/net.rs
+++ b/src/syscalls/net.rs
@@ -564,15 +564,9 @@ extern "C" fn __sys_shutdown_socket(fd: i32, how: i32) -> i32 {
 
 extern "C" fn __sys_recv(fd: i32, buf: *mut u8, len: usize) -> isize {
 	let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
-	let obj = get_object(fd);
-	obj.map_or_else(
+	crate::fd::read(fd, slice).map_or_else(
 		|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-		|v| {
-			(*v).read(slice).map_or_else(
-				|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-				|v| v.try_into().unwrap(),
-			)
-		},
+		|v| v.try_into().unwrap(),
 	)
 }
 


### PR DESCRIPTION
`poll()` examines a set of file descriptors to see if some of them are ready for I/O or if certain events have occurred on them. The currenty implementation is using an asynchronous function to check all file descriptors.

This PR should solve smol-rs/polling#177

Currently, the PR doesn't support file descriptors, which points to the uhyve file system.