### PR TITLE
forward error code to the host

### DIFF
--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -115,12 +115,13 @@ pub fn halt() {
 }
 
 /// Shutdown the system
-pub fn shutdown() -> ! {
+#[allow(unused_variables)]
+pub fn shutdown(error_code: i32) -> ! {
 	info!("Shutting down system");
 
 	cfg_if::cfg_if! {
 		if #[cfg(feature = "semihosting")] {
-			semihosting::process::exit(0)
+			semihosting::process::exit(error_code)
 		} else {
 			unsafe {
 				const PSCI_SYSTEM_OFF: u64 = 0x84000008;

--- a/src/arch/riscv64/kernel/processor.rs
+++ b/src/arch/riscv64/kernel/processor.rs
@@ -227,12 +227,13 @@ pub fn halt() {
 }
 
 /// Shutdown the system
-pub fn shutdown() -> ! {
+#[allow(unused_variables)]
+pub fn shutdown(error_code: i32) -> ! {
 	info!("Shutting down system");
 
 	cfg_if::cfg_if! {
 		if #[cfg(feature = "semihosting")] {
-			semihosting::process::exit(0)
+			semihosting::process::exit(error_code)
 		} else {
 			// use SBI shutdown
 			sbi::legacy::shutdown()

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -997,7 +997,7 @@ fn triple_fault() -> ! {
 }
 
 /// Shutdown the system
-pub fn shutdown() -> ! {
+pub fn shutdown(error_code: i32) -> ! {
 	info!("Shutting down system");
 	let acpi_result: Result<Infallible, ()> = {
 		#[cfg(feature = "acpi")]
@@ -1019,7 +1019,11 @@ pub fn shutdown() -> ! {
 				PlatformInfo::Multiboot { .. } => {
 					// Try QEMU's debug exit
 					let exit_handler = qemu_exit::X86::new(0xf4, 3);
-					exit_handler.exit_success()
+					if error_code == 0 {
+						exit_handler.exit_success()
+					} else {
+						exit_handler.exit_failure()
+					}
 				}
 				PlatformInfo::Uhyve { .. } => todo!(),
 			}

--- a/src/syscalls/interfaces/mod.rs
+++ b/src/syscalls/interfaces/mod.rs
@@ -48,7 +48,7 @@ pub trait SyscallInterface: Send + Sync {
 		(argc, argv, envv)
 	}
 
-	fn shutdown(&self, _arg: i32) -> ! {
-		arch::processor::shutdown()
+	fn shutdown(&self, error_code: i32) -> ! {
+		arch::processor::shutdown(error_code)
 	}
 }

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -167,8 +167,8 @@ impl SyscallInterface for Uhyve {
 		(syscmdsize.argc, argv, env)
 	}
 
-	fn shutdown(&self, arg: i32) -> ! {
-		let mut sysexit = SysExit::new(arg);
+	fn shutdown(&self, error_code: i32) -> ! {
+		let mut sysexit = SysExit::new(error_code);
 		uhyve_send(UHYVE_PORT_EXIT, &mut sysexit);
 
 		loop {

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -193,6 +193,7 @@ impl Qemu {
 		if self.build.cargo_build.artifact.arch == Arch::Aarch64 {
 			memory = memory.max(256);
 		}
+		memory = memory.max(64);
 		memory
 	}
 


### PR DESCRIPTION
If semihosting or qemu_exit is available, the error code will be forwarded to the host system.