### PR TITLE
virtq: use a struct with the actual layout rather than a struct of references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ shell = ["simple-shell"]
 
 [dependencies]
 hermit-macro = { path = "hermit-macro" }
-virtio-def = { path = "virtio-def" }
+virtio-def = { path = "virtio-def", features = ["zerocopy"] }
 ahash = { version = "0.8", default-features = false }
 align-address = "0.1"
 bit_field = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ shell = ["simple-shell"]
 
 [dependencies]
 hermit-macro = { path = "hermit-macro" }
-virtio-def = { path = "virtio-def", features = ["zerocopy"] }
+virtio-def = { path = "virtio-def" }
 ahash = { version = "0.8", default-features = false }
 align-address = "0.1"
 bit_field = "0.10"
@@ -101,7 +101,7 @@ build-time = "0.1.3"
 async-trait = "0.1.80"
 async-lock = { version = "3.3.0", default-features = false }
 simple-shell = { version = "0.0.1", optional = true }
-volatile = "0.5.4"
+volatile = { version = "0.5.4", features = ["unstable"] }
 anstyle = { version = "1", default-features = false }
 
 [dependencies.smoltcp]

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -3367,6 +3367,7 @@ pub mod error {
 		BufferToLarge,
 		QueueSizeNotAllowed(u16),
 		FeatNotSupported(u64),
+		AllocationError,
 	}
 
 	impl core::fmt::Debug for VirtqError {
@@ -3385,6 +3386,7 @@ pub mod error {
                 VirtqError::BufferToLarge => write!(f, "Buffer to large for queue! u32::MAX exceeded."),
 				VirtqError::QueueSizeNotAllowed(_) => write!(f, "The requested queue size is not valid."),
 				VirtqError:: FeatNotSupported(_) => write!(f, "An unsupported feature was requested from the queue."),
+				VirtqError::AllocationError => write!(f, "An error was encountered during the allocation of the queue structures.")
             }
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 #![feature(new_uninit)]
 #![feature(noop_waker)]
 #![feature(slice_from_ptr_range)]
+#![feature(slice_ptr_get)]
 #![cfg_attr(
 	any(target_arch = "aarch64", target_arch = "riscv64"),
 	feature(specialization)


### PR DESCRIPTION
The code is not ready as I haven't yet figured out how the existing code ensures that the whole allocation is on the same page. This PR needs to be modified to ensure that as well. It is also based on #1141.