### PR TITLE
add feature to support mmap and munmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ nostd = []
 semihosting = ["dep:semihosting"]
 shell = ["simple-shell"]
 idle-poll = []
+mmap = []
 
 [dependencies]
 hermit-macro = { path = "hermit-macro" }

--- a/src/arch/riscv64/mm/paging.rs
+++ b/src/arch/riscv64/mm/paging.rs
@@ -644,11 +644,6 @@ pub fn unmap<S: PageSize>(virtual_address: VirtAddr, count: usize) {
 		.map_pages(range, PhysAddr::zero(), PageTableEntryFlags::BLANK);
 }
 
-#[inline]
-pub fn get_application_page_size() -> usize {
-	LargePageSize::SIZE as usize
-}
-
 pub fn identity_map<S: PageSize>(start_address: PhysAddr, end_address: PhysAddr) {
 	let first_page = Page::<S>::including_address(VirtAddr(start_address.as_u64()));
 	let last_page = Page::<S>::including_address(VirtAddr(end_address.as_u64()));

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -106,7 +106,7 @@ pub fn virtual_to_physical(virtual_address: VirtAddr) -> Option<PhysAddr> {
 
 	match translate {
 		TranslateResult::NotMapped | TranslateResult::InvalidFrameAddress(_) => {
-			warn!(
+			trace!(
 				"Uable to determine the physical address of 0x{:X}",
 				virtual_address
 			);
@@ -260,11 +260,6 @@ where
 			Err(err) => panic!("{err:?}"),
 		}
 	}
-}
-
-#[inline]
-pub fn get_application_page_size() -> usize {
-	LargePageSize::SIZE as usize
 }
 
 #[cfg(not(feature = "common-os"))]

--- a/src/syscalls/mmap.rs
+++ b/src/syscalls/mmap.rs
@@ -1,0 +1,101 @@
+use align_address::Align;
+
+use crate::arch;
+#[cfg(target_arch = "x86_64")]
+use crate::arch::mm::paging::PageTableEntryFlagsExt;
+use crate::arch::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::mm::VirtAddr;
+
+bitflags! {
+	#[repr(transparent)]
+	#[derive(Debug, Copy, Clone, Default)]
+	pub struct MemoryProtection: u32 {
+		/// Pages may not be accessed.
+		const None = 0;
+		/// Indicates that the memory region should be readable.
+		const Read = 1 << 0;
+		/// Indicates that the memory region should be writable.
+		const Write = 1 << 1;
+		/// Indicates that the memory region should be executable.
+		const Exec = 1 << 2;
+	}
+}
+
+/// Creates a new virtual memory mapping of the `size` specified with
+/// protection bits specified in `prot_flags`.
+#[hermit_macro::system]
+#[no_mangle]
+pub extern "C" fn sys_mmap(size: usize, prot_flags: MemoryProtection, ret: &mut *mut u8) -> i32 {
+	let size = size.align_up(BasePageSize::SIZE as usize);
+	let virtual_address = arch::mm::virtualmem::allocate(size).unwrap();
+	if prot_flags.is_empty() {
+		*ret = virtual_address.as_mut_ptr();
+		return 0;
+	}
+	let physical_address = arch::mm::physicalmem::allocate(size).unwrap();
+
+	let count = size / BasePageSize::SIZE as usize;
+	let mut flags = PageTableEntryFlags::empty();
+	flags.normal().writable();
+	if prot_flags.contains(MemoryProtection::Write) {
+		flags.writable();
+	}
+	if !prot_flags.contains(MemoryProtection::Exec) {
+		flags.execute_disable();
+	}
+
+	arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+
+	*ret = virtual_address.as_mut_ptr();
+
+	0
+}
+
+/// Unmaps memory at the specified `ptr` for `size` bytes.
+#[hermit_macro::system]
+#[no_mangle]
+pub extern "C" fn sys_munmap(ptr: *mut u8, size: usize) -> i32 {
+	let virtual_address = VirtAddr::from_usize(ptr as usize);
+	let size = size.align_up(BasePageSize::SIZE as usize);
+
+	if let Some(phys_addr) = arch::mm::paging::virtual_to_physical(virtual_address) {
+		arch::mm::paging::unmap::<BasePageSize>(
+			virtual_address,
+			size / BasePageSize::SIZE as usize,
+		);
+		arch::mm::physicalmem::deallocate(phys_addr, size);
+	}
+
+	arch::mm::virtualmem::deallocate(virtual_address, size);
+
+	0
+}
+
+/// Configures the protections associated with a region of virtual memory
+/// starting at `ptr` and going to `size`.
+///
+/// Returns 0 on success and an error code on failure.
+#[hermit_macro::system]
+#[no_mangle]
+pub extern "C" fn sys_mprotect(ptr: *mut u8, size: usize, prot_flags: MemoryProtection) -> i32 {
+	let count = size / BasePageSize::SIZE as usize;
+	let mut flags = PageTableEntryFlags::empty();
+	flags.normal().writable();
+	if prot_flags.contains(MemoryProtection::Write) {
+		flags.writable();
+	}
+	if !prot_flags.contains(MemoryProtection::Exec) {
+		flags.execute_disable();
+	}
+
+	let virtual_address = VirtAddr::from_usize(ptr as usize);
+
+	if let Some(physical_address) = arch::mm::paging::virtual_to_physical(virtual_address) {
+		arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+		0
+	} else {
+		let physical_address = arch::mm::physicalmem::allocate(size).unwrap();
+		arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+		0
+	}
+}

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -34,6 +34,8 @@ mod condvar;
 mod entropy;
 mod futex;
 mod interfaces;
+#[cfg(feature = "mmap")]
+mod mmap;
 mod processor;
 #[cfg(feature = "newlib")]
 mod recmutex;

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -1,5 +1,8 @@
+use crate::arch::mm::paging::{BasePageSize, PageSize};
+
+/// Returns the base page size, in bytes, of the current system.
 #[hermit_macro::system]
 #[no_mangle]
 pub extern "C" fn sys_getpagesize() -> i32 {
-	crate::arch::mm::paging::get_application_page_size() as i32
+	BasePageSize::SIZE.try_into().unwrap()
 }


### PR DESCRIPTION
Both system calls aren't compatible to POSIX. mmap is only used to map a memory region into the address space.