### PR TITLE
build(vscode): don't check all architectures

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,8 @@
         "-Zbuild-std=core,alloc",
         "--quiet",
         "--message-format=json",
-        "--target=aarch64-unknown-none-softfloat",
-        "--target=riscv64gc-unknown-none-elf",
+        // "--target=aarch64-unknown-none-softfloat",
+        // "--target=riscv64gc-unknown-none-elf",
         "--target=x86_64-unknown-none",
     ],
     "rust-analyzer.check.targets": [


### PR DESCRIPTION
This is required because of https://github.com/hermit-os/kernel/pull/1442.

See also https://github.com/hermit-os/kernel/pull/1451.

CC: @jounathaen 