### PR TITLE
add option to increase queue limit for incoming connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,12 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +596,6 @@ dependencies = [
  "build-time",
  "cfg-if",
  "crossbeam-utils",
- "dyn-clone",
  "fdt",
  "float-cmp",
  "free-list",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ bitflags = "2.6"
 build-time = "0.1.3"
 cfg-if = "1"
 crossbeam-utils = { version = "0.8", default-features = false }
-dyn-clone = "1.0"
 fdt = { version = "0.1", features = ["pretty-printing"] }
 free-list = "0.3"
 fuse-abi = { version = "0.2", features = ["linux", "zerocopy"], optional = true }

--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -52,7 +52,7 @@ impl<'a> NetworkInterface<'a> {
 			return NetworkState::InitializationFailed;
 		};
 
-		let mut device = HermitNet::new(mtu, checksums);
+		let mut device = HermitNet::new(mtu, checksums.clone());
 
 		if hermit_var!("HERMIT_IP").is_some() {
 			warn!("A static IP address is specified with the environment variable HERMIT_IP, but the device is configured to use DHCPv4!");
@@ -62,6 +62,7 @@ impl<'a> NetworkInterface<'a> {
 		let hardware_addr = HardwareAddress::Ethernet(ethernet_addr);
 
 		info!("MAC address {}", hardware_addr);
+		info!("{:?}", checksums);
 		info!("MTU: {} bytes", mtu);
 
 		let dhcp = dhcpv4::Socket::new();
@@ -100,7 +101,7 @@ impl<'a> NetworkInterface<'a> {
 			return NetworkState::InitializationFailed;
 		};
 
-		let mut device = HermitNet::new(mtu, checksums);
+		let mut device = HermitNet::new(mtu, checksums.clone());
 
 		let myip = Ipv4Address::from_str(hermit_var_or!("HERMIT_IP", "10.0.5.3")).unwrap();
 		let mygw = Ipv4Address::from_str(hermit_var_or!("HERMIT_GATEWAY", "10.0.5.1")).unwrap();
@@ -141,6 +142,7 @@ impl<'a> NetworkInterface<'a> {
 		info!("MAC address {}", hardware_addr);
 		info!("Configure network interface with address {}", ip_addrs[0]);
 		info!("Configure gateway with address {}", mygw);
+		info!("{:?}", checksums);
 		info!("MTU: {} bytes", mtu);
 
 		// use the current time based on the wall-clock time as seed

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -264,10 +264,9 @@ impl<'a> NetworkInterface<'a> {
 		Ok(tcp_handle)
 	}
 
-	pub(crate) fn poll_common(&mut self, timestamp: Instant) {
-		let _ = self
-			.iface
-			.poll(timestamp, &mut self.device, &mut self.sockets);
+	pub(crate) fn poll_common(&mut self, timestamp: Instant) -> bool {
+		self.iface
+			.poll(timestamp, &mut self.device, &mut self.sockets)
 	}
 
 	pub(crate) fn poll_delay(&mut self, timestamp: Instant) -> Option<Duration> {
@@ -320,22 +319,4 @@ impl<'a> NetworkInterface<'a> {
 		let dns_handle = self.dns_handle.ok_or(io::Error::EINVAL)?;
 		Ok(self.sockets.get_mut(dns_handle))
 	}
-}
-
-#[inline]
-pub(crate) fn network_delay(timestamp: Instant) -> Option<Duration> {
-	crate::executor::network::NIC
-		.lock()
-		.as_nic_mut()
-		.unwrap()
-		.poll_delay(timestamp)
-}
-
-#[inline]
-fn network_poll(timestamp: Instant) {
-	crate::executor::network::NIC
-		.lock()
-		.as_nic_mut()
-		.unwrap()
-		.poll_common(timestamp);
 }

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -79,6 +79,8 @@ impl ObjectInterface for EventFd {
 						cx.wake_by_ref();
 					}
 					Poll::Ready(Ok(len))
+				} else if self.flags.contains(EventFlags::EFD_NONBLOCK) {
+					Poll::Ready(Err(io::Error::EAGAIN))
 				} else {
 					guard.read_queue.push_back(cx.waker().clone());
 					Poll::Pending
@@ -115,6 +117,8 @@ impl ObjectInterface for EventFd {
 				}
 
 				Poll::Ready(Ok(len))
+			} else if self.flags.contains(EventFlags::EFD_NONBLOCK) {
+				Poll::Ready(Err(io::Error::EAGAIN))
 			} else {
 				guard.write_queue.push_back(cx.waker().clone());
 				Poll::Pending
@@ -162,9 +166,5 @@ impl ObjectInterface for EventFd {
 			}
 		})
 		.await
-	}
-
-	async fn is_nonblocking(&self) -> io::Result<bool> {
-		Ok(self.flags.contains(EventFlags::EFD_NONBLOCK))
 	}
 }

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -55,7 +55,7 @@ impl EventFd {
 
 #[async_trait]
 impl ObjectInterface for EventFd {
-	async fn async_read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		let len = mem::size_of::<u64>();
 
 		if buf.len() < len {
@@ -98,7 +98,7 @@ impl ObjectInterface for EventFd {
 		.await
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let len = mem::size_of::<u64>();
 
 		if buf.len() < len {
@@ -174,7 +174,7 @@ impl ObjectInterface for EventFd {
 		.await
 	}
 
-	fn is_nonblocking(&self) -> bool {
-		self.flags.contains(EventFlags::EFD_NONBLOCK)
+	async fn is_nonblocking(&self) -> io::Result<bool> {
+		Ok(self.flags.contains(EventFlags::EFD_NONBLOCK))
 	}
 }

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -7,7 +7,7 @@ use core::task::{ready, Poll, Waker};
 use async_lock::Mutex;
 use async_trait::async_trait;
 
-use crate::fd::{block_on, EventFlags, ObjectInterface, PollEvent};
+use crate::fd::{EventFlags, ObjectInterface, PollEvent};
 use crate::io;
 
 #[derive(Debug)]
@@ -31,16 +31,6 @@ impl EventState {
 pub(crate) struct EventFd {
 	state: Mutex<EventState>,
 	flags: EventFlags,
-}
-
-impl Clone for EventFd {
-	fn clone(&self) -> Self {
-		let counter = block_on(async { Ok(self.state.lock().await.counter) }, None).unwrap();
-		Self {
-			state: Mutex::new(EventState::new(counter)),
-			flags: self.flags,
-		}
-	}
 }
 
 impl EventFd {

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -205,13 +205,13 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	/// `setsockopt` sets options on sockets
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	async fn setsockopt(&self, _opt: SocketOption, _optval: bool) -> io::Result<()> {
-		Err(io::Error::EINVAL)
+		Err(io::Error::ENOTSOCK)
 	}
 
 	/// `getsockopt` gets options on sockets
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	async fn getsockopt(&self, _opt: SocketOption) -> io::Result<bool> {
-		Err(io::Error::EINVAL)
+		Err(io::Error::ENOTSOCK)
 	}
 
 	/// `getsockname` gets socket name

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -152,109 +152,91 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 
 	/// `async_read` attempts to read `len` bytes from the object references
 	/// by the descriptor
-	async fn async_read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
 		Err(io::Error::ENOSYS)
 	}
 
 	/// `async_write` attempts to write `len` bytes to the object references
 	/// by the descriptor
-	async fn async_write(&self, _buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, _buf: &[u8]) -> io::Result<usize> {
 		Err(io::Error::ENOSYS)
+	}
+
+	/// `lseek` function repositions the offset of the file descriptor fildes
+	async fn lseek(&self, _offset: isize, _whence: SeekWhence) -> io::Result<isize> {
+		Err(io::Error::EINVAL)
 	}
 
 	/// `is_nonblocking` returns `true`, if `read`, `write`, `recv` and send operations
 	/// don't block.
-	fn is_nonblocking(&self) -> bool {
-		false
-	}
-
-	/// `lseek` function repositions the offset of the file descriptor fildes
-	async fn async_lseek(&self, _offset: isize, _whence: SeekWhence) -> io::Result<isize> {
-		Err(io::Error::EINVAL)
+	async fn is_nonblocking(&self) -> io::Result<bool> {
+		Ok(false)
 	}
 
 	/// `fstat`
-	fn fstat(&self, _stat: &mut FileAttr) -> io::Result<()> {
-		Err(io::Error::EINVAL)
-	}
-
-	/// `unlink` removes file entry
-	#[allow(dead_code)]
-	fn unlink(&self, _path: &str) -> io::Result<()> {
-		Err(io::Error::EINVAL)
-	}
-
-	/// `rmdir` removes directory entry
-	#[allow(dead_code)]
-	fn rmdir(&self, _path: &str) -> io::Result<()> {
+	async fn fstat(&self) -> io::Result<FileAttr> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// 'readdir' returns a pointer to a dirent structure
 	/// representing the next directory entry in the directory stream
 	/// pointed to by the file descriptor
-	fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
-		Err(io::Error::EINVAL)
-	}
-
-	/// `mkdir` creates a directory entry
-	#[allow(dead_code)]
-	fn mkdir(&self, _path: &str, _mode: u32) -> io::Result<()> {
+	async fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `accept` a connection on a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn accept(&self) -> io::Result<Endpoint> {
+	async fn accept(&self) -> io::Result<Endpoint> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// initiate a connection on a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn connect(&self, _endpoint: Endpoint) -> io::Result<()> {
+	async fn connect(&self, _endpoint: Endpoint) -> io::Result<()> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `bind` a name to a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn bind(&self, _name: ListenEndpoint) -> io::Result<()> {
+	async fn bind(&self, _name: ListenEndpoint) -> io::Result<()> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `listen` for connections on a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn listen(&self, _backlog: i32) -> io::Result<()> {
+	async fn listen(&self, _backlog: i32) -> io::Result<()> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `setsockopt` sets options on sockets
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn setsockopt(&self, _opt: SocketOption, _optval: bool) -> io::Result<()> {
+	async fn setsockopt(&self, _opt: SocketOption, _optval: bool) -> io::Result<()> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `getsockopt` gets options on sockets
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn getsockopt(&self, _opt: SocketOption) -> io::Result<bool> {
+	async fn getsockopt(&self, _opt: SocketOption) -> io::Result<bool> {
 		Err(io::Error::EINVAL)
 	}
 
 	/// `getsockname` gets socket name
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn getsockname(&self) -> Option<Endpoint> {
-		None
+	async fn getsockname(&self) -> io::Result<Option<Endpoint>> {
+		Ok(None)
 	}
 
 	/// `getpeername` get address of connected peer
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	#[allow(dead_code)]
-	fn getpeername(&self) -> Option<Endpoint> {
-		None
+	async fn getpeername(&self) -> io::Result<Option<Endpoint>> {
+		Ok(None)
 	}
 
 	/// receive a message from a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn recvfrom(&self, _buffer: &mut [u8]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, _buffer: &mut [u8]) -> io::Result<(usize, Endpoint)> {
 		Err(io::Error::ENOSYS)
 	}
 
@@ -266,19 +248,19 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug + DynClone {
 	/// be sent to the address specified by dest_addr (overriding the pre-specified peer
 	/// address).
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize> {
+	async fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize> {
 		Err(io::Error::ENOSYS)
 	}
 
 	/// shut down part of a full-duplex connection
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	fn shutdown(&self, _how: i32) -> io::Result<()> {
+	async fn shutdown(&self, _how: i32) -> io::Result<()> {
 		Err(io::Error::ENOSYS)
 	}
 
 	/// The `ioctl` function manipulates the underlying device parameters of special
 	/// files.
-	fn ioctl(&self, _cmd: IoCtl, _value: bool) -> io::Result<()> {
+	async fn ioctl(&self, _cmd: IoCtl, _value: bool) -> io::Result<()> {
 		Err(io::Error::ENOSYS)
 	}
 }
@@ -290,8 +272,8 @@ pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> io::Result<usize> {
 		return Ok(0);
 	}
 
-	if obj.is_nonblocking() {
-		poll_on(obj.async_read(buf), Some(Duration::ZERO)).map_err(|x| {
+	if block_on(obj.is_nonblocking(), None)? {
+		poll_on(obj.read(buf), Some(Duration::ZERO)).map_err(|x| {
 			if x == io::Error::ETIME {
 				io::Error::EAGAIN
 			} else {
@@ -299,14 +281,14 @@ pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> io::Result<usize> {
 			}
 		})
 	} else {
-		block_on(obj.async_read(buf), None)
+		block_on(obj.read(buf), None)
 	}
 }
 
 pub(crate) fn lseek(fd: FileDescriptor, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 	let obj = get_object(fd)?;
 
-	block_on(obj.async_lseek(offset, whence), None)
+	block_on(obj.lseek(offset, whence), None)
 }
 
 pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> io::Result<usize> {
@@ -316,8 +298,8 @@ pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> io::Result<usize> {
 		return Ok(0);
 	}
 
-	if obj.is_nonblocking() {
-		poll_on(obj.async_write(buf), Some(Duration::ZERO)).map_err(|x| {
+	if block_on(obj.is_nonblocking(), None)? {
+		poll_on(obj.write(buf), Some(Duration::ZERO)).map_err(|x| {
 			if x == io::Error::ETIME {
 				io::Error::EAGAIN
 			} else {
@@ -325,7 +307,7 @@ pub(crate) fn write(fd: FileDescriptor, buf: &[u8]) -> io::Result<usize> {
 			}
 		})
 	} else {
-		block_on(obj.async_write(buf), None)
+		block_on(obj.write(buf), None)
 	}
 }
 
@@ -375,6 +357,11 @@ pub fn poll(fds: &mut [PollFd], timeout: Option<Duration>) -> io::Result<u64> {
 	}
 
 	result
+}
+
+pub fn fstat(fd: FileDescriptor) -> io::Result<FileAttr> {
+	let obj = get_object(fd)?;
+	block_on(obj.fstat(), None)
 }
 
 /// Wait for some event on a file descriptor.

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -1,14 +1,13 @@
 use alloc::boxed::Box;
 use core::future;
 use core::ops::DerefMut;
-use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
 use core::task::Poll;
 
 use async_trait::async_trait;
 use smoltcp::iface;
 use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
-use smoltcp::wire::IpEndpoint;
 
 use crate::executor::block_on;
 use crate::executor::network::{now, Handle, NetworkState, NIC};
@@ -32,8 +31,8 @@ fn get_ephemeral_port() -> u16 {
 pub struct Socket {
 	handle: Handle,
 	port: AtomicU16,
+	backlog: AtomicU32,
 	nonblocking: AtomicBool,
-	listen: AtomicBool,
 }
 
 impl Socket {
@@ -41,8 +40,8 @@ impl Socket {
 		Self {
 			handle,
 			port: AtomicU16::new(0),
+			backlog: AtomicU32::new(0),
 			nonblocking: AtomicBool::new(false),
-			listen: AtomicBool::new(false),
 		}
 	}
 
@@ -63,24 +62,6 @@ impl Socket {
 		nic.poll_common(now());
 
 		result
-	}
-
-	async fn async_connect(&self, endpoint: IpEndpoint) -> io::Result<()> {
-		self.with_context(|socket, cx| socket.connect(cx, endpoint, get_ephemeral_port()))
-			.map_err(|_| io::Error::EIO)?;
-
-		future::poll_fn(|cx| {
-			self.with(|socket| match socket.state() {
-				tcp::State::Closed | tcp::State::TimeWait => Poll::Ready(Err(io::Error::EFAULT)),
-				tcp::State::Listen => Poll::Ready(Err(io::Error::EIO)),
-				tcp::State::SynSent | tcp::State::SynReceived => {
-					socket.register_send_waker(cx.waker());
-					Poll::Pending
-				}
-				_ => Poll::Ready(Ok(())),
-			})
-		})
-		.await
 	}
 
 	async fn async_close(&self) -> io::Result<()> {
@@ -108,50 +89,6 @@ impl Socket {
 			})
 		})
 		.await
-	}
-
-	async fn async_accept(&self) -> io::Result<IpEndpoint> {
-		future::poll_fn(|cx| {
-			self.with(|socket| match socket.state() {
-				tcp::State::Closed => {
-					let _ = socket.listen(self.port.load(Ordering::Acquire));
-					Poll::Ready(())
-				}
-				tcp::State::Listen | tcp::State::Established => Poll::Ready(()),
-				_ => {
-					socket.register_recv_waker(cx.waker());
-					Poll::Pending
-				}
-			})
-		})
-		.await;
-
-		future::poll_fn(|cx| {
-			self.with(|socket| {
-				if socket.is_active() {
-					Poll::Ready(Ok(()))
-				} else {
-					match socket.state() {
-						tcp::State::Closed
-						| tcp::State::Closing
-						| tcp::State::FinWait1
-						| tcp::State::FinWait2 => Poll::Ready(Err(io::Error::EIO)),
-						_ => {
-							socket.register_recv_waker(cx.waker());
-							Poll::Pending
-						}
-					}
-				}
-			})
-		})
-		.await?;
-
-		let mut guard = NIC.lock();
-		let nic = guard.as_nic_mut().map_err(|_| io::Error::EIO)?;
-		let socket = nic.get_mut_socket::<tcp::Socket<'_>>(self.handle);
-		socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
-
-		Ok(socket.remote_endpoint().unwrap())
 	}
 }
 
@@ -188,7 +125,7 @@ impl ObjectInterface for Socket {
 					let mut available = PollEvent::empty();
 
 					if socket.can_recv()
-						|| socket.may_recv() && self.listen.swap(false, Ordering::Relaxed)
+						|| socket.may_recv() && self.backlog.load(Ordering::Acquire) > 0
 					{
 						// In case, we just establish a fresh connection in non-blocking mode, we try to read data.
 						available.insert(
@@ -230,7 +167,7 @@ impl ObjectInterface for Socket {
 	// TODO: Remove allow once fixed:
 	// https://github.com/rust-lang/rust-clippy/issues/11380
 	#[allow(clippy::needless_pass_by_ref_mut)]
-	async fn async_read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
 		future::poll_fn(|cx| {
 			self.with(|socket| match socket.state() {
 				tcp::State::Closed => Poll::Ready(Ok(0)),
@@ -259,7 +196,7 @@ impl ObjectInterface for Socket {
 		.await
 	}
 
-	async fn async_write(&self, buffer: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buffer: &[u8]) -> io::Result<usize> {
 		let mut pos: usize = 0;
 
 		while pos < buffer.len() {
@@ -304,7 +241,7 @@ impl ObjectInterface for Socket {
 		Ok(pos)
 	}
 
-	fn bind(&self, endpoint: ListenEndpoint) -> io::Result<()> {
+	async fn bind(&self, endpoint: ListenEndpoint) -> io::Result<()> {
 		#[allow(irrefutable_let_patterns)]
 		if let ListenEndpoint::Ip(endpoint) = endpoint {
 			self.port.store(endpoint.port, Ordering::Release);
@@ -314,70 +251,124 @@ impl ObjectInterface for Socket {
 		}
 	}
 
-	fn connect(&self, endpoint: Endpoint) -> io::Result<()> {
+	async fn connect(&self, endpoint: Endpoint) -> io::Result<()> {
 		#[allow(irrefutable_let_patterns)]
 		if let Endpoint::Ip(endpoint) = endpoint {
-			if self.nonblocking.load(Ordering::Acquire) {
-				block_on(self.async_connect(endpoint), Some(Duration::ZERO.into())).map_err(|x| {
-					if x == io::Error::ETIME {
-						io::Error::EAGAIN
-					} else {
-						x
+			self.with_context(|socket, cx| socket.connect(cx, endpoint, get_ephemeral_port()))
+				.map_err(|_| io::Error::EIO)?;
+
+			future::poll_fn(|cx| {
+				self.with(|socket| match socket.state() {
+					tcp::State::Closed | tcp::State::TimeWait => {
+						Poll::Ready(Err(io::Error::EFAULT))
 					}
+					tcp::State::Listen => Poll::Ready(Err(io::Error::EIO)),
+					tcp::State::SynSent | tcp::State::SynReceived => {
+						socket.register_send_waker(cx.waker());
+						Poll::Pending
+					}
+					_ => Poll::Ready(Ok(())),
 				})
-			} else {
-				block_on(self.async_connect(endpoint), None)
-			}
+			})
+			.await
 		} else {
 			Err(io::Error::EIO)
 		}
 	}
 
-	fn accept(&self) -> io::Result<Endpoint> {
-		let endpoint = if self.is_nonblocking() {
-			block_on(self.async_accept(), Some(Duration::ZERO.into())).map_err(|x| {
-				if x == io::Error::ETIME {
-					io::Error::EAGAIN
-				} else {
-					x
+	async fn accept(&self) -> io::Result<Endpoint> {
+		future::poll_fn(|cx| {
+			self.with(|socket| match socket.state() {
+				tcp::State::Closed => {
+					let _ = socket.listen(self.port.load(Ordering::Acquire));
+					Poll::Ready(())
 				}
-			})?
-		} else {
-			block_on(self.async_accept(), None)?
-		};
+				tcp::State::Listen | tcp::State::Established => Poll::Ready(()),
+				_ => {
+					socket.register_recv_waker(cx.waker());
+					Poll::Pending
+				}
+			})
+		})
+		.await;
 
-		Ok(Endpoint::Ip(endpoint))
+		future::poll_fn(|cx| {
+			self.with(|socket| {
+				if socket.is_active() {
+					Poll::Ready(Ok(()))
+				} else {
+					match socket.state() {
+						tcp::State::Closed
+						| tcp::State::Closing
+						| tcp::State::FinWait1
+						| tcp::State::FinWait2 => Poll::Ready(Err(io::Error::EIO)),
+						_ => {
+							socket.register_recv_waker(cx.waker());
+							Poll::Pending
+						}
+					}
+				}
+			})
+		})
+		.await?;
+
+		let mut guard = NIC.lock();
+		let nic = guard.as_nic_mut().map_err(|_| io::Error::EIO)?;
+		let socket = nic.get_mut_socket::<tcp::Socket<'_>>(self.handle);
+		socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
+
+		Ok(Endpoint::Ip(socket.remote_endpoint().unwrap()))
 	}
 
-	fn getpeername(&self) -> Option<Endpoint> {
-		self.with(|socket| socket.remote_endpoint())
-			.map(Endpoint::Ip)
+	async fn getpeername(&self) -> io::Result<Option<Endpoint>> {
+		Ok(self
+			.with(|socket| socket.remote_endpoint())
+			.map(Endpoint::Ip))
 	}
 
-	fn getsockname(&self) -> Option<Endpoint> {
-		self.with(|socket| socket.local_endpoint())
-			.map(Endpoint::Ip)
+	async fn getsockname(&self) -> io::Result<Option<Endpoint>> {
+		Ok(self
+			.with(|socket| socket.local_endpoint())
+			.map(Endpoint::Ip))
 	}
 
-	fn is_nonblocking(&self) -> bool {
-		self.nonblocking.load(Ordering::Acquire)
+	async fn is_nonblocking(&self) -> io::Result<bool> {
+		Ok(self.nonblocking.load(Ordering::Acquire))
 	}
 
-	fn listen(&self, _backlog: i32) -> io::Result<()> {
+	async fn listen(&self, backlog: i32) -> io::Result<()> {
 		self.with(|socket| {
 			if !socket.is_open() {
-				self.listen.store(true, Ordering::Relaxed);
-				socket
-					.listen(self.port.load(Ordering::Acquire))
-					.map(|_| ())
-					.map_err(|_| io::Error::EIO)
+				if backlog > 0 {
+					self.backlog
+						.store(backlog.try_into().unwrap(), Ordering::Relaxed);
+
+					socket
+						.listen(self.port.load(Ordering::Acquire))
+						.map(|_| ())
+						.map_err(|_| io::Error::EIO)?;
+
+					let rx_size = socket.recv_queue();
+					let tx_size = socket.send_queue();
+					let is_nagle = socket.nagle_enabled();
+					for _ in 1..backlog {
+						let rx_buffer = tcp::SocketBuffer::new(vec![0; rx_size]);
+						let tx_buffer = tcp::SocketBuffer::new(vec![0; tx_size]);
+						let mut tcp_socket = tcp::Socket::new(rx_buffer, tx_buffer);
+						tcp_socket.set_nagle_enabled(is_nagle);
+					}
+
+					Ok(())
+				} else {
+					Err(io::Error::EINVAL)
+				}
 			} else {
 				Err(io::Error::EIO)
 			}
 		})
 	}
 
-	fn setsockopt(&self, opt: SocketOption, optval: bool) -> io::Result<()> {
+	async fn setsockopt(&self, opt: SocketOption, optval: bool) -> io::Result<()> {
 		if opt == SocketOption::TcpNoDelay {
 			self.with(|socket| {
 				socket.set_nagle_enabled(optval);
@@ -393,7 +384,7 @@ impl ObjectInterface for Socket {
 		}
 	}
 
-	fn getsockopt(&self, opt: SocketOption) -> io::Result<bool> {
+	async fn getsockopt(&self, opt: SocketOption) -> io::Result<bool> {
 		if opt == SocketOption::TcpNoDelay {
 			self.with(|socket| Ok(socket.nagle_enabled()))
 		} else {
@@ -401,7 +392,7 @@ impl ObjectInterface for Socket {
 		}
 	}
 
-	fn shutdown(&self, how: i32) -> io::Result<()> {
+	async fn shutdown(&self, how: i32) -> io::Result<()> {
 		match how {
 			SHUT_RD /* Read  */ |
 			SHUT_WR /* Write */ |
@@ -410,7 +401,7 @@ impl ObjectInterface for Socket {
 		}
 	}
 
-	fn ioctl(&self, cmd: IoCtl, value: bool) -> io::Result<()> {
+	async fn ioctl(&self, cmd: IoCtl, value: bool) -> io::Result<()> {
 		if cmd == IoCtl::NonBlocking {
 			if value {
 				trace!("set device to nonblocking mode");
@@ -439,15 +430,16 @@ impl Clone for Socket {
 
 		drop(guard);
 		let port = self.port.load(Ordering::Acquire);
+		let backlog = self.backlog.load(Ordering::Acquire);
 		let obj = Self {
 			handle,
 			port: AtomicU16::new(port),
+			backlog: AtomicU32::new(backlog),
 			nonblocking: AtomicBool::new(self.nonblocking.load(Ordering::Acquire)),
-			listen: AtomicBool::new(false),
 		};
 
 		if port > 0 {
-			let _ = obj.listen(1024);
+			let _ = block_on(obj.listen(backlog.try_into().unwrap()), None);
 		}
 
 		obj

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -22,6 +22,8 @@ pub const SHUT_RD: i32 = 0;
 pub const SHUT_WR: i32 = 1;
 /// further sends and receives will be disallowed
 pub const SHUT_RDWR: i32 = 2;
+/// The default queue size for incoming connections
+pub const DEFAULT_BACKLOG: i32 = 128;
 
 fn get_ephemeral_port() -> u16 {
 	static LOCAL_ENDPOINT: AtomicU16 = AtomicU16::new(49152);
@@ -294,6 +296,10 @@ impl Socket {
 	}
 
 	async fn accept(&mut self) -> io::Result<(Socket, Endpoint)> {
+		if !self.is_listen {
+			self.listen(DEFAULT_BACKLOG).await?;
+		}
+
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_active() {

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -386,8 +386,7 @@ impl Socket {
 	}
 
 	async fn listen(&mut self, backlog: i32) -> io::Result<()> {
-		let (nagle_enabled, ack_delay) =
-			self.with(|socket| (socket.nagle_enabled(), socket.ack_delay()));
+		let nagle_enabled = self.with(|socket| socket.nagle_enabled());
 
 		self.with(|socket| {
 			if !socket.is_open() {
@@ -415,7 +414,6 @@ impl Socket {
 
 			let s = nic.get_mut_socket::<tcp::Socket<'_>>(handle);
 			s.set_nagle_enabled(nagle_enabled);
-			s.set_ack_delay(ack_delay);
 			s.listen(self.port)
 				.map(|_| ())
 				.map_err(|_| io::Error::EIO)?;
@@ -433,11 +431,6 @@ impl Socket {
 			for i in self.handle.iter() {
 				let socket = nic.get_mut_socket::<tcp::Socket<'_>>(*i);
 				socket.set_nagle_enabled(optval);
-				if optval {
-					socket.set_ack_delay(None);
-				} else {
-					socket.set_ack_delay(Some(Duration::from_millis(10)));
-				}
 			}
 
 			Ok(())

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -238,6 +238,7 @@ impl Socket {
 impl Drop for Socket {
 	fn drop(&mut self) {
 		let _ = block_on(self.close(), None);
+		NIC.lock().as_nic_mut().unwrap().destroy_socket(self.handle);
 	}
 }
 

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -8,7 +8,7 @@ use smoltcp::socket::udp::UdpMetadata;
 use smoltcp::wire::IpEndpoint;
 
 use crate::executor::block_on;
-use crate::executor::network::{now, Handle, NIC};
+use crate::executor::network::{Handle, NIC};
 use crate::fd::{Endpoint, IoCtl, ListenEndpoint, ObjectInterface, PollEvent};
 use crate::io;
 
@@ -31,10 +31,7 @@ impl Socket {
 	fn with<R>(&self, f: impl FnOnce(&mut udp::Socket<'_>) -> R) -> R {
 		let mut guard = NIC.lock();
 		let nic = guard.as_nic_mut().unwrap();
-		let result = f(nic.get_mut_socket::<udp::Socket<'_>>(self.handle));
-		nic.poll_common(now());
-
-		result
+		f(nic.get_mut_socket::<udp::Socket<'_>>(self.handle))
 	}
 
 	async fn close(&self) -> io::Result<()> {

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -67,7 +67,7 @@ fn uhyve_send<T>(_port: u16, _data: &mut T) {
 	todo!()
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GenericStdin;
 
 impl ObjectInterface for GenericStdin {}
@@ -78,7 +78,7 @@ impl GenericStdin {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GenericStdout;
 
 #[async_trait]
@@ -102,7 +102,7 @@ impl GenericStdout {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GenericStderr;
 
 #[async_trait]
@@ -126,7 +126,7 @@ impl GenericStderr {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UhyveStdin;
 
 impl ObjectInterface for UhyveStdin {}
@@ -137,7 +137,7 @@ impl UhyveStdin {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UhyveStdout;
 
 #[async_trait]
@@ -161,7 +161,7 @@ impl UhyveStdout {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UhyveStderr;
 
 #[async_trait]

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -88,7 +88,7 @@ impl ObjectInterface for GenericStdout {
 		Ok(event & available)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let _guard = IO_LOCK.lock().await;
 		arch::output_message_buf(buf);
 
@@ -112,7 +112,7 @@ impl ObjectInterface for GenericStderr {
 		Ok(event & available)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let _guard = IO_LOCK.lock().await;
 		arch::output_message_buf(buf);
 
@@ -147,7 +147,7 @@ impl ObjectInterface for UhyveStdout {
 		Ok(event & available)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let mut syswrite = SysWrite::new(STDOUT_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
 
@@ -171,7 +171,7 @@ impl ObjectInterface for UhyveStderr {
 		Ok(event & available)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let mut syswrite = SysWrite::new(STDERR_FILENO, buf.as_ptr(), buf.len());
 		uhyve_send(UHYVE_PORT_WRITE, &mut syswrite);
 

--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -724,15 +724,15 @@ impl ObjectInterface for FuseFileHandle {
 		self.0.lock().await.poll(event).await
 	}
 
-	async fn async_read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		self.0.lock().await.read(buf)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		self.0.lock().await.write(buf)
 	}
 
-	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 		self.0.lock().await.lseek(offset, whence)
 	}
 }
@@ -757,7 +757,7 @@ impl FuseDirectoryHandle {
 
 #[async_trait]
 impl ObjectInterface for FuseDirectoryHandle {
-	fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
+	async fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
 		let path: CString = if let Some(name) = &self.name {
 			CString::new("/".to_string() + name).unwrap()
 		} else {

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -63,7 +63,7 @@ impl ObjectInterface for RomFileInterface {
 		Ok(ret)
 	}
 
-	async fn async_read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		{
 			let microseconds = arch::kernel::systemtime::now_micros();
 			let t = timespec::from_usec(microseconds as i64);
@@ -91,7 +91,7 @@ impl ObjectInterface for RomFileInterface {
 		Ok(len)
 	}
 
-	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 		let guard = self.inner.read().await;
 		let mut pos_guard = self.pos.lock().await;
 
@@ -169,7 +169,7 @@ impl ObjectInterface for RamFileInterface {
 		Ok(event & available)
 	}
 
-	async fn async_read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		{
 			let microseconds = arch::kernel::systemtime::now_micros();
 			let t = timespec::from_usec(microseconds as i64);
@@ -197,7 +197,7 @@ impl ObjectInterface for RamFileInterface {
 		Ok(len)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let microseconds = arch::kernel::systemtime::now_micros();
 		let t = timespec::from_usec(microseconds as i64);
 		let mut guard = self.inner.write().await;
@@ -219,7 +219,7 @@ impl ObjectInterface for RamFileInterface {
 		Ok(buf.len())
 	}
 
-	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 		let mut guard = self.inner.write().await;
 		let mut pos_guard = self.pos.lock().await;
 
@@ -386,18 +386,13 @@ impl MemDirectoryInterface {
 
 #[async_trait]
 impl ObjectInterface for MemDirectoryInterface {
-	fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
-		block_on(
-			async {
-				let mut entries: Vec<DirectoryEntry> = Vec::new();
-				for name in self.inner.read().await.keys() {
-					entries.push(DirectoryEntry::new(name.to_string()));
-				}
+	async fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
+		let mut entries: Vec<DirectoryEntry> = Vec::new();
+		for name in self.inner.read().await.keys() {
+			entries.push(DirectoryEntry::new(name.to_string()));
+		}
 
-				Ok(entries)
-			},
-			None,
-		)
+		Ok(entries)
 	}
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -8,6 +8,7 @@ use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use async_trait::async_trait;
 use hermit_sync::OnceCell;
 use mem::MemDirectory;
 
@@ -127,8 +128,9 @@ impl DirectoryReader {
 	}
 }
 
+#[async_trait]
 impl ObjectInterface for DirectoryReader {
-	fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
+	async fn readdir(&self) -> io::Result<Vec<DirectoryEntry>> {
 		Ok(self.0.clone())
 	}
 }

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -212,15 +212,15 @@ impl UhyveFileHandle {
 
 #[async_trait]
 impl ObjectInterface for UhyveFileHandle {
-	async fn async_read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		self.0.lock().await.read(buf)
 	}
 
-	async fn async_write(&self, buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		self.0.lock().await.write(buf)
 	}
 
-	async fn async_lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 		self.0.lock().await.lseek(offset, whence)
 	}
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -22,6 +22,7 @@ pub enum Error {
 	EEXIST = crate::errno::EEXIST as isize,
 	EADDRINUSE = crate::errno::EADDRINUSE as isize,
 	EOVERFLOW = crate::errno::EOVERFLOW as isize,
+	ENOTSOCK = crate::errno::ENOTSOCK as isize,
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -537,26 +537,6 @@ impl PerCoreScheduler {
 		.await
 	}
 
-	/// Replace an existing IO interface by a new one
-	#[allow(dead_code)]
-	pub async fn replace_object(
-		&self,
-		fd: FileDescriptor,
-		obj: Arc<dyn ObjectInterface>,
-	) -> io::Result<()> {
-		future::poll_fn(|cx| {
-			without_interrupts(|| {
-				let borrowed = self.current_task.borrow();
-				let mut pinned_obj = core::pin::pin!(borrowed.object_map.write());
-
-				let mut guard = ready!(pinned_obj.as_mut().poll(cx));
-				guard.insert(fd, obj.clone());
-				Ready(Ok(()))
-			})
-		})
-		.await
-	}
-
 	/// Duplicate a IO interface and returns a new file descriptor as
 	/// identifier to the new copy
 	pub async fn dup_object(&self, fd: FileDescriptor) -> io::Result<FileDescriptor> {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -468,7 +468,7 @@ impl PerCoreScheduler {
 				let mut pinned_obj = core::pin::pin!(borrowed.object_map.read());
 
 				let guard = ready!(pinned_obj.as_mut().poll(cx));
-				Ready(guard.get(&fd).cloned().ok_or(io::Error::EINVAL))
+				Ready(guard.get(&fd).cloned().ok_or(io::Error::EBADF))
 			})
 		})
 		.await
@@ -579,7 +579,7 @@ impl PerCoreScheduler {
 				let borrowed = self.current_task.borrow();
 				let mut pinned_obj = core::pin::pin!(borrowed.object_map.write());
 				let mut guard = ready!(pinned_obj.as_mut().poll(cx));
-				Ready(guard.remove(&fd).ok_or(io::Error::EINVAL))
+				Ready(guard.remove(&fd).ok_or(io::Error::EBADF))
 			})
 		})
 		.await

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -462,35 +462,32 @@ impl Task {
 				))))
 				.unwrap();
 			let objmap = OBJECT_MAP.get().unwrap().clone();
-			let _ = poll_on(
-				async {
-					let mut guard = objmap.write().await;
-					if env::is_uhyve() {
-						guard
-							.try_insert(STDIN_FILENO, Arc::new(UhyveStdin::new()))
-							.map_err(|_| io::Error::EIO)?;
-						guard
-							.try_insert(STDOUT_FILENO, Arc::new(UhyveStdout::new()))
-							.map_err(|_| io::Error::EIO)?;
-						guard
-							.try_insert(STDERR_FILENO, Arc::new(UhyveStderr::new()))
-							.map_err(|_| io::Error::EIO)?;
-					} else {
-						guard
-							.try_insert(STDIN_FILENO, Arc::new(GenericStdin::new()))
-							.map_err(|_| io::Error::EIO)?;
-						guard
-							.try_insert(STDOUT_FILENO, Arc::new(GenericStdout::new()))
-							.map_err(|_| io::Error::EIO)?;
-						guard
-							.try_insert(STDERR_FILENO, Arc::new(GenericStderr::new()))
-							.map_err(|_| io::Error::EIO)?;
-					}
+			let _ = poll_on(async {
+				let mut guard = objmap.write().await;
+				if env::is_uhyve() {
+					guard
+						.try_insert(STDIN_FILENO, Arc::new(UhyveStdin::new()))
+						.map_err(|_| io::Error::EIO)?;
+					guard
+						.try_insert(STDOUT_FILENO, Arc::new(UhyveStdout::new()))
+						.map_err(|_| io::Error::EIO)?;
+					guard
+						.try_insert(STDERR_FILENO, Arc::new(UhyveStderr::new()))
+						.map_err(|_| io::Error::EIO)?;
+				} else {
+					guard
+						.try_insert(STDIN_FILENO, Arc::new(GenericStdin::new()))
+						.map_err(|_| io::Error::EIO)?;
+					guard
+						.try_insert(STDOUT_FILENO, Arc::new(GenericStdout::new()))
+						.map_err(|_| io::Error::EIO)?;
+					guard
+						.try_insert(STDERR_FILENO, Arc::new(GenericStderr::new()))
+						.map_err(|_| io::Error::EIO)?;
+				}
 
-					Ok(())
-				},
-				None,
-			);
+				Ok(())
+			});
 		}
 
 		Task {

--- a/src/syscalls/socket.rs
+++ b/src/syscalls/socket.rs
@@ -444,7 +444,7 @@ pub extern "C" fn sys_socket(domain: i32, type_: SockType, protocol: i32) -> i32
 			if type_.contains(SockType::SOCK_DGRAM) {
 				let handle = nic.create_udp_handle().unwrap();
 				drop(guard);
-				let socket = Arc::new(udp::Socket::new(handle));
+				let socket = Arc::new(async_lock::RwLock::new(udp::Socket::new(handle)));
 
 				if type_.contains(SockType::SOCK_NONBLOCK) {
 					block_on(socket.ioctl(IoCtl::NonBlocking, true), None).unwrap();


### PR DESCRIPTION
Revise object interface to be a complete asynchronous interface. In addition, add support of listen to increase queue limit for incoming connections.

smoltcp-rs/smoltcp#852 describes if N sockets are listening on the same port, an incoming connections go to a random socket. Consequently, this PR checks all listening sockets to accept a connection.