### PR TITLE
Change CI to support hermit-wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,10 @@ jobs:
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hello_world qemu ${{ matrix.flags }}
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hello_world qemu ${{ matrix.flags }} --uefi
         if: matrix.arch == 'x86_64'
-      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hermit-wasm --features ci qemu ${{ matrix.flags }}
+      - run: |
+          cargo xtask build --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --features fs
+          cd "/home/runner/work/kernel/kernel" && cargo build --target wasm32-wasip1 -Zunstable-options --profile release  --package  hello_world && mkdir -p /home/runner/work/kernel/kernel/kernel/shared && cp target/wasm32-wasip1/release/hello_world.wasm /home/runner/work/kernel/kernel/kernel/shared/ && cd -
+          cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hermit-wasm --features fs qemu ${{ matrix.flags }} --virtiofsd
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package hello_world --no-default-features qemu ${{ matrix.flags }} --microvm
         if: matrix.arch == 'x86_64'


### PR DESCRIPTION
By the PR hermit-os/hermit-rs#719, the command to start `hermit-wasm` changed. Consequently, the CI has to be modified to test `hermit-wasm`.