### PR TITLE
refactor(virtq): remove intermediate virtqueue channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,18 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,12 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
 name = "generic_once_cell"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +595,6 @@ dependencies = [
  "anstyle",
  "anyhow",
  "arm-gic",
- "async-channel",
  "async-lock",
  "async-trait",
  "bit_field",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ virtio = { package = "virtio-spec", version = "0.1", features = ["alloc", "mmio"
 ahash = { version = "0.8", default-features = false }
 align-address = "0.3"
 anstyle = { version = "1", default-features = false }
-async-channel = { version = "2.3", default-features = false }
 async-lock = { version = "3.4.0", default-features = false }
 async-trait = "0.1.83"
 bit_field = "0.10"

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -56,15 +56,11 @@ impl CtrlQueue {
 
 pub struct RxQueues {
 	vqs: Vec<Box<dyn Virtq>>,
-	poll_sender: async_channel::Sender<UsedBufferToken>,
-	poll_receiver: async_channel::Receiver<UsedBufferToken>,
 	packet_size: u32,
 }
 
 impl RxQueues {
 	pub fn new(vqs: Vec<Box<dyn Virtq>>, dev_cfg: &NetDevCfg) -> Self {
-		let (poll_sender, poll_receiver) = async_channel::unbounded();
-
 		// See Virtio specification v1.1 - 5.1.6.3.1
 		//
 		let packet_size = if dev_cfg.features.contains(virtio::net::F::MRG_RXBUF) {
@@ -73,12 +69,7 @@ impl RxQueues {
 			dev_cfg.raw.as_ptr().mtu().read().to_ne().into()
 		};
 
-		Self {
-			vqs,
-			poll_sender,
-			poll_receiver,
-			packet_size,
-		}
+		Self { vqs, packet_size }
 	}
 
 	/// Takes care of handling packets correctly which need some processing after being received.
@@ -95,32 +86,12 @@ impl RxQueues {
 	fn add(&mut self, mut vq: Box<dyn Virtq>) {
 		const BUFF_PER_PACKET: u16 = 2;
 		let num_packets: u16 = u16::from(vq.size()) / BUFF_PER_PACKET;
-		fill_queue(
-			vq.as_mut(),
-			num_packets,
-			self.packet_size,
-			self.poll_sender.clone(),
-		);
+		fill_queue(vq.as_mut(), num_packets, self.packet_size);
 		self.vqs.push(vq);
 	}
 
 	fn get_next(&mut self) -> Option<UsedBufferToken> {
-		let transfer = self.poll_receiver.try_recv();
-
-		transfer
-			.or_else(|_| {
-				// Check if any not yet provided transfers are in the queue.
-				self.poll();
-
-				self.poll_receiver.try_recv()
-			})
-			.ok()
-	}
-
-	fn poll(&mut self) {
-		for vq in &mut self.vqs {
-			vq.poll();
-		}
+		self.vqs[0].try_recv().ok()
 	}
 
 	fn enable_notifs(&mut self) {
@@ -140,12 +111,7 @@ impl RxQueues {
 	}
 }
 
-fn fill_queue(
-	vq: &mut dyn Virtq,
-	num_packets: u16,
-	packet_size: u32,
-	poll_sender: async_channel::Sender<UsedBufferToken>,
-) {
+fn fill_queue(vq: &mut dyn Virtq, num_packets: u16, packet_size: u32) {
 	for _ in 0..num_packets {
 		let buff_tkn = match AvailBufferToken::new(
 			vec![],
@@ -167,12 +133,7 @@ fn fill_queue(
 		// BufferTokens are directly provided to the queue
 		// TransferTokens are directly dispatched
 		// Transfers will be awaited at the queue
-		match vq.dispatch(
-			buff_tkn,
-			Some(poll_sender.clone()),
-			false,
-			BufferType::Direct,
-		) {
+		match vq.dispatch(buff_tkn, false, BufferType::Direct) {
 			Ok(_) => (),
 			Err(err) => {
 				error!("{:#?}", err);
@@ -220,7 +181,9 @@ impl TxQueues {
 
 	fn poll(&mut self) {
 		for vq in &mut self.vqs {
-			vq.poll();
+			// We don't do anything with the buffers but we need to receive them for the
+			// ring slots to be emptied and the memory from the previous transfers to be freed.
+			while vq.try_recv().is_ok() {}
 		}
 	}
 
@@ -339,7 +302,7 @@ impl NetworkDriver for VirtioNetDriver {
 		.unwrap();
 
 		self.send_vqs.vqs[0]
-			.dispatch(buff_tkn, None, false, BufferType::Direct)
+			.dispatch(buff_tkn, false, BufferType::Direct)
 			.unwrap();
 
 		result
@@ -373,7 +336,6 @@ impl NetworkDriver for VirtioNetDriver {
 			self.recv_vqs.vqs[0].as_mut(),
 			num_buffers,
 			self.recv_vqs.packet_size,
-			self.recv_vqs.poll_sender.clone(),
 		);
 
 		let vec_data = packets.into_iter().flatten().collect();

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -23,8 +23,8 @@ use super::super::transport::mmio::{ComCfg, NotifCfg, NotifCtrl};
 use super::super::transport::pci::{ComCfg, NotifCfg, NotifCtrl};
 use super::error::VirtqError;
 use super::{
-	AvailBufferToken, BufferType, MemDescrId, MemPool, TransferToken, UsedBufferToken,
-	UsedBufferTokenSender, Virtq, VirtqPrivate, VqIndex, VqSize,
+	AvailBufferToken, BufferType, MemDescrId, MemPool, TransferToken, UsedBufferToken, Virtq,
+	VirtqPrivate, VqIndex, VqSize,
 };
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::arch::mm::{paging, VirtAddr};
@@ -128,21 +128,14 @@ impl DescriptorRing {
 	}
 
 	/// Polls poll index and sets the state of any finished TransferTokens.
-	/// If [TransferToken::await_queue] is available, the [UsedBufferToken] will be moved to the queue.
-	fn poll(&mut self) {
+	fn try_recv(&mut self) -> Result<UsedBufferToken, VirtqError> {
 		let mut ctrl = self.get_read_ctrler();
 
-		if let Some((mut tkn, written_len)) = ctrl.poll_next() {
-			if let Some(queue) = tkn.await_queue.take() {
-				// Place the TransferToken in a Transfer, which will hold ownership of the token
-				queue
-					.try_send(UsedBufferToken::from_avail_buffer_token(
-						tkn.buff_tkn,
-						written_len,
-					))
-					.unwrap();
-			}
-		}
+		ctrl.poll_next()
+			.map(|(tkn, written_len)| {
+				UsedBufferToken::from_avail_buffer_token(tkn.buff_tkn, written_len)
+			})
+			.ok_or(VirtqError::NoNewUsed)
 	}
 
 	fn push_batch(
@@ -539,8 +532,8 @@ impl Virtq for PackedVq {
 		self.drv_event.disable_notif();
 	}
 
-	fn poll(&mut self) {
-		self.descr_ring.poll();
+	fn try_recv(&mut self) -> Result<UsedBufferToken, VirtqError> {
+		self.descr_ring.try_recv()
 	}
 
 	fn dispatch_batch(
@@ -552,7 +545,7 @@ impl Virtq for PackedVq {
 		assert!(!buffer_tkns.is_empty());
 
 		let transfer_tkns = buffer_tkns.into_iter().map(|(buffer_tkn, buffer_type)| {
-			Self::transfer_token_from_buffer_token(buffer_tkn, None, buffer_type)
+			Self::transfer_token_from_buffer_token(buffer_tkn, buffer_type)
 		});
 
 		let next_idx = self.descr_ring.push_batch(transfer_tkns)?;
@@ -581,18 +574,13 @@ impl Virtq for PackedVq {
 	fn dispatch_batch_await(
 		&mut self,
 		buffer_tkns: Vec<(AvailBufferToken, BufferType)>,
-		await_queue: super::UsedBufferTokenSender,
 		notif: bool,
 	) -> Result<(), VirtqError> {
 		// Zero transfers are not allowed
 		assert!(!buffer_tkns.is_empty());
 
 		let transfer_tkns = buffer_tkns.into_iter().map(|(buffer_tkn, buffer_type)| {
-			Self::transfer_token_from_buffer_token(
-				buffer_tkn,
-				Some(await_queue.clone()),
-				buffer_type,
-			)
+			Self::transfer_token_from_buffer_token(buffer_tkn, buffer_type)
 		});
 
 		let next_idx = self.descr_ring.push_batch(transfer_tkns)?;
@@ -621,11 +609,10 @@ impl Virtq for PackedVq {
 	fn dispatch(
 		&mut self,
 		buffer_tkn: AvailBufferToken,
-		sender: Option<UsedBufferTokenSender>,
 		notif: bool,
 		buffer_type: BufferType,
 	) -> Result<(), VirtqError> {
-		let transfer_tkn = Self::transfer_token_from_buffer_token(buffer_tkn, sender, buffer_type);
+		let transfer_tkn = Self::transfer_token_from_buffer_token(buffer_tkn, buffer_type);
 		let next_idx = self.descr_ring.push(transfer_tkn)?;
 
 		if notif {


### PR DESCRIPTION
Rather than pushing used buffers from the queues to channels, return them directly to the drivers. This removes the dependency on `async-channel`.