### PR TITLE
riscv64: replace deprecated legacy extensions to SBI 2.0 extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
  "pci_types",
  "rand_chacha",
  "riscv",
- "sbi",
+ "sbi-rt",
  "semihosting",
  "shell-words",
  "simple-shell",
@@ -1116,10 +1116,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
-name = "sbi"
-version = "0.2.0"
+name = "sbi-rt"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cb0870400aca7e4487e8ec1e93f9d4288da763cb1da2cedc5102e62b6522ad"
+checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
+dependencies = [
+ "sbi-spec",
+]
+
+[[package]]
+name = "sbi-spec"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ semihosting = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 riscv = "0.11"
-sbi = "0.2"
+sbi-rt = "0.0.3"
 trapframe = "0.9"
 semihosting = { version = "0.1", optional = true }
 

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -123,7 +123,7 @@ pub fn message_output_init() {
 
 pub fn output_message_buf(buf: &[u8]) {
 	for byte in buf {
-		sbi::legacy::console_putchar(*byte);
+		sbi_rt::console_write_byte(*byte);
 	}
 }
 
@@ -198,7 +198,7 @@ fn finish_processor_init() {
 
 		//When running bare-metal/QEMU we use the firmware to start the next hart
 		if !env::is_uhyve() {
-			sbi::hart_state_management::hart_start(
+			sbi_rt::hart_start(
 				next_hart_id as usize,
 				start::_start as usize,
 				RAW_BOOT_INFO.load(Ordering::Relaxed) as usize,


### PR DESCRIPTION
The SBI legacy extensions are deprecated 4 years ago ( https://github.com/riscv-non-isa/riscv-sbi-doc/commit/705e9556d25dc070926b99f8ccbcdc5073407447 ). We replace it using functions from SBI 2.0 extensions. Specifically:
- the legacy console_putchar is replaced into console_write_byte in SBI DBCN extension;
- legacy shutdown is replaced to system_reset in SBI SRST extension with ColdReboot and NoReason as parameters;
- legacy set_timer is replaced with SBI TIME set_timer;
- legacy send_ipi is replaced to SBI IPI extension. The code implemented in file processor.rs creates a HartMask with only one hart_id selected as an IPI target.

By updating to SBI 2.0, this commit supports to send IPI to hart IDs greater than 63 (on 64-bit devices). The current code encodes hart_id parameter in bit-vector like `1 << hart_id`, which will cause the bit to be shifted out from `usize` range when `hart_id >= 64`. SBI 2.0 fixed this problem by adding a `hart_mask_base` parameter, allowing us to specify any hart ID within `usize` range when is provided as an SBI IPI hart mask.