### PR TITLE
fix: `static_mut_refs`

### DIFF
--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -202,7 +202,8 @@ fn detect_interrupt(
 			if irq_type == 0 {
 				// enable interrupt
 				let irq_id = IntId::spi(irq_number);
-				let gic = unsafe { GIC.get_mut().unwrap() };
+				let mut gic = GIC.lock();
+				let gic = gic.as_mut().unwrap();
 				gic.set_interrupt_priority(irq_id, 0x10);
 				if irq_flags == 4 {
 					gic.set_trigger(irq_id, Trigger::Level);

--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -339,9 +339,7 @@ pub fn init() {
 								dev.set_irq(pin, line);
 							}
 
-							unsafe {
-								PCI_DEVICES.push(dev);
-							}
+							PCI_DEVICES.with(|pci_devices| pci_devices.unwrap().push(dev));
 						}
 					}
 				}

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -151,11 +151,8 @@ fn finish_processor_init() {
 	unsafe {
 		// Add hart to HARTS_AVAILABLE, the hart id is stored in current_boot_id
 		HARTS_AVAILABLE.push(current_hart_id);
-		info!(
-			"Initialized CPU with hart_id {}",
-			HARTS_AVAILABLE[core_local::core_id() as usize]
-		);
 	}
+	info!("Initialized CPU with hart_id {current_hart_id}");
 
 	crate::scheduler::add_current_core();
 

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -24,10 +24,11 @@ use crate::arch::riscv64::kernel::processor::lsb;
 use crate::arch::riscv64::mm::{physicalmem, PhysAddr, VirtAddr};
 use crate::config::KERNEL_STACK_SIZE;
 use crate::env;
+use crate::init_cell::InitCell;
 
 // Used to store information about available harts. The index of the hart in the vector
 // represents its CpuId and does not need to match its hart_id
-pub(crate) static mut HARTS_AVAILABLE: Vec<usize> = Vec::new();
+pub(crate) static HARTS_AVAILABLE: InitCell<Vec<usize>> = InitCell::new(Vec::new());
 
 /// Kernel header to announce machine features
 static CPU_ONLINE: AtomicU32 = AtomicU32::new(0);
@@ -148,10 +149,8 @@ fn finish_processor_init() {
 
 	let current_hart_id = get_current_boot_id() as usize;
 
-	unsafe {
-		// Add hart to HARTS_AVAILABLE, the hart id is stored in current_boot_id
-		HARTS_AVAILABLE.push(current_hart_id);
-	}
+	// Add hart to HARTS_AVAILABLE, the hart id is stored in current_boot_id
+	HARTS_AVAILABLE.with(|harts_available| harts_available.unwrap().push(current_hart_id));
 	info!("Initialized CPU with hart_id {current_hart_id}");
 
 	crate::scheduler::add_current_core();

--- a/src/arch/riscv64/kernel/processor.rs
+++ b/src/arch/riscv64/kernel/processor.rs
@@ -282,7 +282,7 @@ pub fn set_oneshot_timer(wakeup_time: Option<u64>) {
 }
 
 pub fn wakeup_core(core_to_wakeup: CoreId) {
-	let hart_id = unsafe { HARTS_AVAILABLE[core_to_wakeup as usize] };
+	let hart_id = HARTS_AVAILABLE.finalize()[core_to_wakeup as usize];
 	debug!("Wakeup core: {} , hart_id: {}", core_to_wakeup, hart_id);
 	sbi_rt::send_ipi(sbi_rt::HartMask::from_mask_base(0b1, hart_id));
 }

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -62,9 +62,8 @@ pub(crate) fn init() {
 
 			let (device_id, vendor_id) = header.id(pci_config);
 			if device_id != u16::MAX && vendor_id != u16::MAX {
-				unsafe {
-					PCI_DEVICES.push(PciDevice::new(pci_address, pci_config));
-				}
+				let device = PciDevice::new(pci_address, pci_config);
+				PCI_DEVICES.with(|pci_devices| pci_devices.unwrap().push(device));
 			}
 		}
 	}

--- a/src/drivers/fs/virtio_fs.rs
+++ b/src/drivers/fs/virtio_fs.rs
@@ -154,7 +154,11 @@ impl FuseInterface for VirtioFsDriver {
 		&mut self,
 		cmd: fuse::Cmd<O>,
 		rsp_payload_len: u32,
-	) -> Result<fuse::Rsp<O>, VirtqError> {
+	) -> Result<fuse::Rsp<O>, VirtqError>
+	where
+		<O as fuse::ops::Op>::InStruct: Send,
+		<O as fuse::ops::Op>::OutStruct: Send,
+	{
 		let fuse::Cmd {
 			headers: cmd_headers,
 			payload: cmd_payload_opt,

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -221,6 +221,9 @@ pub struct GEMDriver {
 	txbuffer_list: VirtAddr,
 }
 
+// FIXME: make `gem` implement `Send` instead
+unsafe impl Send for GEMDriver {}
+
 impl NetworkDriver for GEMDriver {
 	/// Returns the MAC address of the network interface
 	fn get_mac_address(&self) -> [u8; 6] {

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -45,7 +45,7 @@ use crate::init_cell::InitCell;
 
 pub(crate) static PCI_DEVICES: InitCell<Vec<PciDevice<PciConfigRegion>>> =
 	InitCell::new(Vec::new());
-static mut PCI_DRIVERS: Vec<PciDriver> = Vec::new();
+static PCI_DRIVERS: InitCell<Vec<PciDriver>> = InitCell::new(Vec::new());
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct PciDevice<T: ConfigRegionAccess> {
@@ -413,9 +413,7 @@ impl PciDriver {
 }
 
 pub(crate) fn register_driver(drv: PciDriver) {
-	unsafe {
-		PCI_DRIVERS.push(drv);
-	}
+	PCI_DRIVERS.with(|pci_drivers| pci_drivers.unwrap().push(drv));
 }
 
 pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandlerQueue, RandomState>
@@ -423,7 +421,7 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 	let mut handlers: HashMap<InterruptLine, InterruptHandlerQueue, RandomState> =
 		HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0));
 
-	for drv in unsafe { PCI_DRIVERS.iter() } {
+	for drv in PCI_DRIVERS.finalize().iter() {
 		let (irq_number, handler) = drv.get_interrupt_handler();
 
 		if let Some(map) = handlers.get_mut(&irq_number) {
@@ -440,26 +438,34 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 
 #[cfg(all(not(feature = "rtl8139"), any(feature = "tcp", feature = "udp")))]
 pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
-	unsafe { PCI_DRIVERS.iter().find_map(|drv| drv.get_network_driver()) }
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_network_driver())
 }
 
 #[cfg(all(feature = "rtl8139", any(feature = "tcp", feature = "udp")))]
 pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<RTL8139Driver>> {
-	unsafe { PCI_DRIVERS.iter().find_map(|drv| drv.get_network_driver()) }
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_network_driver())
 }
 
 #[cfg(feature = "vsock")]
 pub(crate) fn get_vsock_driver() -> Option<&'static InterruptTicketMutex<VirtioVsockDriver>> {
-	unsafe { PCI_DRIVERS.iter().find_map(|drv| drv.get_vsock_driver()) }
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_vsock_driver())
 }
 
 #[cfg(feature = "fuse")]
 pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<VirtioFsDriver>> {
-	unsafe {
-		PCI_DRIVERS
-			.iter()
-			.find_map(|drv| drv.get_filesystem_driver())
-	}
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_filesystem_driver())
 }
 
 pub(crate) fn init() {

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -266,6 +266,9 @@ pub struct NotifCfg {
 	queue_notify: *mut le32,
 }
 
+// FIXME: make `queue_notify` implement `Send` instead
+unsafe impl Send for NotifCfg {}
+
 impl NotifCfg {
 	pub fn new(mut registers: VolatileRef<'_, DeviceRegisters>) -> Self {
 		let raw = registers.as_mut_ptr().queue_notify().as_raw_ptr().as_ptr();
@@ -286,6 +289,9 @@ pub struct NotifCtrl {
 	/// Where to write notification
 	notif_addr: *mut le32,
 }
+
+// FIXME: make `notif_addr` implement `Send` instead
+unsafe impl Send for NotifCtrl {}
 
 impl NotifCtrl {
 	/// Returns a new controller. By default MSI-X capabilities and VIRTIO_F_NOTIFICATION_DATA

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -472,6 +472,9 @@ pub struct NotifCtrl {
 	notif_addr: *mut le32,
 }
 
+// FIXME: make `notif_addr` implement `Send` instead
+unsafe impl Send for NotifCtrl {}
+
 impl NotifCtrl {
 	/// Returns a new controller. By default MSI-X capabilities and VIRTIO_F_NOTIFICATION_DATA
 	/// are disabled.

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -96,7 +96,7 @@ impl From<VqSize> for u16 {
 /// might not provide the complete feature set of each queue. Drivers who
 /// do need these features should refrain from providing support for both
 /// Virtqueue types and use the structs directly instead.
-pub trait Virtq {
+pub trait Virtq: Send {
 	/// The `notif` parameter indicates if the driver wants to have a notification for this specific
 	/// transfer. This is only for performance optimization. As it is NOT ensured, that the device sees the
 	/// updated notification flags before finishing transfers!
@@ -344,7 +344,7 @@ impl<Descriptor> TransferToken<Descriptor> {
 
 #[derive(Debug)]
 pub enum BufferElem {
-	Sized(Box<dyn Any, DeviceAlloc>),
+	Sized(Box<dyn Any + Send, DeviceAlloc>),
 	Vector(Vec<u8, DeviceAlloc>),
 }
 

--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -47,7 +47,10 @@ pub(crate) trait FuseInterface {
 		&mut self,
 		cmd: Cmd<O>,
 		rsp_payload_len: u32,
-	) -> Result<Rsp<O>, VirtqError>;
+	) -> Result<Rsp<O>, VirtqError>
+	where
+		<O as ops::Op>::InStruct: Send,
+		<O as ops::Op>::OutStruct: Send;
 
 	fn get_mount_point(&self) -> String;
 }

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -2,6 +2,7 @@
 	all(
 		not(feature = "pci"),
 		not(all(target_arch = "x86_64", feature = "tcp")),
+		not(all(target_arch = "riscv64", feature = "tcp")),
 	),
 	expect(dead_code)
 )]

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -1,4 +1,10 @@
-#![cfg_attr(not(feature = "pci"), expect(dead_code))]
+#![cfg_attr(
+	all(
+		not(feature = "pci"),
+		not(all(target_arch = "x86_64", feature = "tcp")),
+	),
+	expect(dead_code)
+)]
 
 use hermit_sync::{OnceCell, SpinMutex};
 

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -1,0 +1,29 @@
+#![cfg_attr(any(not(feature = "pci"), target_arch = "riscv64"), expect(dead_code))]
+
+use hermit_sync::{OnceCell, SpinMutex};
+
+/// A cell for iteratively initializing a `OnceCell`.
+///
+/// This should be used as a stop-gap measure only.
+pub struct InitCell<T> {
+	init: SpinMutex<Option<T>>,
+	once: OnceCell<T>,
+}
+
+impl<T> InitCell<T> {
+	pub const fn new(val: T) -> Self {
+		Self {
+			init: SpinMutex::new(Some(val)),
+			once: OnceCell::new(),
+		}
+	}
+
+	pub fn with(&self, f: impl FnOnce(Option<&mut T>)) {
+		let mut guard = self.init.lock();
+		f((*guard).as_mut())
+	}
+
+	pub fn finalize(&self) -> &T {
+		self.once.get_or_init(|| self.init.lock().take().unwrap())
+	}
+}

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(any(not(feature = "pci"), target_arch = "riscv64"), expect(dead_code))]
+#![cfg_attr(not(feature = "pci"), expect(dead_code))]
 
 use hermit_sync::{OnceCell, SpinMutex};
 
@@ -21,6 +21,11 @@ impl<T> InitCell<T> {
 	pub fn with(&self, f: impl FnOnce(Option<&mut T>)) {
 		let mut guard = self.init.lock();
 		f((*guard).as_mut())
+	}
+
+	#[cfg_attr(all(feature = "pci", not(feature = "tcp")), expect(dead_code))]
+	pub fn get(&self) -> Option<&T> {
+		self.once.get()
 	}
 
 	pub fn finalize(&self) -> &T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub mod errno;
 mod executor;
 pub mod fd;
 pub mod fs;
+mod init_cell;
 pub mod io;
 mod mm;
 pub mod scheduler;


### PR DESCRIPTION
This resolves the `static_mut_refs` lint by putting offending `static mut`s into cells or mutexes.