### PR TITLE
virtio-pci: store only the most preferred capability of a type

### DIFF
--- a/src/drivers/fs/virtio_fs.rs
+++ b/src/drivers/fs/virtio_fs.rs
@@ -202,12 +202,6 @@ pub mod error {
 	pub enum VirtioFsError {
 		#[cfg(feature = "pci")]
 		NoDevCfg(u16),
-		#[cfg(feature = "pci")]
-		NoComCfg(u16),
-		#[cfg(feature = "pci")]
-		NoIsrCfg(u16),
-		#[cfg(feature = "pci")]
-		NoNotifCfg(u16),
 		FailFeatureNeg(u16),
 		/// The first field contains the feature bits wanted by the driver.
 		/// but which are incompatible with the device feature set, second field.

--- a/src/drivers/fs/virtio_pci.rs
+++ b/src/drivers/fs/virtio_pci.rs
@@ -28,53 +28,30 @@ impl VirtioFsDriver {
 	/// Instantiates a new (VirtioFsDriver)[VirtioFsDriver] struct, by checking the available
 	/// configuration structures and moving them into the struct.
 	pub fn new(
-		mut caps_coll: UniCapsColl,
+		caps_coll: UniCapsColl,
 		device: &PciDevice<PciConfigRegion>,
 	) -> Result<Self, error::VirtioFsError> {
 		let device_id = device.device_id();
 
-		let com_cfg = match caps_coll.get_com_cfg() {
-			Some(com_cfg) => com_cfg,
-			None => {
-				error!("No common config. Aborting!");
-				return Err(error::VirtioFsError::NoComCfg(device_id));
-			}
-		};
+		let UniCapsColl {
+			com_cfg,
+			notif_cfg,
+			isr_cfg,
+			dev_cfg_list,
+			..
+		} = caps_coll;
 
-		let isr_stat = match caps_coll.get_isr_cfg() {
-			Some(isr_stat) => isr_stat,
-			None => {
-				error!("No ISR status config. Aborting!");
-				return Err(error::VirtioFsError::NoIsrCfg(device_id));
-			}
-		};
-
-		let notif_cfg = match caps_coll.get_notif_cfg() {
-			Some(notif_cfg) => notif_cfg,
-			None => {
-				error!("No notif config. Aborting!");
-				return Err(error::VirtioFsError::NoNotifCfg(device_id));
-			}
-		};
-
-		let dev_cfg = loop {
-			match caps_coll.get_dev_cfg() {
-				Some(cfg) => {
-					if let Some(dev_cfg) = VirtioFsDriver::map_cfg(&cfg) {
-						break dev_cfg;
-					}
-				}
-				None => {
-					error!("No dev config. Aborting!");
-					return Err(error::VirtioFsError::NoDevCfg(device_id));
-				}
-			}
+		let dev_cfg = if let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioFsDriver::map_cfg) {
+			dev_cfg
+		} else {
+			error!("No dev config. Aborting!");
+			return Err(error::VirtioFsError::NoDevCfg(device_id));
 		};
 
 		Ok(VirtioFsDriver {
 			dev_cfg,
 			com_cfg,
-			isr_stat,
+			isr_stat: isr_cfg,
 			notif_cfg,
 			vqueues: Vec::new(),
 			irq: device.get_irq().unwrap(),
@@ -91,9 +68,9 @@ impl VirtioFsDriver {
 					return Err(VirtioError::FsDriver(fs_err));
 				}
 			},
-			Err(pci_error) => {
+			Err(err) => {
 				error!("Mapping capabilities failed. Aborting!");
-				return Err(VirtioError::FromPci(pci_error));
+				return Err(err);
 			}
 		};
 

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -819,12 +819,6 @@ pub mod error {
 	pub enum VirtioNetError {
 		#[cfg(feature = "pci")]
 		NoDevCfg(u16),
-		#[cfg(feature = "pci")]
-		NoComCfg(u16),
-		#[cfg(feature = "pci")]
-		NoIsrCfg(u16),
-		#[cfg(feature = "pci")]
-		NoNotifCfg(u16),
 		FailFeatureNeg(u16),
 		/// Set of features does not adhere to the requirements of features
 		/// indicated by the specification

--- a/src/drivers/net/virtio/pci.rs
+++ b/src/drivers/net/virtio/pci.rs
@@ -37,46 +37,24 @@ impl VirtioNetDriver {
 	/// Instantiates a new (VirtioNetDriver)[VirtioNetDriver] struct, by checking the available
 	/// configuration structures and moving them into the struct.
 	pub(crate) fn new(
-		mut caps_coll: UniCapsColl,
+		caps_coll: UniCapsColl,
 		device: &PciDevice<PciConfigRegion>,
 	) -> Result<Self, error::VirtioNetError> {
 		let device_id = device.device_id();
-		let com_cfg = match caps_coll.get_com_cfg() {
-			Some(com_cfg) => com_cfg,
-			None => {
-				error!("No common config. Aborting!");
-				return Err(error::VirtioNetError::NoComCfg(device_id));
-			}
-		};
+		let UniCapsColl {
+			com_cfg,
+			notif_cfg,
+			isr_cfg,
+			dev_cfg_list,
+			..
+		} = caps_coll;
 
-		let isr_stat = match caps_coll.get_isr_cfg() {
-			Some(isr_stat) => isr_stat,
-			None => {
-				error!("No ISR status config. Aborting!");
-				return Err(error::VirtioNetError::NoIsrCfg(device_id));
-			}
-		};
-
-		let notif_cfg = match caps_coll.get_notif_cfg() {
-			Some(notif_cfg) => notif_cfg,
-			None => {
-				error!("No notif config. Aborting!");
-				return Err(error::VirtioNetError::NoNotifCfg(device_id));
-			}
-		};
-
-		let dev_cfg = loop {
-			match caps_coll.get_dev_cfg() {
-				Some(cfg) => {
-					if let Some(dev_cfg) = VirtioNetDriver::map_cfg(&cfg) {
-						break dev_cfg;
-					}
-				}
-				None => {
-					error!("No dev config. Aborting!");
-					return Err(error::VirtioNetError::NoDevCfg(device_id));
-				}
-			}
+		let dev_cfg = if let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioNetDriver::map_cfg)
+		{
+			dev_cfg
+		} else {
+			error!("No dev config. Aborting!");
+			return Err(error::VirtioNetError::NoDevCfg(device_id));
 		};
 
 		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
@@ -91,7 +69,7 @@ impl VirtioNetDriver {
 		Ok(VirtioNetDriver {
 			dev_cfg,
 			com_cfg,
-			isr_stat,
+			isr_stat: isr_cfg,
 			notif_cfg,
 			ctrl_vq: CtrlQueue::new(None),
 			recv_vqs,
@@ -124,9 +102,9 @@ impl VirtioNetDriver {
 					return Err(VirtioError::NetDriver(vnet_err));
 				}
 			},
-			Err(pci_error) => {
+			Err(err) => {
 				error!("Mapping capabilities failed. Aborting!");
-				return Err(VirtioError::FromPci(pci_error));
+				return Err(err);
 			}
 		};
 

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -22,6 +22,12 @@ pub mod error {
 	pub enum VirtioError {
 		#[cfg(feature = "pci")]
 		FromPci(PciError),
+		#[cfg(feature = "pci")]
+		NoComCfg(u16),
+		#[cfg(feature = "pci")]
+		NoIsrCfg(u16),
+		#[cfg(feature = "pci")]
+		NoNotifCfg(u16),
 		DevNotSupported(u16),
 		#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 		NetDriver(VirtioNetError),
@@ -45,17 +51,17 @@ pub mod error {
                     PciError::NoCapPtr(id) => write!(f, "Driver failed to initialize device with id: {id:#x}. Reason: No Capabilities pointer found."),
                     PciError::NoVirtioCaps(id) => write!(f, "Driver failed to initialize device with id: {id:#x}. Reason: No Virtio capabilities were found."),
                 },
+				#[cfg(feature = "pci")]
+				VirtioError::NoComCfg(id) =>  write!(f, "Virtio driver failed, for device {id:x}, due to a missing or malformed common config!"),
+				#[cfg(feature = "pci")]
+				VirtioError::NoIsrCfg(id) =>  write!(f, "Virtio driver failed, for device {id:x}, due to a missing or malformed ISR status config!"),
+				#[cfg(feature = "pci")]
+				VirtioError::NoNotifCfg(id) =>  write!(f, "Virtio driver failed, for device {id:x}, due to a missing or malformed notification config!"),
                 VirtioError::DevNotSupported(id) => write!(f, "Device with id {id:#x} not supported."),
 				#[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
                 VirtioError::NetDriver(net_error) => match net_error {
 					#[cfg(feature = "pci")]
 					VirtioNetError::NoDevCfg(id) => write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed device config!"),
-					#[cfg(feature = "pci")]
-                    VirtioNetError::NoComCfg(id) =>  write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed common config!"),
-					#[cfg(feature = "pci")]
-                    VirtioNetError::NoIsrCfg(id) =>  write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed ISR status config!"),
-					#[cfg(feature = "pci")]
-                    VirtioNetError::NoNotifCfg(id) =>  write!(f, "Virtio network driver failed, for device {id:x}, due to a missing or malformed notification config!"),
                     VirtioNetError::FailFeatureNeg(id) => write!(f, "Virtio network driver failed, for device {id:x}, device did not acknowledge negotiated feature set!"),
                     VirtioNetError::FeatureRequirementsNotMet(features) => write!(f, "Virtio network driver tried to set feature bit without setting dependency feature. Feat set: {features:?}"),
                     VirtioNetError::IncompatibleFeatureSets(driver_features, device_features) => write!(f, "Feature set: {driver_features:?} , is incompatible with the device features: {device_features:?}"),
@@ -64,12 +70,6 @@ pub mod error {
 				VirtioError::FsDriver(fs_error) => match fs_error {
 					#[cfg(feature = "pci")]
 					VirtioFsError::NoDevCfg(id) => write!(f, "Virtio filesystem driver failed, for device {id:x}, due to a missing or malformed device config!"),
-					#[cfg(feature = "pci")]
-					VirtioFsError::NoComCfg(id) =>  write!(f, "Virtio filesystem driver failed, for device {id:x}, due to a missing or malformed common config!"),
-					#[cfg(feature = "pci")]
-					VirtioFsError::NoIsrCfg(id) =>  write!(f, "Virtio filesystem driver failed, for device {id:x}, due to a missing or malformed ISR status config!"),
-					#[cfg(feature = "pci")]
-                    VirtioFsError::NoNotifCfg(id) =>  write!(f, "Virtio filesystem driver failed, for device {id:x}, due to a missing or malformed notification config!"),
 					VirtioFsError::FailFeatureNeg(id) => write!(f, "Virtio filesystem driver failed, for device {id:x}, device did not acknowledge negotiated feature set!"),
                     VirtioFsError::FeatureRequirementsNotMet(features) => write!(f, "Virtio filesystem driver tried to set feature bit without setting dependency feature. Feat set: {features:?}"),
 					VirtioFsError::IncompatibleFeatureSets(driver_features, device_features) => write!(f, "Feature set: {driver_features:?} , is incompatible with the device features: {device_features:?}", ),

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -174,103 +174,12 @@ impl PciCap {
 /// [PciCap] objects, to allow the driver to map its
 /// device specific configurations independently.
 pub struct UniCapsColl {
-	com_cfg_list: Vec<ComCfg>,
-	notif_cfg_list: Vec<NotifCfg>,
-	isr_stat_list: Vec<IsrStatus>,
-	sh_mem_cfg_list: Vec<ShMemCfg>,
-	dev_cfg_list: Vec<PciCap>,
+	pub(crate) com_cfg: ComCfg,
+	pub(crate) notif_cfg: NotifCfg,
+	pub(crate) isr_cfg: IsrStatus,
+	pub(crate) sh_mem_cfg_list: Vec<ShMemCfg>,
+	pub(crate) dev_cfg_list: Vec<PciCap>,
 }
-
-impl UniCapsColl {
-	/// Returns an Caps with empty lists.
-	fn new() -> Self {
-		UniCapsColl {
-			com_cfg_list: Vec::new(),
-			notif_cfg_list: Vec::new(),
-			isr_stat_list: Vec::new(),
-			sh_mem_cfg_list: Vec::new(),
-			dev_cfg_list: Vec::new(),
-		}
-	}
-
-	fn add_cfg_common(&mut self, com: ComCfg) {
-		self.com_cfg_list.push(com);
-		// Resort array
-		//
-		// This should not be to expensive, as "rational" devices will hold an
-		// acceptibal amount of configuration structures.
-		self.com_cfg_list.sort_by(|a, b| b.rank.cmp(&a.rank));
-	}
-
-	fn add_cfg_notif(&mut self, notif: NotifCfg) {
-		self.notif_cfg_list.push(notif);
-		// Resort array
-		//
-		// This should not be to expensive, as "rational" devices will hold an
-		// acceptable amount of configuration structures.
-		self.notif_cfg_list.sort_by(|a, b| b.rank.cmp(&a.rank));
-	}
-
-	fn add_cfg_isr(&mut self, isr_stat: IsrStatus) {
-		self.isr_stat_list.push(isr_stat);
-		// Resort array
-		//
-		// This should not be to expensive, as "rational" devices will hold an
-		// acceptable amount of configuration structures.
-		self.isr_stat_list.sort_by(|a, b| b.rank.cmp(&a.rank));
-	}
-
-	fn add_cfg_sh_mem(&mut self, sh_mem: ShMemCfg) {
-		self.sh_mem_cfg_list.push(sh_mem);
-		// Resort array
-		//
-		// This should not be to expensive, as "rational" devices will hold an
-		// acceptable amount of configuration structures.
-		self.sh_mem_cfg_list.sort_by(|a, b| b.id.cmp(&a.id));
-	}
-
-	fn add_cfg_dev(&mut self, pci_cap: PciCap) {
-		self.dev_cfg_list.push(pci_cap);
-		// Resort array
-		//
-		// This should not be to expensive, as "rational" devices will hold an
-		// acceptable amount of configuration structures.
-		self.dev_cfg_list.sort_by(|a, b| b.cap.id.cmp(&a.cap.id));
-	}
-}
-
-// Public interface of UniCapsCollection
-impl UniCapsColl {
-	/// Returns the highest prioritized PciCap that indiactes a
-	/// Virito device configuration.
-	///
-	/// INFO: This function removes the capability and returns ownership.
-	pub fn get_dev_cfg(&mut self) -> Option<PciCap> {
-		self.dev_cfg_list.pop()
-	}
-
-	/// Returns the highest prioritized common configuration structure.
-	///
-	/// INFO: This function removes the capability and returns ownership.
-	pub fn get_com_cfg(&mut self) -> Option<ComCfg> {
-		self.com_cfg_list.pop()
-	}
-
-	/// Returns the highest prioritized ISR status configuration structure.
-	///
-	/// INFO: This function removes the Capability and returns ownership.
-	pub fn get_isr_cfg(&mut self) -> Option<IsrStatus> {
-		self.isr_stat_list.pop()
-	}
-
-	/// Returns the highest prioritized notification structure.
-	///
-	/// INFO: This function removes the Capability and returns ownership.
-	pub fn get_notif_cfg(&mut self) -> Option<NotifCfg> {
-		self.notif_cfg_list.pop()
-	}
-}
-
 /// Wraps a [`CommonCfg`] in order to preserve
 /// the original structure.
 ///
@@ -800,72 +709,65 @@ fn map_bars(device: &PciDevice<PciConfigRegion>) -> Result<Vec<PciBar>, PciError
 	crate::drivers::virtio::env::pci::map_bar_mem(device)
 }
 
-/// Checks if minimal set of capabilities is present.
-///
-/// INFO: Currently only checks if at least one common config struct has been found and mapped.
-fn check_caps(caps: UniCapsColl) -> Result<UniCapsColl, PciError> {
-	if caps.com_cfg_list.is_empty() {
-		error!("Device with unknown id, does not have a common config structure!");
-		return Err(PciError::General(0));
-	}
-
-	Ok(caps)
-}
-
-pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsColl, PciError> {
+pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsColl, VirtioError> {
 	let device_id = device.device_id();
 
 	// In case caplist pointer is not used, abort as it is essential
 	if !device.status().has_capability_list() {
 		error!("Found virtio device without capability list. Aborting!");
-		return Err(PciError::NoCapPtr(device_id));
+		return Err(VirtioError::FromPci(PciError::NoCapPtr(device_id)));
 	}
 
 	// Mapped memory areas are reachable through PciBar structs.
 	let bar_list = match map_bars(device) {
 		Ok(list) => list,
-		Err(pci_error) => return Err(pci_error),
+		Err(pci_error) => return Err(VirtioError::FromPci(pci_error)),
 	};
 
 	// Get list of PciCaps pointing to capabilities
 	let cap_list = match read_caps(device, &bar_list) {
 		Ok(list) => list,
-		Err(pci_error) => return Err(pci_error),
+		Err(pci_error) => return Err(VirtioError::FromPci(pci_error)),
 	};
 
-	let mut caps = UniCapsColl::new();
+	let mut com_cfg = None;
+	let mut notif_cfg = None;
+	let mut isr_cfg = None;
+	let mut sh_mem_cfg_list = Vec::new();
+	let mut dev_cfg_list = Vec::new();
 	// Map Caps in virtual memory
 	for pci_cap in cap_list {
 		match pci_cap.cap.cfg_type {
-			CapCfgType::Common => match pci_cap.map_common_cfg() {
-				Some(cap) => caps.add_cfg_common(ComCfg::new(cap, pci_cap.cap.id)),
-				None => error!(
-					"Common config capability with id {}, of device {:x}, could not be mapped!",
-					pci_cap.cap.id, device_id
-				),
-			},
-			CapCfgType::Notify => match NotifCfg::new(&pci_cap) {
-				Some(notif) => caps.add_cfg_notif(notif),
-				None => error!(
-					"Notification config capability with id {}, of device {:x} could not be used!",
-					pci_cap.cap.id, device_id
-				),
-			},
-			CapCfgType::Isr => match pci_cap.map_isr_status() {
-				Some(isr_stat) => caps.add_cfg_isr(IsrStatus::new(isr_stat, pci_cap.cap.id)),
-				None => error!(
-					"ISR status config capability with id {}, of device {:x} could not be used!",
-					pci_cap.cap.id, device_id
-				),
-			},
+			CapCfgType::Common => {
+				if com_cfg.is_none() {
+					match pci_cap.map_common_cfg() {
+						Some(cap) => com_cfg = Some(ComCfg::new(cap, pci_cap.cap.id)),
+						None => error!("Common config capability with id {}, of device {:x}, could not be mapped!", pci_cap.cap.id, device_id),
+					}
+				}
+			}
+			CapCfgType::Notify => {
+				if notif_cfg.is_none() {
+					match NotifCfg::new(&pci_cap) {
+						Some(notif) => notif_cfg = Some(notif),
+						None => error!("Notification config capability with id {}, of device {device_id:x} could not be used!", pci_cap.cap.id),
+					}
+				}
+			}
+			CapCfgType::Isr => {
+				if isr_cfg.is_none() {
+					match pci_cap.map_isr_status() {
+						Some(isr_stat) => isr_cfg = Some(IsrStatus::new(isr_stat, pci_cap.cap.id)),
+						None => error!("ISR status config capability with id {}, of device {device_id:x} could not be used!", pci_cap.cap.id),
+					}
+				}
+			}
 			CapCfgType::SharedMemory => match ShMemCfg::new(&pci_cap) {
-				Some(sh_mem) => caps.add_cfg_sh_mem(sh_mem),
-				None => error!(
-					"Shared Memory config capability with id {}, of device {:x} could not be used!",
-					pci_cap.cap.id, device_id
+				Some(sh_mem) => sh_mem_cfg_list.push(sh_mem),
+				None => error!("Shared Memory config capability with id {}, of device {device_id:x} could not be used!", pci_cap.cap.id, 
 				),
 			},
-			CapCfgType::Device => caps.add_cfg_dev(pci_cap),
+			CapCfgType::Device => dev_cfg_list.push(pci_cap),
 
 			// PCI's configuration space is allowed to hold other structures, which are not virtio specific and are therefore ignored
 			// in the following
@@ -873,7 +775,13 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 		}
 	}
 
-	check_caps(caps)
+	Ok(UniCapsColl {
+		com_cfg: com_cfg.ok_or(VirtioError::NoComCfg(device_id))?,
+		notif_cfg: notif_cfg.ok_or(VirtioError::NoNotifCfg(device_id))?,
+		isr_cfg: isr_cfg.ok_or(VirtioError::NoIsrCfg(device_id))?,
+		sh_mem_cfg_list,
+		dev_cfg_list,
+	})
 }
 
 /// Checks existing drivers for support of given device. Upon match, provides


### PR DESCRIPTION
According to the section 4.1.4 of the VIRTIO specification v1.2, "[t]he order of the capabilities in the capability list specifies the order of preference suggested by the device." Accordingly, store only the most preferred capability of a type in the `UniCapsCollection` structure when only one is necessary.

This also allows the corresponding fields to be changed from vectors to singles (when appropriate) and the existence of the mandatory capabilities to be checked early on.