### PR TITLE
add option to define the DNS servers at compile time

### DIFF
--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -101,6 +101,12 @@ impl<'a> NetworkInterface<'a> {
 		let myip = Ipv4Address::from_str(hermit_var_or!("HERMIT_IP", "10.0.5.3")).unwrap();
 		let mygw = Ipv4Address::from_str(hermit_var_or!("HERMIT_GATEWAY", "10.0.5.1")).unwrap();
 		let mymask = Ipv4Address::from_str(hermit_var_or!("HERMIT_MASK", "255.255.255.0")).unwrap();
+		// Quad9 DNS server
+		#[cfg(feature = "dns")]
+		let mydns1 = Ipv4Address::from_str(hermit_var_or!("HERMIT_DNS1", "9.9.9.9")).unwrap();
+		// Cloudflare DNS server
+		#[cfg(feature = "dns")]
+		let mydns2 = Ipv4Address::from_str(hermit_var_or!("HERMIT_DNS2", "1.1.1.1")).unwrap();
 
 		// calculate the netmask length
 		// => count the number of contiguous 1 bits,
@@ -161,12 +167,7 @@ impl<'a> NetworkInterface<'a> {
 
 		#[cfg(feature = "dns")]
 		let dns_handle = {
-			let servers = &[
-				// Quad9 DNS server
-				Ipv4Address::new(9, 9, 9, 9).into(),
-				// Cloudflare DNS server
-				Ipv4Address::new(1, 1, 1, 1).into(),
-			];
+			let servers = &[mydns1.into(), mydns2.into()];
 			let dns_socket = dns::Socket::new(servers, vec![]);
 			sockets.add(dns_socket)
 		};

--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -161,10 +161,11 @@ impl<'a> NetworkInterface<'a> {
 
 		#[cfg(feature = "dns")]
 		let dns_handle = {
-			// use Google's DNS servers
 			let servers = &[
-				Ipv4Address::new(8, 8, 4, 4).into(),
-				Ipv4Address::new(8, 8, 8, 8).into(),
+				// Quad9 DNS server
+				Ipv4Address::new(9, 9, 9, 9).into(),
+				// Cloudflare DNS server
+				Ipv4Address::new(1, 1, 1, 1).into(),
 			];
 			let dns_socket = dns::Socket::new(servers, vec![]);
 			sockets.add(dns_socket)


### PR DESCRIPTION
Per default, Hermit's (static) network interface uses 9.9.9.9 (Quad9) and 1.1.1.1 (Cloudflare) as DNS servers. The default configuration could be overloaded at compile time by the environment variables HERMIT_DNS1 and HERMIT_DNS2. For instance, the following command sets the DNS servers to 8.8.8.8 and 8.8.4.4 .

```
HERMIT_DNS1="8.8.8.8" HERMIT_DNS2="8.8.4.4" cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --features hermit/dns,hermit/tcp
```