### PR TITLE
zeroed stack during the initialization

### DIFF
--- a/src/arch/aarch64/kernel/scheduler.rs
+++ b/src/arch/aarch64/kernel/scheduler.rs
@@ -161,7 +161,7 @@ impl TaskStacks {
 		unsafe {
 			ptr::write_bytes(
 				(virt_addr + DEFAULT_STACK_SIZE + 2 * BasePageSize::SIZE).as_mut_ptr::<u8>(),
-				0xAC,
+				0,
 				user_stack_size,
 			);
 		}
@@ -360,8 +360,6 @@ impl TaskFrame for Task {
 			stack -= mem::size_of::<State>();
 
 			let state = stack.as_mut_ptr::<State>();
-			ptr::write_bytes(stack.as_mut_ptr::<u8>(), 0, mem::size_of::<State>());
-
 			if let Some(tls) = &self.tls {
 				(*state).tpidr_el0 = tls.thread_ptr() as u64;
 			}

--- a/src/arch/riscv64/kernel/scheduler.rs
+++ b/src/arch/riscv64/kernel/scheduler.rs
@@ -161,7 +161,7 @@ impl TaskStacks {
 				(virt_addr + KERNEL_STACK_SIZE + DEFAULT_STACK_SIZE + 3 * BasePageSize::SIZE)
 					//(virt_addr + KERNEL_STACK_SIZE + DEFAULT_STACK_SIZE)
 					.as_mut_ptr::<u8>(),
-				0xAC,
+				0,
 				user_stack_size,
 			);
 		}
@@ -391,8 +391,6 @@ impl TaskFrame for Task {
 			stack -= mem::size_of::<State>();
 
 			let state = stack.as_mut_ptr::<State>();
-			ptr::write_bytes(stack.as_mut_ptr::<u8>(), 0, mem::size_of::<State>());
-
 			if let Some(tls) = &self.tls {
 				(*state).tp = tls.tp().as_usize();
 			}

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -147,7 +147,7 @@ impl TaskStacks {
 			ptr::write_bytes(
 				(virt_addr + IST_SIZE + DEFAULT_STACK_SIZE + 3 * BasePageSize::SIZE)
 					.as_mut_ptr::<u8>(),
-				0xAC,
+				0,
 				user_stack_size,
 			);
 		}
@@ -358,8 +358,6 @@ impl TaskFrame for Task {
 			stack -= mem::size_of::<State>();
 
 			let state = stack.as_mut_ptr::<State>();
-			ptr::write_bytes(stack.as_mut_ptr::<u8>(), 0, mem::size_of::<State>());
-
 			#[cfg(not(feature = "common-os"))]
 			if let Some(tls) = &self.tls {
 				(*state).fs = tls.thread_ptr().addr() as u64;


### PR DESCRIPTION
- the stack initialization with dummy values isn't longer necessary
- initialization with 0 reduce the number of "memset" calls