### PR TITLE
fuse: reduce copying and handle errors

### DIFF
--- a/src/drivers/fs/virtio_pci.rs
+++ b/src/drivers/fs/virtio_pci.rs
@@ -112,7 +112,6 @@ impl VirtioFsDriver {
 			isr_stat,
 			notif_cfg,
 			vqueues: Vec::new(),
-			ready_queue: Vec::new(),
 			irq: device.get_irq().unwrap(),
 		})
 	}

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -3307,6 +3307,7 @@ impl From<DescrFlags> for u16 {
 /// virtqueue implementation, realized via the different enum variants.
 pub mod error {
 	use super::Transfer;
+	use crate::fd;
 
 	#[derive(Debug)]
 	// Internal Error Handling for Buffers
@@ -3385,6 +3386,12 @@ pub mod error {
 				VirtqError::QueueSizeNotAllowed(_) => write!(f, "The requested queue size is not valid."),
 				VirtqError:: FeatNotSupported(_) => write!(f, "An unsupported feature was requested from the queue."),
             }
+		}
+	}
+
+	impl core::convert::From<VirtqError> for fd::IoError {
+		fn from(_: VirtqError) -> Self {
+			fd::IoError::EIO
 		}
 	}
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -506,7 +506,7 @@ impl PerCoreScheduler {
 					}
 				}
 
-				Ready(Ok(()))
+				Ready(Ok::<(), IoError>(()))
 			})
 		})
 		.await?;


### PR DESCRIPTION
Instead of copying the commands into Virtqueue buffers and the buffers back into responses, directly provide the commands and responses as references to the send_command method.