### PR TITLE
fix(x86_64): make `CoreLocal` `#[repr(Rust)]` again

### DIFF
--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -314,7 +314,7 @@ where
 	if tls_size > 0 {
 		// To access TLS blocks on x86-64, TLS offsets are *subtracted* from the thread register value.
 		// So the thread pointer needs to be `block_ptr + tls_offset`.
-		// GNU style TLS requires `gs:0` to represent the same address as the thread pointer.
+		// GNU style TLS requires `fs:0` to represent the same address as the thread pointer.
 		// Since the thread pointer points to the end of the TLS blocks, we need to store it there.
 		let tcb_size = core::mem::size_of::<*mut ()>();
 		let tls_offset = tls_size as usize;

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -273,7 +273,7 @@ impl TaskTLS {
 		let mut block = {
 			// To access TLS blocks on x86-64, TLS offsets are *subtracted* from the thread register value.
 			// So the thread pointer needs to be `block_ptr + tls_offset`.
-			// GNU style TLS requires `gs:0` to represent the same address as the thread pointer.
+			// GNU style TLS requires `fs:0` to represent the same address as the thread pointer.
 			// Since the thread pointer points to the end of the TLS blocks, we need to store it there.
 			let tcb_size = mem::size_of::<*mut ()>();
 


### PR DESCRIPTION
@stlankes, `feature = "common-os"` does not use `gs` in other special ways, right?

Thanks for bringing this to my attention again, @camnwalter. :)

Closes https://github.com/hermit-os/kernel/issues/710
Closes https://github.com/hermit-os/kernel/pull/1170