### PR TITLE
feat: align Uhyve mount path to virtiofsd

### DIFF
--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -321,7 +321,7 @@ impl VfsNode for UhyveDirectory {
 pub(crate) fn init() {
 	info!("Try to initialize uhyve filesystem");
 	if is_uhyve() {
-		let mount_point = hermit_var_or!("UHYVE_MOUNT", "/host").to_string();
+		let mount_point = hermit_var_or!("UHYVE_MOUNT", "/root").to_string();
 		info!("Mounting virtio-fs at {}", mount_point);
 		fs::FILESYSTEM
 			.get()


### PR DESCRIPTION
Currently, Uhyve mounts to `/host` and virtiofsd mounts to `/root` (see [rftrace-example](https://github.com/hermit-os/hermit-rs/blob/14b59f8e92d9981446448003ff13ef6cc6469f56/examples/rftrace-example/src/main.rs#L12)).

Both [`xtask`](https://github.com/hermit-os/kernel/blob/6a89761bdc2dbdac6a3843079aed8579a9d3f8e7/xtask/src/ci/qemu.rs#L251) and [`runh`](https://github.com/hermit-os/runh/blob/70663eacd81f159b9a8bb107fe058f58b8b5ace0/src/hermit.rs#L115) currently set `tag=root` for virtiosfsd.