### PR TITLE
Fix: Correctly parse irq-flags from dts

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -327,9 +327,9 @@ pub(crate) fn init() {
 					panic!("Invalid interrupt type");
 				};
 				gic.set_interrupt_priority(timer_irqid, 0x00);
-				if irqflags == 4 || irqflags == 8 {
+				if (irqflags & 0xf) == 4 || (irqflags & 0xf) == 8 {
 					gic.set_trigger(timer_irqid, Trigger::Level);
-				} else if irqflags == 2 || irqflags == 1 {
+				} else if (irqflags & 0xf) == 2 || (irqflags & 0xf) == 1 {
 					gic.set_trigger(timer_irqid, Trigger::Edge);
 				} else {
 					panic!("Invalid interrupt level!");


### PR DESCRIPTION
When parsing the Interrupt-Flags from the device-tree, only the 4 least significant bits specify the Trigger-Mode.
(ref: https://elixir.bootlin.com/linux/v6.10.2/source/Documentation/devicetree/bindings/interrupt-controller/arm,gic.yaml).

Only check 4 least significant bits by masking the others to make sure this does not lead to wrong panics.