### PR TITLE
add basic support a linux-like syscall `evendfd`

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -180,6 +180,7 @@ pub fn boot_processor_init() {
 
 	apic::init();
 	scheduler::install_timer_handler();
+	serial::install_serial_interrupt();
 	finish_processor_init();
 	interrupts::enable();
 }

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -1,5 +1,8 @@
 use x86_64::instructions::port::Port;
 
+use crate::arch::x86_64::kernel::interrupts::{self, IDT};
+use crate::arch::x86_64::kernel::{apic, COM1};
+
 enum Inner {
 	Uart(uart_16550::SerialPort),
 	Uhyve(Port<u8>),
@@ -19,6 +22,14 @@ impl SerialPort {
 		}
 	}
 
+	pub fn receive(&mut self) -> u8 {
+		if let Inner::Uart(s) = &mut self.0 {
+			s.receive()
+		} else {
+			0
+		}
+	}
+
 	pub fn send(&mut self, buf: &[u8]) {
 		match &mut self.0 {
 			Inner::Uhyve(s) => {
@@ -35,4 +46,25 @@ impl SerialPort {
 			}
 		}
 	}
+}
+
+extern "x86-interrupt" fn serial_interrupt(_stack_frame: crate::interrupts::ExceptionStackFrame) {
+	let c = unsafe { char::from_u32_unchecked(COM1.lock().as_mut().unwrap().receive().into()) };
+	if !c.is_ascii_control() {
+		print!("{}", c);
+	}
+
+	apic::eoi();
+}
+
+pub(crate) fn install_serial_interrupt() {
+	const SERIAL_IRQ: usize = 36;
+
+	unsafe {
+		let mut idt = IDT.lock();
+		idt[SERIAL_IRQ]
+			.set_handler_fn(serial_interrupt)
+			.set_stack_index(0);
+	}
+	interrupts::add_irq_name((SERIAL_IRQ - 32).try_into().unwrap(), "COM1");
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -274,6 +274,7 @@ where
 				backoff.snooze();
 			}
 		}
+
 		#[cfg(not(any(feature = "tcp", feature = "udp")))]
 		{
 			if backoff.is_completed() {

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -1,0 +1,168 @@
+use alloc::boxed::Box;
+use alloc::collections::vec_deque::VecDeque;
+use core::future::{self, Future};
+use core::mem;
+use core::task::{Poll, Waker};
+
+use async_lock::Mutex;
+use async_trait::async_trait;
+
+use crate::fd::{block_on, EventFlags, IoError, ObjectInterface, PollEvent};
+
+#[derive(Debug)]
+struct EventState {
+	pub counter: u64,
+	pub queue: VecDeque<Waker>,
+}
+
+impl EventState {
+	pub fn new(counter: u64) -> Self {
+		Self {
+			counter,
+			queue: VecDeque::new(),
+		}
+	}
+}
+
+#[derive(Debug)]
+pub(crate) struct EventFd {
+	state: Mutex<EventState>,
+	flags: EventFlags,
+}
+
+impl Clone for EventFd {
+	fn clone(&self) -> Self {
+		let counter = block_on(async { Ok(self.state.lock().await.counter) }, None).unwrap();
+		Self {
+			state: Mutex::new(EventState::new(counter)),
+			flags: self.flags,
+		}
+	}
+}
+
+impl EventFd {
+	pub fn new(initval: u64, flags: EventFlags) -> Self {
+		Self {
+			state: Mutex::new(EventState::new(initval)),
+			flags,
+		}
+	}
+}
+
+#[async_trait]
+impl ObjectInterface for EventFd {
+	async fn async_read(&self, buf: &mut [u8]) -> Result<usize, IoError> {
+		let len = mem::size_of::<u64>();
+
+		if buf.len() < len {
+			return Err(IoError::EINVAL);
+		}
+
+		future::poll_fn(|cx| {
+			if self.flags.contains(EventFlags::EFD_SEMAPHORE) {
+				let mut pinned = core::pin::pin!(self.state.lock());
+				if let Poll::Ready(mut guard) = pinned.as_mut().poll(cx) {
+					if guard.counter > 0 {
+						guard.counter -= 1;
+						let tmp = u64::to_ne_bytes(1);
+						buf[..len].copy_from_slice(&tmp);
+						Poll::Ready(Ok(len))
+					} else {
+						guard.queue.push_back(cx.waker().clone());
+						Poll::Pending
+					}
+				} else {
+					Poll::Pending
+				}
+			} else {
+				let mut pinned = core::pin::pin!(self.state.lock());
+				if let Poll::Ready(mut guard) = pinned.as_mut().poll(cx) {
+					let tmp = guard.counter;
+					if tmp > 0 {
+						guard.counter = 0;
+						buf[..len].copy_from_slice(&u64::to_ne_bytes(tmp));
+						Poll::Ready(Ok(len))
+					} else {
+						guard.queue.push_back(cx.waker().clone());
+						Poll::Pending
+					}
+				} else {
+					Poll::Pending
+				}
+			}
+		})
+		.await
+	}
+
+	async fn async_write(&self, buf: &[u8]) -> Result<usize, IoError> {
+		let len = mem::size_of::<u64>();
+
+		if buf.len() < len {
+			return Err(IoError::EINVAL);
+		}
+
+		let c = u64::from_ne_bytes(buf[..len].try_into().unwrap());
+		if self.flags.contains(EventFlags::EFD_SEMAPHORE) {
+			let mut guard = self.state.lock().await;
+			for _i in 0..c {
+				if guard.counter == u64::MAX - 1 {
+					if self.is_nonblocking() {
+						return Err(IoError::EAGAIN);
+					} else {
+						// TODO: task should be blocked until the addition is possible
+						return Err(IoError::EINVAL);
+					}
+				}
+				guard.counter += 1;
+				if let Some(cx) = guard.queue.pop_front() {
+					cx.wake_by_ref();
+				}
+			}
+		} else {
+			let mut guard = self.state.lock().await;
+			if guard.counter == u64::MAX - c - 1 {
+				if self.is_nonblocking() {
+					return Err(IoError::EAGAIN);
+				} else {
+					// TODO: task should be blocked until the addition is possible
+					return Err(IoError::EINVAL);
+				}
+			}
+			guard.counter += c;
+			if let Some(cx) = guard.queue.pop_front() {
+				cx.wake_by_ref();
+			}
+		}
+
+		Ok(len)
+	}
+
+	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
+		let mut result: PollEvent = PollEvent::EMPTY;
+
+		if event.contains(PollEvent::POLLOUT) {
+			result.insert(PollEvent::POLLOUT);
+		} else if event.contains(PollEvent::POLLWRNORM) {
+			result.insert(PollEvent::POLLWRNORM);
+		} else if event.contains(PollEvent::POLLWRBAND) {
+			result.insert(PollEvent::POLLWRBAND);
+		}
+
+		let guard = self.state.lock().await;
+		if guard.counter > 0 {
+			if event.contains(PollEvent::POLLIN) {
+				result.insert(PollEvent::POLLIN);
+			} else if event.contains(PollEvent::POLLRDNORM) {
+				result.insert(PollEvent::POLLRDNORM);
+			} else if event.contains(PollEvent::POLLRDBAND) {
+				result.insert(PollEvent::POLLRDBAND);
+			}
+		}
+
+		Ok(result)
+	}
+
+	fn is_nonblocking(&self) -> bool {
+		self.flags.contains(EventFlags::EFD_NONBLOCK)
+	}
+}

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -125,10 +125,8 @@ impl ObjectInterface for EventFd {
 								break;
 							}
 						}
-					} else {
-						if let Some(cx) = guard.read_queue.pop_front() {
-							cx.wake_by_ref();
-						}
+					} else if let Some(cx) = guard.read_queue.pop_front() {
+						cx.wake_by_ref();
 					}
 
 					Poll::Ready(Ok(len))

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -382,7 +382,7 @@ impl ObjectInterface for Socket {
 		self.nonblocking.load(Ordering::Acquire)
 	}
 
-	fn listen(&self, backlog: i32) -> Result<(), IoError> {
+	fn listen(&self, _backlog: i32) -> Result<(), IoError> {
 		self.with(|socket| {
 			if !socket.is_open() {
 				socket

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -33,6 +33,7 @@ pub struct Socket {
 	handle: Handle,
 	port: AtomicU16,
 	nonblocking: AtomicBool,
+	old_connection: AtomicBool,
 }
 
 impl Socket {
@@ -41,6 +42,7 @@ impl Socket {
 			handle,
 			port: AtomicU16::new(0),
 			nonblocking: AtomicBool::new(false),
+			old_connection: AtomicBool::new(false),
 		}
 	}
 
@@ -125,7 +127,7 @@ impl Socket {
 					let _ = socket.listen(self.port.load(Ordering::Acquire));
 					Poll::Ready(())
 				}
-				tcp::State::Listen => Poll::Ready(()),
+				tcp::State::Listen | tcp::State::Established => Poll::Ready(()),
 				_ => {
 					socket.register_recv_waker(cx.waker());
 					Poll::Pending
@@ -166,27 +168,69 @@ impl Socket {
 #[async_trait]
 impl ObjectInterface for Socket {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		future::poll_fn(|cx| {
 			self.with(|socket| match socket.state() {
-				tcp::State::Closed
-				| tcp::State::Closing
-				| tcp::State::CloseWait
-				| tcp::State::FinWait1
-				| tcp::State::FinWait2
-				| tcp::State::Listen
-				| tcp::State::TimeWait => {
-					result.insert(PollEvent::POLLNVAL);
-					Poll::Ready(Ok(result))
+				tcp::State::Closed | tcp::State::Closing | tcp::State::CloseWait => {
+					if event.contains(PollEvent::POLLOUT) {
+						result.insert(PollEvent::POLLOUT);
+					}
+					if event.contains(PollEvent::POLLWRNORM) {
+						result.insert(PollEvent::POLLWRNORM);
+					}
+					if event.contains(PollEvent::POLLWRBAND) {
+						result.insert(PollEvent::POLLWRBAND);
+					}
+
+					if event.contains(PollEvent::POLLIN) {
+						result.insert(PollEvent::POLLIN);
+					}
+					if event.contains(PollEvent::POLLRDNORM) {
+						result.insert(PollEvent::POLLRDNORM);
+					}
+					if event.contains(PollEvent::POLLRDBAND) {
+						result.insert(PollEvent::POLLRDBAND);
+					}
+
+					if result.is_empty() {
+						Poll::Ready(Ok(PollEvent::POLLHUP))
+					} else {
+						Poll::Ready(Ok(result))
+					}
+				}
+				tcp::State::FinWait1 | tcp::State::FinWait2 | tcp::State::TimeWait => {
+					Poll::Ready(Ok(PollEvent::POLLHUP))
+				}
+				tcp::State::Listen => {
+					socket.register_recv_waker(cx.waker());
+					socket.register_send_waker(cx.waker());
+					Poll::Pending
 				}
 				_ => {
+					if self.is_nonblocking()
+						&& socket.may_recv() && !self.old_connection.swap(true, Ordering::Acquire)
+					{
+						// In case, we just establish a fresh connection in non-blocking mode, we try to read data.
+						if event.contains(PollEvent::POLLIN) {
+							result.insert(PollEvent::POLLIN);
+						}
+						if event.contains(PollEvent::POLLRDNORM) {
+							result.insert(PollEvent::POLLRDNORM);
+						}
+						if event.contains(PollEvent::POLLRDBAND) {
+							result.insert(PollEvent::POLLRDBAND);
+						}
+					}
+
 					if socket.can_send() {
 						if event.contains(PollEvent::POLLOUT) {
 							result.insert(PollEvent::POLLOUT);
-						} else if event.contains(PollEvent::POLLWRNORM) {
+						}
+						if event.contains(PollEvent::POLLWRNORM) {
 							result.insert(PollEvent::POLLWRNORM);
-						} else if event.contains(PollEvent::POLLWRBAND) {
+						}
+						if event.contains(PollEvent::POLLWRBAND) {
 							result.insert(PollEvent::POLLWRBAND);
 						}
 					}
@@ -194,15 +238,18 @@ impl ObjectInterface for Socket {
 					if socket.can_recv() {
 						if event.contains(PollEvent::POLLIN) {
 							result.insert(PollEvent::POLLIN);
-						} else if event.contains(PollEvent::POLLRDNORM) {
+						}
+						if event.contains(PollEvent::POLLRDNORM) {
 							result.insert(PollEvent::POLLRDNORM);
-						} else if event.contains(PollEvent::POLLRDBAND) {
+						}
+						if event.contains(PollEvent::POLLRDBAND) {
 							result.insert(PollEvent::POLLRDBAND);
 						}
 					}
 
 					if result.is_empty() {
 						socket.register_recv_waker(cx.waker());
+						socket.register_send_waker(cx.waker());
 						Poll::Pending
 					} else {
 						Poll::Ready(Ok(result))
@@ -310,7 +357,17 @@ impl ObjectInterface for Socket {
 	}
 
 	fn accept(&self) -> Result<IpEndpoint, IoError> {
-		block_on(self.async_accept(), None)
+		if self.is_nonblocking() {
+			block_on(self.async_accept(), Some(Duration::ZERO.into())).map_err(|x| {
+				if x == IoError::ETIME {
+					IoError::EAGAIN
+				} else {
+					x
+				}
+			})
+		} else {
+			block_on(self.async_accept(), None)
+		}
 	}
 
 	fn getpeername(&self) -> Option<IpEndpoint> {
@@ -325,7 +382,7 @@ impl ObjectInterface for Socket {
 		self.nonblocking.load(Ordering::Acquire)
 	}
 
-	fn listen(&self, _backlog: i32) -> Result<(), IoError> {
+	fn listen(&self, backlog: i32) -> Result<(), IoError> {
 		self.with(|socket| {
 			if !socket.is_open() {
 				socket
@@ -374,10 +431,10 @@ impl ObjectInterface for Socket {
 	fn ioctl(&self, cmd: IoCtl, value: bool) -> Result<(), IoError> {
 		if cmd == IoCtl::NonBlocking {
 			if value {
-				info!("set device to nonblocking mode");
+				trace!("set device to nonblocking mode");
 				self.nonblocking.store(true, Ordering::Release);
 			} else {
-				info!("set device to blocking mode");
+				trace!("set device to blocking mode");
 				self.nonblocking.store(false, Ordering::Release);
 			}
 
@@ -398,11 +455,20 @@ impl Clone for Socket {
 			panic!("Unable to create handle");
 		};
 
-		Self {
+		drop(guard);
+		let port = self.port.load(Ordering::Acquire);
+		let obj = Self {
 			handle,
-			port: AtomicU16::new(self.port.load(Ordering::Acquire)),
+			port: AtomicU16::new(port),
 			nonblocking: AtomicBool::new(self.nonblocking.load(Ordering::Acquire)),
+			old_connection: AtomicBool::new(false),
+		};
+
+		if port > 0 {
+			let _ = obj.listen(1024);
 		}
+
+		obj
 	}
 }
 

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -119,7 +119,7 @@ impl Socket {
 #[async_trait]
 impl ObjectInterface for Socket {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		future::poll_fn(|cx| {
 			self.with(|socket| {
@@ -127,9 +127,11 @@ impl ObjectInterface for Socket {
 					if socket.can_send() {
 						if event.contains(PollEvent::POLLOUT) {
 							result.insert(PollEvent::POLLOUT);
-						} else if event.contains(PollEvent::POLLWRNORM) {
+						}
+						if event.contains(PollEvent::POLLWRNORM) {
 							result.insert(PollEvent::POLLWRNORM);
-						} else if event.contains(PollEvent::POLLWRBAND) {
+						}
+						if event.contains(PollEvent::POLLWRBAND) {
 							result.insert(PollEvent::POLLWRBAND);
 						}
 					}
@@ -137,9 +139,11 @@ impl ObjectInterface for Socket {
 					if socket.can_recv() {
 						if event.contains(PollEvent::POLLIN) {
 							result.insert(PollEvent::POLLIN);
-						} else if event.contains(PollEvent::POLLRDNORM) {
+						}
+						if event.contains(PollEvent::POLLRDNORM) {
 							result.insert(PollEvent::POLLRDNORM);
-						} else if event.contains(PollEvent::POLLRDBAND) {
+						}
+						if event.contains(PollEvent::POLLRDBAND) {
 							result.insert(PollEvent::POLLRDBAND);
 						}
 					}
@@ -149,6 +153,7 @@ impl ObjectInterface for Socket {
 
 				if result.is_empty() {
 					socket.register_recv_waker(cx.waker());
+					socket.register_send_waker(cx.waker());
 					Poll::Pending
 				} else {
 					Poll::Ready(Ok(result))

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -84,13 +84,15 @@ pub struct GenericStdout;
 #[async_trait]
 impl ObjectInterface for GenericStdout {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		if event.contains(PollEvent::POLLOUT) {
 			result.insert(PollEvent::POLLOUT);
-		} else if event.contains(PollEvent::POLLWRNORM) {
+		}
+		if event.contains(PollEvent::POLLWRNORM) {
 			result.insert(PollEvent::POLLWRNORM);
-		} else if event.contains(PollEvent::POLLWRBAND) {
+		}
+		if event.contains(PollEvent::POLLWRBAND) {
 			result.insert(PollEvent::POLLWRBAND);
 		}
 
@@ -117,13 +119,15 @@ pub struct GenericStderr;
 #[async_trait]
 impl ObjectInterface for GenericStderr {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		if event.contains(PollEvent::POLLOUT) {
 			result.insert(PollEvent::POLLOUT);
-		} else if event.contains(PollEvent::POLLWRNORM) {
+		}
+		if event.contains(PollEvent::POLLWRNORM) {
 			result.insert(PollEvent::POLLWRNORM);
-		} else if event.contains(PollEvent::POLLWRBAND) {
+		}
+		if event.contains(PollEvent::POLLWRBAND) {
 			result.insert(PollEvent::POLLWRBAND);
 		}
 
@@ -161,13 +165,15 @@ pub struct UhyveStdout;
 #[async_trait]
 impl ObjectInterface for UhyveStdout {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		if event.contains(PollEvent::POLLOUT) {
 			result.insert(PollEvent::POLLOUT);
-		} else if event.contains(PollEvent::POLLWRNORM) {
+		}
+		if event.contains(PollEvent::POLLWRNORM) {
 			result.insert(PollEvent::POLLWRNORM);
-		} else if event.contains(PollEvent::POLLWRBAND) {
+		}
+		if event.contains(PollEvent::POLLWRBAND) {
 			result.insert(PollEvent::POLLWRBAND);
 		}
 
@@ -194,13 +200,15 @@ pub struct UhyveStderr;
 #[async_trait]
 impl ObjectInterface for UhyveStderr {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 
 		if event.contains(PollEvent::POLLOUT) {
 			result.insert(PollEvent::POLLOUT);
-		} else if event.contains(PollEvent::POLLWRNORM) {
+		}
+		if event.contains(PollEvent::POLLWRNORM) {
 			result.insert(PollEvent::POLLWRNORM);
-		} else if event.contains(PollEvent::POLLWRBAND) {
+		}
+		if event.contains(PollEvent::POLLWRBAND) {
 			result.insert(PollEvent::POLLWRBAND);
 		}
 

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -50,16 +50,18 @@ struct RomFileInterface {
 #[async_trait]
 impl ObjectInterface for RomFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 		let len = self.inner.read().await.data.len();
 		let pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
 			result.insert(PollEvent::POLLIN);
-		} else if event.contains(PollEvent::POLLRDNORM) && pos < len {
+		}
+		if event.contains(PollEvent::POLLRDNORM) && pos < len {
 			result.insert(PollEvent::POLLRDNORM);
-		} else if event.contains(PollEvent::POLLRDBAND) && pos < len {
+		}
+		if event.contains(PollEvent::POLLRDBAND) && pos < len {
 			result.insert(PollEvent::POLLRDBAND);
 		}
 
@@ -134,22 +136,27 @@ pub struct RamFileInterface {
 #[async_trait]
 impl ObjectInterface for RamFileInterface {
 	async fn poll(&self, event: PollEvent) -> Result<PollEvent, IoError> {
-		let mut result: PollEvent = PollEvent::EMPTY;
+		let mut result: PollEvent = PollEvent::empty();
 		let len = self.inner.read().await.data.len();
 		let pos_guard = self.pos.lock().await;
 		let pos = *pos_guard;
 
 		if event.contains(PollEvent::POLLIN) && pos < len {
 			result.insert(PollEvent::POLLIN);
-		} else if event.contains(PollEvent::POLLRDNORM) && pos < len {
+		}
+		if event.contains(PollEvent::POLLRDNORM) && pos < len {
 			result.insert(PollEvent::POLLRDNORM);
-		} else if event.contains(PollEvent::POLLRDBAND) && pos < len {
+		}
+		if event.contains(PollEvent::POLLRDBAND) && pos < len {
 			result.insert(PollEvent::POLLRDBAND);
-		} else if event.contains(PollEvent::POLLOUT) {
+		}
+		if event.contains(PollEvent::POLLOUT) {
 			result.insert(PollEvent::POLLOUT);
-		} else if event.contains(PollEvent::POLLWRNORM) {
+		}
+		if event.contains(PollEvent::POLLWRNORM) {
 			result.insert(PollEvent::POLLWRNORM);
-		} else if event.contains(PollEvent::POLLWRBAND) {
+		}
+		if event.contains(PollEvent::POLLWRBAND) {
 			result.insert(PollEvent::POLLWRBAND);
 		}
 


### PR DESCRIPTION
`eventfd` creates an linux-like "eventfd object" that can be used as an event wait/notify mechanism by user-space applications, and by the kernel to notify user-space applications of events. The object contains an unsigned 64-bit integer counter that is maintained by the kernel. This counter is initialized with the value specified in the argument `initval`.

As its return value, `eventfd` returns a new file descriptor that can be used to refer to the eventfd object.

The following values may be bitwise set in flags to change the behavior of `eventfd`:
- `EFD_NONBLOCK`: Set the file descriptor in non-blocking mode
- `EFD_SEMAPHORE`: Provide semaphore-like semantics for reads from the new file descriptor.

In addition, the PR includes some fine-tuning of the IP stack and the behavior of the system call `poll`. This should increase the compatibility to Unix.