### PR TITLE
refactor(virtq): eliminate RefCell and Rc usage

### DIFF
--- a/src/drivers/fs/virtio_fs.rs
+++ b/src/drivers/fs/virtio_fs.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::rc::Rc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::str;
@@ -43,7 +42,7 @@ pub(crate) struct VirtioFsDriver {
 	pub(super) com_cfg: ComCfg,
 	pub(super) isr_stat: IsrStatus,
 	pub(super) notif_cfg: NotifCfg,
-	pub(super) vqueues: Vec<Rc<dyn Virtq>>,
+	pub(super) vqueues: Vec<Box<dyn Virtq>>,
 	pub(super) irq: InterruptLine,
 }
 
@@ -139,7 +138,7 @@ impl VirtioFsDriver {
 				self.dev_cfg.features.into(),
 			)
 			.unwrap();
-			self.vqueues.push(Rc::new(vq));
+			self.vqueues.push(Box::new(vq));
 		}
 
 		// At this point the device is "live"

--- a/src/drivers/net/virtio/mmio.rs
+++ b/src/drivers/net/virtio/mmio.rs
@@ -2,7 +2,7 @@
 //!
 //! The module contains ...
 
-use alloc::rc::Rc;
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::str::FromStr;
 
@@ -47,8 +47,8 @@ impl VirtioNetDriver {
 			1514
 		};
 
-		let send_vqs = TxQueues::new(Vec::<Rc<dyn Virtq>>::new(), false, &dev_cfg);
-		let recv_vqs = RxQueues::new(Vec::<Rc<dyn Virtq>>::new(), false, &dev_cfg);
+		let send_vqs = TxQueues::new(Vec::<Box<dyn Virtq>>::new(), false, &dev_cfg);
+		let recv_vqs = RxQueues::new(Vec::<Box<dyn Virtq>>::new(), false, &dev_cfg);
 		Ok(VirtioNetDriver {
 			dev_cfg,
 			com_cfg: ComCfg::new(registers, 1),


### PR DESCRIPTION
Since we no longer store a reference to the queue inside the transfer structures, we don't need to wrap the queues inside `Rc`s and the queue fields inside `RefCell`s.