### PR TITLE
fix(x86_64): downgrade log level of page unmap

### DIFF
--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -255,7 +255,7 @@ where
 			// FIXME: Some sentinel pages around stacks are supposed to be unmapped.
 			// We should handle this case there instead of here.
 			Err(UnmapError::PageNotMapped) => {
-				info!("Tried to unmap {page:?}, which was not mapped.")
+				debug!("Tried to unmap {page:?}, which was not mapped.")
 			}
 			Err(err) => panic!("{err:?}"),
 		}


### PR DESCRIPTION
This happens every time we spawn and destroy threads.