### PR TITLE
feat(newlib): add support for aarch64

### DIFF
--- a/src/arch/aarch64/mm/virtualmem.rs
+++ b/src/arch/aarch64/mm/virtualmem.rs
@@ -145,3 +145,9 @@ pub fn print_information() {
 	let free_list = KERNEL_FREE_LIST.lock();
 	info!("Virtual memory free list:\n{free_list}");
 }
+
+#[cfg(feature = "newlib")]
+#[inline]
+pub const fn kernel_heap_end() -> VirtAddr {
+	KERNEL_VIRTUAL_MEMORY_END
+}


### PR DESCRIPTION
This PR simply defines `kernel_heap_end()` as `KERNEL_VIRTUAL_MEMORY_END` for the `aarch64` architecture.
This function is required for building the hermit kernel for `aarch64` with the newlib feature flag enabled.

Changes are identical to #1328. 