### PR TITLE
feat(env): parse env=KEY=VALUE for env vars

### DIFF
--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -91,15 +91,7 @@ pub fn get_processor_count() -> u32 {
 }
 
 pub fn args() -> Option<&'static str> {
-	let dtb = unsafe {
-		hermit_dtb::Dtb::from_raw(ptr::with_exposed_provenance(
-			boot_info().hardware_info.device_tree.unwrap().get() as usize,
-		))
-		.expect(".dtb file has invalid header")
-	};
-
-	dtb.get_property("/chosen", "bootargs")
-		.map(|property| str::from_utf8(property).unwrap())
+	None
 }
 
 /// Earliest initialization function called by the Boot Processor.

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -84,10 +84,7 @@ pub fn get_base_address() -> VirtAddr {
 }
 
 pub fn args() -> Option<&'static str> {
-	unsafe {
-		let fdt = Fdt::from_ptr(get_dtb_ptr()).expect("FDT is invalid");
-		fdt.chosen().bootargs()
-	}
+	None
 }
 
 pub fn get_dtb_ptr() -> *const u8 {

--- a/src/env.rs
+++ b/src/env.rs
@@ -100,12 +100,22 @@ impl Default for Cli {
 					env_vars.insert(String::from("UHYVE_MOUNT"), gateway);
 				}
 				"--" => args.extend(&mut words),
+				word if word.contains('=') => {
+					let (arg, value) = word.split_once('=').unwrap();
+
+					match arg {
+						"env" => {
+							let Some((key, value)) = value.split_once('=') else {
+								error!("could not parse bootarg: {word}");
+								continue;
+							};
+							env_vars.insert(key.to_string(), value.to_string());
+						}
+						_ => error!("could not parse bootarg: {word}"),
+					}
+				}
 				_ if image_path.is_none() => image_path = Some(word),
-				word => warn!(
-					"Found argument '{word}' which wasn't expected, or isn't valid in this context
-			
- 		If you tried to supply `{word}` as a value rather than a flag, use `-- {word}`"
-				),
+				word => error!("could not parse bootarg: {word}"),
 			};
 		}
 

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -1,15 +1,10 @@
-use alloc::alloc::{alloc, Layout};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use core::{mem, ptr};
+use core::ptr;
 
 use crate::arch;
-use crate::arch::mm::{paging, PhysAddr, VirtAddr};
+use crate::arch::mm::{paging, VirtAddr};
 use crate::syscalls::interfaces::SyscallInterface;
 
 const UHYVE_PORT_EXIT: u16 = 0x540;
-const UHYVE_PORT_CMDSIZE: u16 = 0x740;
-const UHYVE_PORT_CMDVAL: u16 = 0x780;
 
 /// forward a request to the hypervisor uhyve
 #[inline]
@@ -36,42 +31,6 @@ fn uhyve_send<T>(port: u16, data: &mut T) {
 	todo!("uhyve_send(port = {port}, physical_address = {physical_address})");
 }
 
-const MAX_ARGC_ENVC: usize = 128;
-
-#[repr(C, packed)]
-struct SysCmdsize {
-	argc: i32,
-	argsz: [i32; MAX_ARGC_ENVC],
-	envc: i32,
-	envsz: [i32; MAX_ARGC_ENVC],
-}
-
-impl SysCmdsize {
-	fn new() -> SysCmdsize {
-		SysCmdsize {
-			argc: 0,
-			argsz: [0; MAX_ARGC_ENVC],
-			envc: 0,
-			envsz: [0; MAX_ARGC_ENVC],
-		}
-	}
-}
-
-#[repr(C, packed)]
-struct SysCmdval {
-	argv: PhysAddr,
-	envp: PhysAddr,
-}
-
-impl SysCmdval {
-	fn new(argv: VirtAddr, envp: VirtAddr) -> SysCmdval {
-		SysCmdval {
-			argv: paging::virtual_to_physical(argv).unwrap(),
-			envp: paging::virtual_to_physical(envp).unwrap(),
-		}
-	}
-}
-
 #[repr(C, packed)]
 struct SysExit {
 	arg: i32,
@@ -86,62 +45,6 @@ impl SysExit {
 pub struct Uhyve;
 
 impl SyscallInterface for Uhyve {
-	/// ToDo: This function needs a description - also applies to trait in src/syscalls/interfaces/mod.rs
-	///
-	/// ToDo: Add Safety section under which circumctances this is safe/unsafe to use
-	/// ToDo: Add an Errors section - What happens when e.g. malloc fails, how is that handled (currently it isn't)
-	#[cfg(target_os = "none")]
-	fn get_application_parameters(&self) -> (i32, *const *const u8, *const *const u8) {
-		// determine the number of arguments and environment variables
-		let mut syscmdsize = SysCmdsize::new();
-		uhyve_send(UHYVE_PORT_CMDSIZE, &mut syscmdsize);
-
-		// create array to receive all arguments
-		let mut argv = Box::new(Vec::with_capacity(syscmdsize.argc as usize));
-		let mut argv_phy = Vec::with_capacity(syscmdsize.argc as usize);
-		for i in 0..syscmdsize.argc as usize {
-			let layout =
-				Layout::from_size_align(syscmdsize.argsz[i] as usize * mem::size_of::<u8>(), 1)
-					.unwrap();
-
-			argv.push(unsafe { alloc(layout).cast_const() });
-
-			argv_phy.push(ptr::with_exposed_provenance::<u8>(
-				paging::virtual_to_physical(VirtAddr(argv[i] as u64))
-					.unwrap()
-					.as_usize(),
-			));
-		}
-
-		// create array to receive the environment
-		let mut env = Box::new(Vec::with_capacity(syscmdsize.envc as usize + 1));
-		let mut env_phy = Vec::with_capacity(syscmdsize.envc as usize + 1);
-		for i in 0..syscmdsize.envc as usize {
-			let layout =
-				Layout::from_size_align(syscmdsize.envsz[i] as usize * mem::size_of::<u8>(), 1)
-					.unwrap();
-			env.push(unsafe { alloc(layout).cast_const() });
-
-			env_phy.push(ptr::with_exposed_provenance::<u8>(
-				paging::virtual_to_physical(VirtAddr(env[i] as u64))
-					.unwrap()
-					.as_usize(),
-			));
-		}
-		env.push(ptr::null::<u8>());
-
-		// ask uhyve for the environment
-		let mut syscmdval = SysCmdval::new(
-			VirtAddr(argv_phy.as_ptr() as u64),
-			VirtAddr(env_phy.as_ptr() as u64),
-		);
-		uhyve_send(UHYVE_PORT_CMDVAL, &mut syscmdval);
-
-		let argv = argv.leak().as_ptr();
-		let env = env.leak().as_ptr();
-		(syscmdsize.argc, argv, env)
-	}
-
 	fn shutdown(&self, error_code: i32) -> ! {
 		let mut sysexit = SysExit::new(error_code);
 		uhyve_send(UHYVE_PORT_EXIT, &mut sysexit);

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -3,9 +3,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::{mem, ptr};
 
-#[cfg(target_arch = "x86_64")]
-use x86::io::*;
-
 use crate::arch;
 use crate::arch::mm::{paging, PhysAddr, VirtAddr};
 use crate::syscalls::interfaces::SyscallInterface;
@@ -16,40 +13,27 @@ const UHYVE_PORT_CMDVAL: u16 = 0x780;
 
 /// forward a request to the hypervisor uhyve
 #[inline]
-#[cfg(target_arch = "x86_64")]
 fn uhyve_send<T>(port: u16, data: &mut T) {
 	let ptr = VirtAddr(ptr::from_mut(data).addr() as u64);
 	let physical_address = paging::virtual_to_physical(ptr).unwrap();
 
+	#[cfg(target_arch = "x86_64")]
 	unsafe {
-		outl(port, physical_address.as_u64() as u32);
+		x86::io::outl(port, physical_address.as_u64() as u32);
 	}
-}
 
-/// forward a request to the hypervisor uhyve
-#[inline]
-#[cfg(target_arch = "aarch64")]
-fn uhyve_send<T>(port: u16, data: &mut T) {
-	use core::arch::asm;
-
-	let ptr = VirtAddr(ptr::from_mut(data).addr() as u64);
-	let physical_address = paging::virtual_to_physical(ptr).unwrap();
-
+	#[cfg(target_arch = "aarch64")]
 	unsafe {
-		asm!(
+		core::arch::asm!(
 			"str x8, [{port}]",
 			port = in(reg) u64::from(port),
 			in("x8") physical_address.as_u64(),
 			options(nostack),
 		);
 	}
-}
 
-/// forward a request to the hypervisor uhyve
-#[inline]
-#[cfg(target_arch = "riscv64")]
-fn uhyve_send<T>(_port: u16, _data: &mut T) {
-	todo!()
+	#[cfg(target_arch = "riscv64")]
+	todo!("uhyve_send(port = {port}, physical_address = {physical_address})");
 }
 
 const MAX_ARGC_ENVC: usize = 128;


### PR DESCRIPTION
This PR

1. unifies FDT bootargs parsing across all platforms,
2. adds `env=KEY=VALUE` kernel arguments for environment variable initialization, and
3. disables the Uhyve `CMDSIZE` and `CMDVAL` hypercalls to use the kernel-maintained environment on Uhyve (breaking).

## Questions

1. Should we use the proposed `env=KEY=VALUE` format? This differs from our current format for other kernel arguments, such as `-freq FREQ` and `-ip IP`. I think we should migrate those to `freq=FREQ` and `ip=IP` eventually.
2. Do we need to support `=` in environment variable names?
3. Should we immediately disable the Uhyve hypercalls (easy)? This would break older versions of Uhyve, but I don't think this is a big problem. Alternatively, we could merge the Uhyve hypercall environment with the kernel one (complicated), or we only use the kernel environment when Uhyve returns an empty one (medium).

Extracted 0. commit: https://github.com/hermit-os/kernel/pull/1396
Corresponding Uhyve PR: https://github.com/hermit-os/uhyve/pull/758