### PR TITLE
ci: remove caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   check:
     name: Check
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +33,7 @@ jobs:
 
   clippy:
     name: Clippy
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +43,7 @@ jobs:
 
   format:
     name: Format
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +53,7 @@ jobs:
 
   typos:
     name: Typos
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +61,7 @@ jobs:
 
   doc:
     name: Doc
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +70,7 @@ jobs:
 
   build:
     name: Build
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +82,7 @@ jobs:
 
   test:
     name: Test
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack
       - uses: mkroening/rust-toolchain-toml@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: rustup target add x86_64-unknown-none
       - name: Check each feature
         run: cargo hack check --package hermit-kernel --each-feature --skip gem-net --no-dev-deps --target x86_64-unknown-none
@@ -40,12 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mkroening/rust-toolchain-toml@main
       - run: rustup component add clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: |
-            .
-            hermit-builtins
       - run: cargo xtask clippy
 
   format:
@@ -70,9 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mkroening/rust-toolchain-toml@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo xtask doc
 
   build:
@@ -81,12 +69,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mkroening/rust-toolchain-toml@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: |
-            .
-            hermit-builtins
       - name: Build minimal kernel
         run: |
           cargo xtask build --arch x86_64 --no-default-features
@@ -102,12 +84,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install qemu-system-x86
       - uses: mkroening/rust-toolchain-toml@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: |
-            .
-            hermit-builtins
       - name: Unit tests
         run: cargo test --lib
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
         with:
           key: ${{ matrix.arch }}-${{ matrix.profile }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          lookup-only: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             .
             kernel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 
@@ -19,7 +16,6 @@ defaults:
 jobs:
   check:
     name: Check
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +29,6 @@ jobs:
 
   clippy:
     name: Clippy
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +38,6 @@ jobs:
 
   format:
     name: Format
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +47,6 @@ jobs:
 
   typos:
     name: Typos
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +54,6 @@ jobs:
 
   doc:
     name: Doc
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +62,6 @@ jobs:
 
   build:
     name: Build
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +73,6 @@ jobs:
 
   test:
     name: Test
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -157,15 +147,6 @@ jobs:
       - uses: mkroening/rust-toolchain-toml@main
         with:
           toolchain-file: 'kernel/rust-toolchain.toml'
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.arch }}-${{ matrix.profile }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          lookup-only: ${{ github.ref == 'refs/heads/main' }}
-          workspaces: |
-            .
-            kernel
-            kernel/hermit-builtins
       - name: Download loader
         run: gh release download --repo hermit-os/loader --pattern 'hermit-loader-${{ matrix.arch }}*'
       - name: Dowload OpenSBI


### PR DESCRIPTION
Removing caches actually speeds up our CI ([before](https://github.com/hermit-os/kernel/actions/runs/12271864154) vs. [after](https://github.com/hermit-os/kernel/actions/runs/12275289472)):

- Short jobs (`check`, `clippy`, `doc`, `build`, `test`) may be up to 30 seconds slower, but this was mostly variance in QEMU installs.
- For long jobs, the cache does not provide benefits. Due to testing many configurations in one job, things get recompiled anyway.
- We are recently seeing some out-of-disk-space errors. These will hopefully be mended by avoiding a non-clean cache.