### PR TITLE
fix(POSIX/time): make subsecond fields signed and use `timespec` in `stat`

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -26,6 +26,7 @@ use crate::fs::{
 	self, fuse_abi, AccessPermission, DirectoryEntry, FileAttr, NodeKind, ObjectInterface,
 	OpenOption, SeekWhence, VfsNode,
 };
+use crate::time::{time_t, timespec};
 
 // response out layout eg @ https://github.com/zargony/fuse-rs/blob/bf6d1cf03f3277e35b580f3c7b9999255d72ecf3/src/ll/request.rs#L44
 // op in/out sizes/layout: https://github.com/hanwen/go-fuse/blob/204b45dba899dfa147235c255908236d5fde2d32/fuse/opcode.go#L439
@@ -439,12 +440,18 @@ impl From<fuse_abi::Attr> for FileAttr {
 			st_size: attr.size,
 			st_blksize: attr.blksize as i64,
 			st_blocks: attr.blocks.try_into().unwrap(),
-			st_atime: attr.atime,
-			st_atime_nsec: attr.atimensec as u64,
-			st_mtime: attr.mtime,
-			st_mtime_nsec: attr.atimensec as u64,
-			st_ctime: attr.ctime,
-			st_ctime_nsec: attr.ctimensec as u64,
+			st_atim: timespec {
+				tv_sec: attr.atime as time_t,
+				tv_nsec: attr.atimensec as i32,
+			},
+			st_mtim: timespec {
+				tv_sec: attr.mtime as time_t,
+				tv_nsec: attr.mtimensec as i32,
+			},
+			st_ctim: timespec {
+				tv_sec: attr.ctime as time_t,
+				tv_nsec: attr.ctimensec as i32,
+			},
 			..Default::default()
 		}
 	}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -298,14 +298,11 @@ pub struct FileAttr {
 	/// size in blocks
 	pub st_blocks: i64,
 	/// time of last access
-	pub st_atime: u64,
-	pub st_atime_nsec: u64,
+	pub st_atim: timespec,
 	/// time of last modification
-	pub st_mtime: u64,
-	pub st_mtime_nsec: u64,
+	pub st_mtim: timespec,
 	/// time of last status change
-	pub st_ctime: u64,
-	pub st_ctime_nsec: u64,
+	pub st_ctim: timespec,
 }
 
 #[derive(Debug, FromPrimitive, ToPrimitive)]
@@ -414,20 +411,12 @@ impl Metadata {
 
 	/// Returns the last modification time listed in this metadata.
 	pub fn modified(&self) -> Result<SystemTime, IoError> {
-		let t = timespec {
-			tv_sec: self.0.st_mtime as i64,
-			tv_nsec: self.0.st_mtime_nsec as i32,
-		};
-		Ok(SystemTime::from(t))
+		Ok(SystemTime::from(self.0.st_mtim))
 	}
 
 	/// Returns the last modification time listed in this metadata.
 	pub fn accessed(&self) -> Result<SystemTime, IoError> {
-		let t = timespec {
-			tv_sec: self.0.st_atime as i64,
-			tv_nsec: self.0.st_atime_nsec as i32,
-		};
-		Ok(SystemTime::from(t))
+		Ok(SystemTime::from(self.0.st_atim))
 	}
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -414,16 +414,20 @@ impl Metadata {
 
 	/// Returns the last modification time listed in this metadata.
 	pub fn modified(&self) -> Result<SystemTime, IoError> {
-		Ok(SystemTime::from(timespec::from_usec(
-			self.0.st_mtime * 1_000_000 + self.0.st_mtime_nsec / 1000,
-		)))
+		let t = timespec {
+			tv_sec: self.0.st_mtime as i64,
+			tv_nsec: self.0.st_mtime_nsec as i32,
+		};
+		Ok(SystemTime::from(t))
 	}
 
 	/// Returns the last modification time listed in this metadata.
 	pub fn accessed(&self) -> Result<SystemTime, IoError> {
-		Ok(SystemTime::from(timespec::from_usec(
-			self.0.st_atime * 1_000_000 + self.0.st_atime_nsec / 1000,
-		)))
+		let t = timespec {
+			tv_sec: self.0.st_atime as i64,
+			tv_nsec: self.0.st_atime_nsec as i32,
+		};
+		Ok(SystemTime::from(t))
 	}
 }
 

--- a/src/syscalls/futex.rs
+++ b/src/syscalls/futex.rs
@@ -26,8 +26,8 @@ pub unsafe extern "C" fn sys_futex_wait(
 		None
 	} else {
 		match unsafe { timeout.read().into_usec() } {
-			t @ Some(_) => t,
-			None => return -EINVAL,
+			Some(usec) if usec >= 0 => Some(usec as u64),
+			_ => return -EINVAL,
 		}
 	};
 	let flags = match Flags::from_bits(flags) {

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -61,11 +61,11 @@ pub unsafe extern "C" fn sys_clock_gettime(clock_id: clockid_t, tp: *mut timespe
 
 	match clock_id {
 		CLOCK_REALTIME => {
-			*result = timespec::from_usec(arch::kernel::systemtime::now_micros());
+			*result = timespec::from_usec(arch::kernel::systemtime::now_micros() as i64);
 			0
 		}
 		CLOCK_MONOTONIC => {
-			*result = timespec::from_usec(arch::processor::get_timer_ticks());
+			*result = timespec::from_usec(arch::processor::get_timer_ticks() as i64);
 			0
 		}
 		_ => {
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
 		// Return the current time based on the wallclock time when we were booted up
 		// plus the current timer ticks.
 		let microseconds = arch::kernel::systemtime::now_micros();
-		*result = timeval::from_usec(microseconds);
+		*result = timeval::from_usec(microseconds as i64);
 	}
 
 	if tz > 0 {


### PR DESCRIPTION
This also improves handling of dates before UNIX epoch.