### PR TITLE
fix: boot application processors after initializing scheduler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,5 +250,7 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: UHYVE=$CARGO_HOME/bin/uhyve cargo xtask ci uhyve --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --sudo --package rusty_demo
         if: matrix.arch == 'x86_64'
+      - run: UHYVE=$CARGO_HOME/bin/uhyve cargo xtask ci uhyve --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --sudo --package rusty_demo --smp
+        if: matrix.arch == 'x86_64'
       - run: FIRECRACKER=$HOME/.local/bin/firecracker cargo xtask ci firecracker --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --sudo --package hello_world --no-default-features
         if: matrix.arch == 'x86_64'

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -156,12 +156,6 @@ pub fn boot_processor_init() {
 	finish_processor_init();
 }
 
-/// Boots all available Application Processors on bare-metal or QEMU.
-/// Called after the Boot Processor has been fully initialized along with its scheduler.
-pub fn boot_application_processors() {
-	// Nothing to do here yet.
-}
-
 /// Application Processor initialization
 #[allow(dead_code)]
 pub fn application_processor_init() {
@@ -171,7 +165,9 @@ pub fn application_processor_init() {
 
 fn finish_processor_init() {
 	debug!("Initialized Processor");
+}
 
+pub fn boot_next_processor() {
 	CPU_ONLINE.fetch_add(1, Ordering::Release);
 }
 

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -19,7 +19,6 @@ cfg_if::cfg_if! {
 		#[cfg(feature = "smp")]
 		pub(crate) use self::aarch64::kernel::application_processor_init;
 		pub(crate) use self::aarch64::kernel::{
-			boot_application_processors,
 			get_processor_count,
 			message_output_init,
 			output_message_buf,
@@ -44,10 +43,7 @@ cfg_if::cfg_if! {
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(target_os = "none")]
-		pub(crate) use self::x86_64::kernel::{
-			boot_application_processors,
-			boot_processor_init,
-		};
+		pub(crate) use self::x86_64::kernel::boot_processor_init;
 		pub(crate) use self::x86_64::kernel::{
 			get_processor_count,
 			message_output_init,
@@ -68,7 +64,6 @@ cfg_if::cfg_if! {
 		pub(crate) use self::riscv64::kernel::pci;
 		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
-			boot_application_processors,
 			boot_processor_init,
 			core_local,
 			get_processor_count,

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -141,12 +141,6 @@ pub fn boot_processor_init() {
 	interrupts::enable();
 }
 
-/// Boots all available Application Processors on bare-metal or QEMU.
-/// Called after the Boot Processor has been fully initialized along with its scheduler.
-pub fn boot_application_processors() {
-	// Nothing to do here yet.
-}
-
 /// Application Processor initialization
 #[cfg(feature = "smp")]
 pub fn application_processor_init() {
@@ -179,6 +173,10 @@ fn finish_processor_init() {
 	// Remove current hart from the hart_mask
 	let new_hart_mask = get_hart_mask() & (u64::MAX - (1 << current_hart_id));
 	HART_MASK.store(new_hart_mask, Ordering::Relaxed);
+}
+
+pub fn boot_next_processor() {
+	let new_hart_mask = HART_MASK.load(Ordering::Relaxed);
 
 	let next_hart_index = lsb(new_hart_mask);
 

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -804,6 +804,8 @@ pub fn boot_application_processors() {
 			}
 		}
 	}
+
+	print_information();
 }
 
 #[cfg(feature = "smp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,7 @@ fn boot_processor_main() -> ! {
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
 
-	if !env::is_uhyve() {
-		arch::boot_application_processors();
-	}
+	arch::kernel::boot_next_processor();
 
 	#[cfg(feature = "smp")]
 	synch_all_cores();
@@ -253,6 +251,7 @@ fn application_processor_main() -> ! {
 	arch::application_processor_init();
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
+	arch::kernel::boot_next_processor();
 
 	debug!("Entering idle loop for application processor");
 


### PR DESCRIPTION
Without this, an application processor might call `scheduler::add_current_core` before the boot processor, for example on the GitHub runners with Uhyve.

Fixes https://github.com/hermit-os/kernel/issues/1366