### PR TITLE
fix(virtqueue/packed): set flags according to wrap count

### DIFF
--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -772,7 +772,8 @@ impl<'a> WriteCtrl<'a> {
 			desc_ref.id = (self.buff_id).into();
 			// Remove possibly set avail and used flags and then set avail and used
 			// according to the current WrapCount.
-			desc_ref.flags = flags - virtq::DescF::AVAIL - virtq::DescF::USED;
+			desc_ref.flags = (flags - virtq::DescF::AVAIL - virtq::DescF::USED)
+				| self.desc_ring.drv_wc.as_flags_avail();
 
 			self.incrmt()
 		}


### PR DESCRIPTION
This was an oversight in [`ed87942`](https://github.com/hermit-os/kernel/commit/ed87942798e44c8d5337b7f03e1ada80f2bb4cfa#diff-07dba9e5c603eb9b9163e081becfabea01d5d932b30f411de671140c446461d7L796-L799).