### PR TITLE
refactor(pci): use more of the `pci_types` crate

### DIFF
--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -5,7 +5,7 @@
 use alloc::boxed::Box;
 use core::mem;
 
-use pci_types::{Bar, InterruptLine, MAX_BARS};
+use pci_types::{Bar, CommandRegister, InterruptLine, MAX_BARS};
 use x86::io::*;
 
 use crate::arch::kernel::core_local::increment_irq_counter;
@@ -15,7 +15,7 @@ use crate::arch::mm::VirtAddr;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::{network_irqhandler, NetworkDriver};
-use crate::drivers::pci::{PciCommand, PciDevice};
+use crate::drivers::pci::PciDevice;
 use crate::executor::device::{RxToken, TxToken};
 
 /// size of the receive buffer
@@ -438,7 +438,7 @@ pub(crate) fn init_device(
 
 	debug!("Found RTL8139 at iobase {:#x} (irq {})", iobase, irq);
 
-	device.set_command(PciCommand::PCI_COMMAND_MASTER);
+	device.set_command(CommandRegister::BUS_MASTER_ENABLE);
 
 	let mac: [u8; 6] = unsafe {
 		[

--- a/src/drivers/net/virtio_pci.rs
+++ b/src/drivers/net/virtio_pci.rs
@@ -5,11 +5,12 @@
 use alloc::vec::Vec;
 use core::str::FromStr;
 
+use pci_types::CommandRegister;
 use smoltcp::phy::ChecksumCapabilities;
 
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::net::virtio_net::{CtrlQueue, NetDevCfg, RxQueues, TxQueues, VirtioNetDriver};
-use crate::drivers::pci::{PciCommand, PciDevice};
+use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};
 use crate::drivers::virtio::transport::pci;
 use crate::drivers::virtio::transport::pci::{PciCap, UniCapsColl};
@@ -163,7 +164,7 @@ impl VirtioNetDriver {
 		device: &PciDevice<PciConfigRegion>,
 	) -> Result<VirtioNetDriver, VirtioError> {
 		// enable bus master mode
-		device.set_command(PciCommand::PCI_COMMAND_MASTER);
+		device.set_command(CommandRegister::BUS_MASTER_ENABLE);
 
 		let mut drv = match pci::map_caps(device) {
 			Ok(caps) => match VirtioNetDriver::new(caps, device) {

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -9,7 +9,7 @@ use hermit_sync::without_interrupts;
 use hermit_sync::InterruptTicketMutex;
 use pci_types::{
 	Bar, ConfigRegionAccess, DeviceId, EndpointHeader, InterruptLine, InterruptPin, PciAddress,
-	PciHeader, VendorId, MAX_BARS,
+	PciHeader, StatusRegister, VendorId, MAX_BARS,
 };
 
 use crate::arch::mm::{PhysAddr, VirtAddr};
@@ -343,6 +343,10 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 
 	pub fn id(&self) -> (VendorId, DeviceId) {
 		self.header().id(&self.access)
+	}
+
+	pub fn status(&self) -> StatusRegister {
+		self.header().status(&self.access)
 	}
 }
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -157,48 +157,35 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 	}
 
 	/// Configure the bar at register `slot`
-	#[allow(unused_variables)]
 	pub fn set_bar(&self, slot: u8, bar: Bar) {
-		let cmd = u16::from(DeviceHeader::PCI_BAR0_REGISTER) + u16::from(slot) * 4;
-		match bar {
-			Bar::Io { port } => unsafe {
-				self.access.write(self.address, cmd, port | 1);
-			},
+		let value = match bar {
+			Bar::Io { port } => (port | 1) as usize,
 			Bar::Memory32 {
 				address,
-				size,
+				size: _,
 				prefetchable,
 			} => {
 				if prefetchable {
-					unsafe {
-						self.access.write(self.address, cmd, address | 1 << 3);
-					}
+					(address | 1 << 3) as usize
 				} else {
-					unsafe {
-						self.access.write(self.address, cmd, address);
-					}
+					address as usize
 				}
 			}
 			Bar::Memory64 {
 				address,
-				size,
+				size: _,
 				prefetchable,
 			} => {
-				let high: u32 = (address >> 32).try_into().unwrap();
-				let low: u32 = (address & 0xFFFF_FFF0u64).try_into().unwrap();
 				if prefetchable {
-					unsafe {
-						self.access.write(self.address, cmd, low | 2 << 1 | 1 << 3);
-					}
+					(address | 2 << 1 | 1 << 3) as usize
 				} else {
-					unsafe {
-						self.access.write(self.address, cmd, low | 2 << 1);
-					}
-				}
-				unsafe {
-					self.access.write(self.address, cmd + 4, high);
+					(address | 2 << 1) as usize
 				}
 			}
+		};
+		let mut header = EndpointHeader::from_header(self.header(), &self.access).unwrap();
+		unsafe {
+			header.write_bar(slot, &self.access, value).unwrap();
 		}
 	}
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -7,6 +7,7 @@ use bitflags::bitflags;
 use hermit_sync::without_interrupts;
 #[cfg(any(feature = "tcp", feature = "udp", feature = "fuse"))]
 use hermit_sync::InterruptTicketMutex;
+use pci_types::capability::CapabilityIterator;
 use pci_types::{
 	Bar, ConfigRegionAccess, DeviceId, EndpointHeader, InterruptLine, InterruptPin, PciAddress,
 	PciHeader, StatusRegister, VendorId, MAX_BARS,
@@ -347,6 +348,11 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 
 	pub fn status(&self) -> StatusRegister {
 		self.header().status(&self.access)
+	}
+
+	pub fn capabilities(&self) -> Option<CapabilityIterator<'_, T>> {
+		EndpointHeader::from_header(self.header(), &self.access)
+			.map(|header| header.capabilities(&self.access))
 	}
 }
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -72,38 +72,6 @@ impl From<DeviceHeader> for u16 {
 	}
 }
 
-/// PCI masks. For convenience put into an enum and provides
-/// an `Into<u32>` method for usage.
-#[allow(dead_code, non_camel_case_types)]
-#[repr(u32)]
-pub enum Masks {
-	PCI_MASK_IS_BAR_IO_BAR = 0x0000_0001u32,
-	PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT = 0x0000_0004u32,
-	PCI_MASK_IS_MEM_BAR_PREFETCHABLE = 0x0000_0008u32,
-	PCI_MASK_STATUS_CAPABILITIES_LIST = 0x0000_0010u32,
-	PCI_MASK_CAPLIST_POINTER = 0x0000_00FCu32,
-	PCI_MASK_HEADER_TYPE = 0x007F_0000u32,
-	PCI_MASK_MULTIFUNCTION = 0x0080_0000u32,
-	PCI_MASK_MEM_BASE_ADDRESS = 0xFFFF_FFF0u32,
-	PCI_MASK_IO_BASE_ADDRESS = 0xFFFF_FFFCu32,
-}
-
-impl From<Masks> for u32 {
-	fn from(val: Masks) -> u32 {
-		match val {
-			Masks::PCI_MASK_STATUS_CAPABILITIES_LIST => 0x0000_0010u32,
-			Masks::PCI_MASK_CAPLIST_POINTER => 0x0000_00FCu32,
-			Masks::PCI_MASK_HEADER_TYPE => 0x007F_0000u32,
-			Masks::PCI_MASK_MULTIFUNCTION => 0x0080_0000u32,
-			Masks::PCI_MASK_MEM_BASE_ADDRESS => 0xFFFF_FFF0u32,
-			Masks::PCI_MASK_IO_BASE_ADDRESS => 0xFFFF_FFFCu32,
-			Masks::PCI_MASK_IS_MEM_BAR_PREFETCHABLE => 0x0000_0008u32,
-			Masks::PCI_MASK_IS_MEM_BASE_ADDRESS_64BIT => 0x0000_0004u32,
-			Masks::PCI_MASK_IS_BAR_IO_BAR => 0x0000_0001u32,
-		}
-	}
-}
-
 pub(crate) static mut PCI_DEVICES: Vec<PciDevice<PciConfigRegion>> = Vec::new();
 static mut PCI_DRIVERS: Vec<PciDriver> = Vec::new();
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -257,6 +257,8 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 	}
 
 	pub fn set_irq(&self, pin: InterruptPin, line: InterruptLine) {
+		// TODO: implement with `EndpointHeader::update_interrupt` and remove `DeviceHeader` once merged:
+		// https://github.com/rust-osdev/pci_types/pull/21
 		unsafe {
 			let mut command = self
 				.access

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -958,7 +958,7 @@ fn read_cap_raw(device: &PciDevice<PciConfigRegion>, register: u32) -> PciCapRaw
 /// structures inside the memory areas, indicated by the BaseAddressRegisters (BAR's).
 fn read_caps(
 	device: &PciDevice<PciConfigRegion>,
-	bars: Vec<PciBar>,
+	bars: &[PciBar],
 ) -> Result<Vec<PciCap>, PciError> {
 	let device_id = device.device_id();
 	let ptr: u32 = dev_caps_ptr(device);
@@ -1073,7 +1073,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 	};
 
 	// Get list of PciCaps pointing to capabilities
-	let cap_list = match read_caps(device, bar_list) {
+	let cap_list = match read_caps(device, &bar_list) {
 		Ok(list) => list,
 		Err(pci_error) => return Err(pci_error),
 	};

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -974,18 +974,7 @@ fn read_caps(
 	// Loop through capabilities list via next pointer
 	'cap_list: while next_ptr != 0u32 {
 		// read into raw capabilities structure
-		//
-		// Devices configuration space must be read twice
-		// and only returns correct values if both reads
-		// return equal values.
-		// For clarity see Virtio specification v1.1. - 2.4.1
-		let mut before = read_cap_raw(device, next_ptr);
-		let mut cap_raw = read_cap_raw(device, next_ptr);
-
-		while before != cap_raw {
-			before = read_cap_raw(device, next_ptr);
-			cap_raw = read_cap_raw(device, next_ptr);
-		}
+		let cap_raw = read_cap_raw(device, next_ptr);
 
 		let mut iter = bars.iter();
 


### PR DESCRIPTION
This is best reviewed commit by commit.

We can remove `DeviceHeader` fully once https://github.com/rust-osdev/pci_types/pull/21 is released.