### PR TITLE
ci: don't run `security_audit` workflow on PRs

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,9 +1,5 @@
 name: Security audit
 on:
-  push:
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
See https://github.com/rustsec/audit-check/issues/34.