### PR TITLE
feat: stabilize kernel interface

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -407,6 +407,13 @@ pub(crate) static ERRNO: core::cell::UnsafeCell<i32> = core::cell::UnsafeCell::n
 #[cfg(not(feature = "nostd"))]
 #[no_mangle]
 pub extern "C" fn sys_get_errno() -> i32 {
+	sys_errno()
+}
+
+/// Get the error number from the thread local storage
+#[cfg(not(feature = "nostd"))]
+#[no_mangle]
+pub extern "C" fn sys_errno() -> i32 {
 	cfg_if::cfg_if! {
 		if #[cfg(any(feature = "common-os", target_arch = "riscv64"))] {
 			0

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::future::{self, Future};
 use core::ptr;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use core::task::ready;
 use core::task::Poll::Ready;
 
@@ -873,7 +873,7 @@ impl PerCoreScheduler {
 }
 
 fn get_tid() -> TaskId {
-	static TID_COUNTER: AtomicU32 = AtomicU32::new(0);
+	static TID_COUNTER: AtomicI32 = AtomicI32::new(0);
 	let guard = TASKS.lock();
 
 	loop {

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -56,14 +56,14 @@ pub(crate) enum TaskStatus {
 
 /// Unique identifier for a task (i.e. `pid`).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
-pub struct TaskId(u32);
+pub struct TaskId(i32);
 
 impl TaskId {
-	pub const fn into(self) -> u32 {
+	pub const fn into(self) -> i32 {
 		self.0
 	}
 
-	pub const fn from(x: u32) -> Self {
+	pub const fn from(x: i32) -> Self {
 		TaskId(x)
 	}
 }

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -96,10 +96,7 @@ pub unsafe extern "C" fn sys_clock_nanosleep(
 		"sys_clock_nanosleep called with a zero rqtp parameter"
 	);
 	let requested_time = unsafe { &*rqtp };
-	if requested_time.tv_sec < 0
-		|| requested_time.tv_nsec < 0
-		|| requested_time.tv_nsec > 999_999_999
-	{
+	if requested_time.tv_sec < 0 || requested_time.tv_nsec > 999_999_999 {
 		debug!("sys_clock_nanosleep called with an invalid requested time, returning -EINVAL");
 		return -EINVAL;
 	}

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,21 +1,26 @@
 use crate::arch;
 
+#[allow(non_camel_case_types)]
+pub type time_t = i64;
+#[allow(non_camel_case_types)]
+pub type suseconds_t = u32;
+
 /// Represent the number of seconds and microseconds since
 /// the Epoch (1970-01-01 00:00:00 +0000 (UTC))
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct timeval {
 	/// seconds
-	pub tv_sec: i64,
+	pub tv_sec: time_t,
 	/// microseconds
-	pub tv_usec: i64,
+	pub tv_usec: suseconds_t,
 }
 
 impl timeval {
 	pub fn from_usec(microseconds: u64) -> Self {
 		Self {
 			tv_sec: (microseconds / 1_000_000) as i64,
-			tv_usec: (microseconds % 1_000_000) as i64,
+			tv_usec: (microseconds % 1_000_000) as u32,
 		}
 	}
 
@@ -23,7 +28,7 @@ impl timeval {
 		u64::try_from(self.tv_sec)
 			.ok()
 			.and_then(|secs| secs.checked_mul(1_000_000))
-			.and_then(|millions| millions.checked_add(u64::try_from(self.tv_usec).ok()?))
+			.and_then(|millions| millions.checked_add(u64::from(self.tv_usec)))
 	}
 }
 
@@ -36,20 +41,20 @@ pub struct itimerval {
 
 /// Represent the number of seconds and nanoseconds since
 /// the Epoch (1970-01-01 00:00:00 +0000 (UTC))
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 pub struct timespec {
 	/// seconds
-	pub tv_sec: i64,
+	pub tv_sec: time_t,
 	/// nanoseconds
-	pub tv_nsec: i64,
+	pub tv_nsec: u32,
 }
 
 impl timespec {
 	pub fn from_usec(microseconds: u64) -> Self {
 		Self {
 			tv_sec: (microseconds / 1_000_000) as i64,
-			tv_nsec: ((microseconds % 1_000_000) * 1000) as i64,
+			tv_nsec: ((microseconds % 1_000_000) * 1000) as u32,
 		}
 	}
 
@@ -57,11 +62,11 @@ impl timespec {
 		u64::try_from(self.tv_sec)
 			.ok()
 			.and_then(|secs| secs.checked_mul(1_000_000))
-			.and_then(|millions| millions.checked_add(u64::try_from(self.tv_nsec).ok()? / 1000))
+			.and_then(|millions| millions.checked_add(u64::from(self.tv_nsec) / 1000))
 	}
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct SystemTime(timespec);
 
 impl SystemTime {


### PR DESCRIPTION
In case, that POSIX provides similar system calls, HermitOS uses variants of these system calls. These similiarties should increase the readability of the interface.

See also hermit-os/hermit-rs#570