### PR TITLE
perf: make network buffers a power of two

### DIFF
--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -195,7 +195,7 @@ impl Device for HermitNet {
 	fn capabilities(&self) -> DeviceCapabilities {
 		let mut cap = DeviceCapabilities::default();
 		cap.max_transmission_unit = self.mtu.into();
-		cap.max_burst_size = Some(0xffff / cap.max_transmission_unit);
+		cap.max_burst_size = Some(0x10000 / cap.max_transmission_unit);
 		cap.checksum = self.checksums.clone();
 		cap
 	}

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -243,9 +243,9 @@ impl<'a> NetworkInterface<'a> {
 	#[cfg(feature = "udp")]
 	pub(crate) fn create_udp_handle(&mut self) -> Result<Handle, ()> {
 		let udp_rx_buffer =
-			udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY; 4], vec![0; 0xffff]);
+			udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY; 4], vec![0; 0x10000]);
 		let udp_tx_buffer =
-			udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY; 4], vec![0; 0xffff]);
+			udp::PacketBuffer::new(vec![udp::PacketMetadata::EMPTY; 4], vec![0; 0x10000]);
 		let udp_socket = udp::Socket::new(udp_rx_buffer, udp_tx_buffer);
 		let udp_handle = self.sockets.add(udp_socket);
 
@@ -254,8 +254,8 @@ impl<'a> NetworkInterface<'a> {
 
 	#[cfg(feature = "tcp")]
 	pub(crate) fn create_tcp_handle(&mut self) -> Result<Handle, ()> {
-		let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 0xffff]);
-		let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 0xffff]);
+		let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 0x10000]);
+		let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 0x10000]);
 		let mut tcp_socket = tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer);
 		tcp_socket.set_nagle_enabled(true);
 		let tcp_handle = self.sockets.add(tcp_socket);


### PR DESCRIPTION
I am not sure on this but rounding up to the next power of two seems sensible to me.

In their [server example](https://github.com/smoltcp-rs/smoltcp/blob/v0.12.0/examples/server.rs), smoltcp uses `0xffff`, but in the [benchmark](https://github.com/smoltcp-rs/smoltcp/blob/v0.12.0/examples/loopback_benchmark.rs) they use `0x10000`.

`0x10000` also aligns with the maximum for the `fragmentation_buffer_size` and `reassembly_buffer_size` configuration options.