### PR TITLE
Fix device notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,10 @@ jobs:
             hermit-careful: 1
           - arch: x86_64
             packages: qemu-system-x86 libcap-ng-dev libseccomp-dev uftrace
-            flags: --features hermit/pci-ids
+            #flags: --features hermit/pci-ids
           - arch: aarch64
             packages: qemu-system-aarch64
-            flags: --features hermit/pci-ids
+            #flags: --features hermit/pci-ids
           - arch: riscv64
             packages: qemu-system-misc
 
@@ -200,6 +200,8 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.flags }} --package httpd --features ci,hermit/dhcpv4 --netdev virtio-net-pci
         if: matrix.arch != 'riscv64'
+      - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.flags }} --package httpd --no-default-features --microvm --features ci,hermit/dhcpv4,hermit/tcp --netdev virtio-net-mmio
+        if: matrix.arch == 'x86_64'
       - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.flags }} --package httpd --features ci,hermit/dhcpv4 --netdev rtl8139 --features hermit/rtl8139
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.flags }} --package testudp --features hermit/udp,hermit/dhcpv4 --netdev virtio-net-pci

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -18,7 +18,7 @@ pub const MAGIC_VALUE: u32 = 0x74726976;
 
 pub const MMIO_START: usize = 0x00000000feb00000;
 pub const MMIO_END: usize = 0x00000000feb0ffff;
-const IRQ_NUMBER: u8 = 23;
+const IRQ_NUMBER: u8 = 44 - 32;
 
 static mut MMIO_DRIVERS: Vec<MmioDriver> = Vec::new();
 

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -308,10 +308,12 @@ impl NotifCtrl {
 				ptr.write_volatile(notif_data[0..4].try_into().unwrap());
 			}
 		} else {
-			let ptr = self.notif_addr as *mut [u8; 2];
+			let mut data: [u8; 4] = [0, 0, 0, 0];
+			data[0..2].copy_from_slice(&notif_data[0..2]);
+			let ptr = self.notif_addr as *mut [u8; 4];
 
 			unsafe {
-				ptr.write_volatile(notif_data[0..2].try_into().unwrap());
+				ptr.write_volatile(data[0..4].try_into().unwrap());
 			}
 		}
 

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -761,7 +761,7 @@ impl NotifCtrl {
 
 	pub fn notify_dev(&self, notif_data: &[u8]) {
 		// See Virtio specification v.1.1. - 4.1.5.2
-		// Depending in the feature negotiation, we write eitehr only the
+		// Depending in the feature negotiation, we write either only the
 		// virtqueue index or the index and the next position inside the queue.
 
 		fence(Ordering::Acquire);


### PR DESCRIPTION
Fix the initialize of the MMIO device and use the correct interrupt number. In addition, the driver writes always 32bit values to the MMIO device. Otherwise, the device will not see the device notification.

Closes #1173