### PR TITLE
fix(fuse): potential panic on unknown mode bits

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -470,7 +470,7 @@ impl From<fuse_abi::Attr> for FileAttr {
 		FileAttr {
 			st_ino: attr.ino,
 			st_nlink: attr.nlink as u64,
-			st_mode: AccessPermission::from_bits(attr.mode).unwrap(),
+			st_mode: AccessPermission::from_bits_retain(attr.mode),
 			st_uid: attr.uid,
 			st_gid: attr.gid,
 			st_rdev: attr.rdev as u64,


### PR DESCRIPTION
There has been a panic here at least once: https://github.com/hermit-os/kernel/actions/runs/9357240494/job/25756534015?pr=1248#step:25:195

```
$ cargo xtask ci qemu --arch x86_64 --profile release --package rftrace-example --virtiofsd
...
Saving traces to disk...!
0xc1b000, Events { ptr: 0xc1b000, len: 2000, cap: 2000 }
  Parsing TID 1...!
  Writing to disk: 8 events, 128 bytes (/root/tracedir/1.dat)
  Parsed all events!
Creating fake uftrace data dir at /root/tracedir..
  Creating ./info
    feats = TASK_SESSION | SYM_REL_ADDR
    info = CMDLINE | TASKINFO
    cmdline = 'fakeuftrace'
    tid = [1]
  Creating ./task.txt
[0][PANIC] panicked at src/fs/fuse.rs:479:47:
called `Result::unwrap()` on an `Err` value: TryFromIntError(())
```