### PR TITLE
fix(apic): fix width of MP config table entry type

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -422,7 +422,7 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 		// entries starts directly after the config table
 		addr += mem::size_of::<ApicConfigTable>();
 		for _i in 0..mp_config.entry_count {
-			match unsafe { *(ptr::with_exposed_provenance(addr)) } {
+			match unsafe { *(ptr::with_exposed_provenance::<u8>(addr)) } {
 				// CPU entry
 				0 => {
 					let cpu_entry: &ApicProcessorEntry =


### PR DESCRIPTION
This was `i32` implicitly, which is wrong and fails on firecracker.