### PR TITLE
add lseek support for in-memory files

### DIFF
--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -151,7 +151,7 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	}
 
 	/// `lseek` function repositions the offset of the file descriptor fildes
-	fn lseek(&self, _offset: isize, _whence: SeekWhence) -> io::Result<isize> {
+	async fn async_lseek(&self, _offset: isize, _whence: SeekWhence) -> io::Result<isize> {
 		Err(io::Error::EINVAL)
 	}
 
@@ -287,6 +287,12 @@ pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> io::Result<usize> {
 			Ok(x) => Ok(x),
 		}
 	}
+}
+
+pub(crate) fn lseek(fd: FileDescriptor, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+	let obj = get_object(fd)?;
+
+	block_on(obj.async_lseek(offset, whence), None)
 }
 
 pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> io::Result<usize> {

--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -725,8 +725,8 @@ impl ObjectInterface for FuseFileHandle {
 		self.0.lock().await.write(buf)
 	}
 
-	fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
-		block_on(async { self.0.lock().await.lseek(offset, whence) }, None)
+	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		self.0.lock().await.lseek(offset, whence)
 	}
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -313,7 +313,7 @@ pub enum FileType {
 	Whiteout = 14,       // DT_WHT
 }
 
-#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive, PartialEq)]
 pub enum SeekWhence {
 	Set = 0,
 	Cur = 1,

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -13,7 +13,6 @@ use x86::io::outl;
 
 use crate::arch::mm::{paging, PhysAddr, VirtAddr};
 use crate::env::is_uhyve;
-use crate::executor::block_on;
 use crate::fs::{
 	self, AccessPermission, FileAttr, NodeKind, ObjectInterface, OpenOption, SeekWhence, VfsNode,
 };
@@ -221,8 +220,8 @@ impl ObjectInterface for UhyveFileHandle {
 		self.0.lock().await.write(buf)
 	}
 
-	fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
-		block_on(async { self.0.lock().await.lseek(offset, whence) }, None)
+	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		self.0.lock().await.lseek(offset, whence)
 	}
 }
 

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -208,8 +208,12 @@ pub(crate) fn init() {
 		// Afterwards, we already use the heap and map the rest into
 		// the virtual address space.
 
+		#[cfg(not(feature = "mmap"))]
 		let virt_size: usize =
 			(available_memory - stack_reserve).align_down(LargePageSize::SIZE as usize);
+		#[cfg(feature = "mmap")]
+		let virt_size: usize = ((available_memory * 75) / 100).align_down(LargePageSize::SIZE as usize);
+
 		let virt_addr =
 			arch::mm::virtualmem::allocate_aligned(virt_size, LargePageSize::SIZE as usize)
 				.unwrap();

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -570,14 +570,8 @@ pub extern "C" fn sys_fcntl(fd: i32, cmd: i32, arg: i32) -> i32 {
 #[hermit_macro::system]
 #[no_mangle]
 pub extern "C" fn sys_lseek(fd: FileDescriptor, offset: isize, whence: i32) -> isize {
-	let obj = get_object(fd);
-	obj.map_or_else(
-		|e| -num::ToPrimitive::to_isize(&e).unwrap(),
-		|v| {
-			(*v).lseek(offset, num::FromPrimitive::from_i32(whence).unwrap())
-				.map_or_else(|e| -num::ToPrimitive::to_isize(&e).unwrap(), |_| 0)
-		},
-	)
+	crate::fd::lseek(fd, offset, num::FromPrimitive::from_i32(whence).unwrap())
+		.map_or_else(|e| -num::ToPrimitive::to_isize(&e).unwrap(), |_| 0)
 }
 
 #[repr(C)]


### PR DESCRIPTION
In addition, the synchronous `lseek` interface is converted asynchronous interface. Furthermore, if the feature `mmap` is available, the heap is reduced because it will expected that `mmap` will be used to map additional pages into the user address space.