### PR TITLE
fix(virtqueue): make `BufferElem::{len,capacity}` return `u32`

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -268,7 +268,7 @@ trait VirtqPrivate {
 						paging::virt_to_phys(VirtAddr::from_ptr(mem_descr.addr()))
 							.as_u64()
 							.into(),
-						u32::from(len).into(),
+						len.into(),
 						incomplete_flags | virtq::DescF::NEXT,
 					)
 				});
@@ -356,7 +356,7 @@ impl BufferElem {
 	// should be only relevant for read buffer elements, which should not be uninit.
 	// If the element belongs to a write buffer, it is likely that [Self::capacity]
 	// is more appropriate.
-	pub fn len(&self) -> u16 {
+	pub fn len(&self) -> u32 {
 		match self {
 			BufferElem::Sized(sized) => mem::size_of_val(sized.as_ref()),
 			BufferElem::Vector(vec) => vec.len(),
@@ -365,7 +365,7 @@ impl BufferElem {
 		.unwrap()
 	}
 
-	pub fn capacity(&self) -> u16 {
+	pub fn capacity(&self) -> u32 {
 		match self {
 			BufferElem::Sized(sized) => mem::size_of_val(sized.as_ref()),
 			BufferElem::Vector(vec) => vec.capacity(),


### PR DESCRIPTION
Closes https://github.com/hermit-os/kernel/issues/1514.

This was a `usize` before, which got cast to `u32` without checks, which was wrong: [`1749ab4`](https://github.com/hermit-os/kernel/commit/1749ab4e547662c49eacdcd1490b63706de35978#diff-7be7614ab7713c8f3be62447e6a579dbd78b3757c84cd38559566aee623b62d4L1446-L1450)
The fix for that restricted this to `u16`, though, which is too narrow.

`u32` should be correct, though: https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-430005