### PR TITLE
feat(newlib): add support for riscv64

### DIFF
--- a/src/arch/riscv64/mm/virtualmem.rs
+++ b/src/arch/riscv64/mm/virtualmem.rs
@@ -151,3 +151,9 @@ pub fn print_information() {
 	let free_list = KERNEL_FREE_LIST.lock();
 	info!("Virtual memory free list:\n{free_list}");
 }
+
+#[cfg(feature = "newlib")]
+#[inline]
+pub const fn kernel_heap_end() -> VirtAddr {
+	KERNEL_VIRTUAL_MEMORY_END
+}


### PR DESCRIPTION
This PR simply defines `kernel_heap_end()` as `KERNEL_VIRTUAL_MEMORY_END` for the riscv64 architecture. 
This function is required for building the hermit kernel for riscv64 with the `newlib` feature flag enabled. 