### PR TITLE
uhyve: don't panic on initial unmap if page is not mapped

### DIFF
--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -387,8 +387,11 @@ pub fn init_page_tables() {
 
 		let mut page_table = unsafe { recursive_page_table() };
 		for page in page_range {
-			let (_frame, flush) = page_table.unmap(page).unwrap();
-			flush.ignore();
+			match page_table.unmap(page) {
+				Ok((_frame, flush)) => flush.ignore(),
+				Err(UnmapError::PageNotMapped) => {} // If it wasn't mapped, that's not an issue
+				Err(e) => panic!("Couldn't unmap page {page:?}: {e:?}"),
+			}
 		}
 
 		tlb::flush_all();


### PR DESCRIPTION
I'm reworking the initial page mapping of uhyve to resolve https://github.com/hermit-os/uhyve/issues/426, but the kernel currently expects the first GiB to be mapped and panics otherwise. 
In a transition phase, it makes sense to at least not panic if the page is not mapped.