### PR TITLE
feat(fs): make `off_t` signed as required by POSIX

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -405,7 +405,7 @@ impl From<fuse_attr> for FileAttr {
 			st_uid: attr.uid,
 			st_gid: attr.gid,
 			st_rdev: attr.rdev.into(),
-			st_size: attr.size,
+			st_size: attr.size.try_into().unwrap(),
 			st_blksize: attr.blksize.into(),
 			st_blocks: attr.blocks.try_into().unwrap(),
 			st_atim: timespec {

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -296,7 +296,7 @@ impl RomFile {
 		let microseconds = arch::kernel::systemtime::now_micros();
 		let t = timespec::from_usec(microseconds as i64);
 		let attr = FileAttr {
-			st_size: data.len() as u64,
+			st_size: data.len().try_into().unwrap(),
 			st_mode: mode | AccessPermission::S_IFREG,
 			st_atim: t,
 			st_mtim: t,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -286,7 +286,7 @@ pub struct FileAttr {
 	/// device id
 	pub st_rdev: u64,
 	/// size in bytes
-	pub st_size: u64,
+	pub st_size: i64,
 	/// block size
 	pub st_blksize: i64,
 	/// size in blocks


### PR DESCRIPTION
> **blkcnt_t** and **off_t** shall be signed integer types.

[<sys/types.h>](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_types.h.html)