### PR TITLE
Fixed missing NULLPTR at the end of the environment list from uhyve

### DIFF
--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -144,6 +144,7 @@ impl SyscallInterface for Uhyve {
 					.as_usize(),
 			));
 		}
+		env.push(ptr::null::<u8>());
 
 		// ask uhyve for the environment
 		let mut syscmdval = SysCmdval::new(


### PR DESCRIPTION
Another one of these "How has this worked before" bugs:

`env` is a vector of pointers where uhyve writes the environment variables into. This vector is then cast into a pointer and passed to `std::sys::pal::hermit::os::init_environment`, where a hashmap is built from this list by iterating over the pointers.
The stop-condition of this iteration is a nullptr, but we never added that to the vector. Probably it worked before because the memory at the end of the list was zero by chance, but it failed now on my machine.

I appreciate any second thoughts because I'm skeptical as the bug has not triggered before.