### PR TITLE
Uhyve: Speed up serial output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "free-list",
  "fuse-abi",
  "hashbrown",
+ "heapless",
  "hermit-dtb",
  "hermit-entry",
  "hermit-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ fdt = { version = "0.1", features = ["pretty-printing"] }
 free-list = "0.3"
 fuse-abi = { version = "0.2", features = ["linux", "zerocopy"], optional = true }
 hashbrown = { version = "0.15", default-features = false }
+heapless = "0.8"
 hermit-entry = { version = "0.10", features = ["kernel"] }
 hermit-sync = "0.1"
 lock_api = "0.4"

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -49,9 +49,7 @@ impl Console {
 	}
 
 	pub fn write(&mut self, buf: &[u8]) {
-		for byte in buf {
-			self.serial_port.write_byte(*byte);
-		}
+		self.serial_port.write_buf(buf);
 	}
 
 	pub fn read(&mut self) -> Option<u8> {

--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -1,36 +1,59 @@
 use core::arch::asm;
 
+use crate::syscalls::interfaces::serial_buf_hypercall;
+
+enum SerialInner {
+	Uart(u32),
+	Uhyve,
+}
+
 pub struct SerialPort {
-	pub port_address: u32,
+	inner: SerialInner,
 }
 
 impl SerialPort {
-	pub const fn new(port_address: u32) -> Self {
-		Self { port_address }
-	}
-
-	pub fn write_byte(&self, byte: u8) {
-		let port = core::ptr::with_exposed_provenance_mut::<u8>(self.port_address as usize);
-
-		// LF newline characters need to be extended to CRLF over a real serial port.
-		if byte == b'\n' {
-			unsafe {
-				asm!(
-					"strb w8, [{port}]",
-					port = in(reg) port,
-					in("x8") b'\r',
-					options(nostack),
-				);
+	pub fn new(port_address: u32) -> Self {
+		if crate::env::is_uhyve() {
+			Self {
+				inner: SerialInner::Uhyve,
+			}
+		} else {
+			Self {
+				inner: SerialInner::Uart(port_address),
 			}
 		}
+	}
 
-		unsafe {
-			asm!(
-				"strb w8, [{port}]",
-				port = in(reg) port,
-				in("x8") byte,
-				options(nostack),
-			);
+	pub fn write_buf(&mut self, buf: &[u8]) {
+		match &mut self.inner {
+			SerialInner::Uhyve => {
+				serial_buf_hypercall(buf);
+			}
+			SerialInner::Uart(port_address) => {
+				let port = core::ptr::with_exposed_provenance_mut::<u8>(*port_address as usize);
+				for &byte in buf {
+					// LF newline characters need to be extended to CRLF over a real serial port.
+					if byte == b'\n' {
+						unsafe {
+							asm!(
+								"strb w8, [{port}]",
+								port = in(reg) port,
+								in("x8") b'\r',
+								options(nostack),
+							);
+						}
+					}
+
+					unsafe {
+						asm!(
+							"strb w8, [{port}]",
+							port = in(reg) port,
+							in("x8") byte,
+							options(nostack),
+						);
+					}
+				}
+			}
 		}
 	}
 

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -1,23 +1,17 @@
 use alloc::collections::VecDeque;
 use core::task::Waker;
 
-use memory_addresses::VirtAddr;
-use uhyve_interface::Hypercall;
-use uhyve_interface::parameters::SerialWriteBufferParams;
-use x86_64::instructions::port::Port;
-
-use crate::arch::mm::paging::virtual_to_physical;
 use crate::arch::x86_64::kernel::apic;
 use crate::arch::x86_64::kernel::core_local::increment_irq_counter;
 use crate::arch::x86_64::kernel::interrupts::{self, IDT};
 use crate::executor::WakerRegistration;
-use crate::syscalls::interfaces::uhyve_hypercall;
+use crate::syscalls::interfaces::serial_buf_hypercall;
 
 const SERIAL_IRQ: u8 = 36;
 
 enum SerialInner {
 	Uart(uart_16550::SerialPort),
-	Uhyve(Port<u8>),
+	Uhyve,
 }
 
 pub struct SerialPort {
@@ -29,9 +23,8 @@ pub struct SerialPort {
 impl SerialPort {
 	pub unsafe fn new(base: u16) -> Self {
 		if crate::env::is_uhyve() {
-			let serial = Port::new(base);
 			Self {
-				inner: SerialInner::Uhyve(serial),
+				inner: SerialInner::Uhyve,
 				buffer: VecDeque::new(),
 				waker: WakerRegistration::new(),
 			}
@@ -72,14 +65,7 @@ impl SerialPort {
 
 	pub fn send(&mut self, buf: &[u8]) {
 		match &mut self.inner {
-			SerialInner::Uhyve(_s) => {
-				let p = SerialWriteBufferParams {
-					buf: virtual_to_physical(VirtAddr::from_ptr(core::ptr::from_ref::<[u8]>(buf)))
-						.unwrap(),
-					len: buf.len(),
-				};
-				uhyve_hypercall(Hypercall::SerialWriteBuffer(&p));
-			}
+			SerialInner::Uhyve => serial_buf_hypercall(buf),
 			SerialInner::Uart(s) => {
 				for &data in buf {
 					s.send(data);
@@ -90,7 +76,7 @@ impl SerialPort {
 }
 
 extern "x86-interrupt" fn serial_interrupt(_stack_frame: crate::interrupts::ExceptionStackFrame) {
-	crate::console::CONSOLE.lock().0.buffer_input();
+	crate::console::CONSOLE.lock().inner.buffer_input();
 	increment_irq_counter(SERIAL_IRQ);
 	crate::executor::run();
 

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -1,12 +1,23 @@
 use core::ptr;
 
 use memory_addresses::VirtAddr;
-use uhyve_interface::parameters::ExitParams;
+use uhyve_interface::parameters::{ExitParams, SerialWriteBufferParams};
 use uhyve_interface::{Hypercall, HypercallAddress};
 
 use crate::arch;
-use crate::arch::mm::paging;
+use crate::arch::mm::paging::{self, virtual_to_physical};
 use crate::syscalls::interfaces::SyscallInterface;
+
+/// perform a SerialWriteBuffer hypercall with `buf` as payload.
+#[inline]
+#[cfg_attr(target_arch = "riscv64", expect(dead_code))]
+pub(crate) fn serial_buf_hypercall(buf: &[u8]) {
+	let p = SerialWriteBufferParams {
+		buf: virtual_to_physical(VirtAddr::from_ptr(core::ptr::from_ref::<[u8]>(buf))).unwrap(),
+		len: buf.len(),
+	};
+	uhyve_hypercall(Hypercall::SerialWriteBuffer(&p));
+}
 
 /// calculates the physical address of the struct passed as reference.
 #[inline]


### PR DESCRIPTION
- Uhyve: Use the `SerialBufferWrite` hypercall instead of the `Uart` hypercall: This reduces the number of serial output related hypercalls by ~3x.

Attention:
- Depends on https://github.com/hermit-os/kernel/pull/1393
- Depends on a new Uhyve release that has support for this hypercall (v0.4.0)