### PR TITLE
ci: workaround bad mio branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,10 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo +stable install cargo-careful
         if: matrix.profile == 'dev'
+      # FIXME: mio branch `v0.8.x` mio broke from `f5d912e7` to `a8a5c5bb`
+      # See https://github.com/hermit-os/kernel/actions/runs/9242628556/job/25489845418
+      - run: cargo update -p mio --precise f5d912e7
+        working-directory: .
       - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hello_world
       - run: cargo xtask ci qemu --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hello_world --no-default-features --microvm
         if: matrix.arch == 'x86_64'


### PR DESCRIPTION
@stlankes, CI broke after `v0.8.x` got updated from https://github.com/hermit-os/mio/commit/f5d912e774a9b24767cc937c8e3a1be9f8253334 to https://github.com/hermit-os/mio/commit/a8a5c5bbcf5590901ff41d76ed1ee60464f33f54.

See https://github.com/hermit-os/kernel/actions/runs/9242628556/job/25489845418.