### PR TITLE
enable IP fragmentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,8 @@ features = [
     "proto-ipv4",
     "proto-ipv6",
     # Enable IP fragmentation
-    #"proto-ipv4-fragmentation",
+    "proto-ipv4-fragmentation",
+    "proto-ipv6-fragmentation",
     #
     # Assume a MTU size of 9000
     #"fragmentation-buffer-size-8192",


### PR DESCRIPTION
Per default, IP framentation should be activated to avoid issues like hermit-os/hermit-rs#606

closes hermit-os/hermit-rs#606