### PR TITLE
fix(x86_64): use unaligned write for TLS pointer

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -293,7 +293,7 @@ impl TaskTLS {
 		// thread_ptr = block_ptr + tls_offset
 		let thread_ptr = block[tls_offset..].as_mut_ptr().cast::<()>();
 		unsafe {
-			thread_ptr.cast::<*mut ()>().write(thread_ptr);
+			thread_ptr.cast::<*mut ()>().write_unaligned(thread_ptr);
 		}
 
 		let this = Self {


### PR DESCRIPTION
TLS alignment may be 4 and require an unaligned write. This was found with hermit-c and cargo-careful.