### PR TITLE
Use uninitialized buffers for `read` and `recvfrom`

### DIFF
--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -231,7 +231,7 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 
 	/// receive a message from a socket
 	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
-	async fn recvfrom(&self, _buffer: &mut [u8]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, _buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
 		Err(io::Error::ENOSYS)
 	}
 

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::future::{self, Future};
+use core::mem::MaybeUninit;
 use core::task::Poll::{Pending, Ready};
 use core::time::Duration;
 
@@ -152,7 +153,7 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 
 	/// `async_read` attempts to read `len` bytes from the object references
 	/// by the descriptor
-	async fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, _buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		Err(io::Error::ENOSYS)
 	}
 
@@ -264,7 +265,7 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	}
 }
 
-pub(crate) fn read(fd: FileDescriptor, buf: &mut [u8]) -> io::Result<usize> {
+pub(crate) fn read(fd: FileDescriptor, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 	let obj = get_object(fd)?;
 
 	if buf.is_empty() {

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use core::future;
+use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::Poll;
 
@@ -171,7 +172,7 @@ impl Socket {
 		.await
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				let state = socket.state();
@@ -187,7 +188,7 @@ impl Socket {
 								socket
 									.recv(|data| {
 										let len = core::cmp::min(buffer.len(), data.len());
-										buffer[..len].copy_from_slice(&data[..len]);
+										buffer[..len].write_copy_of_slice(&data[..len]);
 										(len, len)
 									})
 									.map_err(|_| io::Error::EIO),
@@ -468,7 +469,7 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 		self.read().await.poll(event).await
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		self.read().await.read(buffer).await
 	}
 

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use core::future;
+use core::mem::MaybeUninit;
 use core::task::Poll;
 
 use async_trait::async_trait;
@@ -261,7 +262,10 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 		self.read().await.recvfrom(buffer).await
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		// FIXME
+		let buffer =
+			unsafe { core::slice::from_raw_parts_mut(buffer.as_mut_ptr().cast(), buffer.len()) };
 		self.read().await.read(buffer).await
 	}
 

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -142,24 +142,23 @@ impl Socket {
 		}
 	}
 
-	async fn recvfrom(&self, buffer: &mut [u8]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_open() {
 					if socket.can_recv() {
-						match socket.recv_slice(buffer) {
-							Ok((len, meta)) => match self.endpoint {
-								Some(ep) => {
-									if meta.endpoint == ep {
-										Poll::Ready(Ok((len, meta.endpoint)))
-									} else {
-										buffer[..len].iter_mut().for_each(|x| *x = 0);
-										socket.register_recv_waker(cx.waker());
-										Poll::Pending
-									}
+						match socket.recv() {
+							// Drop the packet when the provided buffer cannot
+							// fit the payload.
+							Ok((data, meta)) if data.len() <= buffer.len() => {
+								if self.endpoint.is_none_or(|ep| meta.endpoint == ep) {
+									buffer[..data.len()].write_copy_of_slice(data);
+									Poll::Ready(Ok((data.len(), meta.endpoint)))
+								} else {
+									socket.register_recv_waker(cx.waker());
+									Poll::Pending
 								}
-								None => Poll::Ready(Ok((len, meta.endpoint))),
-							},
+							}
 							_ => Poll::Ready(Err(io::Error::EIO)),
 						}
 					} else {
@@ -175,24 +174,23 @@ impl Socket {
 		.map(|(len, endpoint)| (len, Endpoint::Ip(endpoint)))
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_open() {
 					if socket.can_recv() {
-						match socket.recv_slice(buffer) {
-							Ok((len, meta)) => match self.endpoint {
-								Some(ep) => {
-									if meta.endpoint == ep {
-										Poll::Ready(Ok(len))
-									} else {
-										buffer[..len].iter_mut().for_each(|x| *x = 0);
-										socket.register_recv_waker(cx.waker());
-										Poll::Pending
-									}
+						match socket.recv() {
+							// Drop the packet when the provided buffer cannot
+							// fit the payload.
+							Ok((data, meta)) if data.len() <= buffer.len() => {
+								if self.endpoint.is_none_or(|ep| meta.endpoint == ep) {
+									buffer[..data.len()].write_copy_of_slice(data);
+									Poll::Ready(Ok(data.len()))
+								} else {
+									socket.register_recv_waker(cx.waker());
+									Poll::Pending
 								}
-								None => Poll::Ready(Ok(len)),
-							},
+							}
 							_ => Poll::Ready(Err(io::Error::EIO)),
 						}
 					} else {
@@ -258,14 +256,11 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 		self.read().await.sendto(buffer, endpoint).await
 	}
 
-	async fn recvfrom(&self, buffer: &mut [u8]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
 		self.read().await.recvfrom(buffer).await
 	}
 
 	async fn read(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
-		// FIXME
-		let buffer =
-			unsafe { core::slice::from_raw_parts_mut(buffer.as_mut_ptr().cast(), buffer.len()) };
 		self.read().await.read(buffer).await
 	}
 

--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -4,6 +4,7 @@ use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::task::Poll;
 use core::{future, mem};
@@ -629,7 +630,7 @@ impl FuseFileHandleInner {
 		.await
 	}
 
-	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+	fn read(&mut self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		let mut len = buf.len();
 		if len > MAX_READ_LEN {
 			debug!("Reading longer than max_read_len: {}", len);
@@ -651,7 +652,7 @@ impl FuseFileHandleInner {
 				};
 			self.offset += len;
 
-			buf[..len].copy_from_slice(&rsp.payload.unwrap()[..len]);
+			buf[..len].write_copy_of_slice(&rsp.payload.unwrap()[..len]);
 
 			Ok(len)
 		} else {
@@ -767,7 +768,7 @@ impl ObjectInterface for FuseFileHandle {
 		self.0.lock().await.poll(event).await
 	}
 
-	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		self.0.lock().await.read(buf)
 	}
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -496,6 +496,7 @@ impl File {
 
 impl crate::io::Read for File {
 	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+		let buf = unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr().cast(), buf.len()) };
 		fd::read(self.fd, buf)
 	}
 }

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -4,6 +4,7 @@ use alloc::ffi::CString;
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -29,7 +30,7 @@ impl UhyveFileHandleInner {
 		Self(fd)
 	}
 
-	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+	fn read(&mut self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		let mut read_params = ReadParams {
 			fd: self.0,
 			buf: GuestVirtAddr::new(buf.as_mut_ptr() as u64),
@@ -94,7 +95,7 @@ impl UhyveFileHandle {
 
 #[async_trait]
 impl ObjectInterface for UhyveFileHandle {
-	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		self.0.lock().await.read(buf)
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(map_try_insert)]
 #![feature(maybe_uninit_as_bytes)]
 #![feature(maybe_uninit_slice)]
+#![feature(maybe_uninit_write_slice)]
 #![feature(naked_functions)]
 #![feature(never_type)]
 #![feature(slice_from_ptr_range)]

--- a/src/syscalls/socket.rs
+++ b/src/syscalls/socket.rs
@@ -884,7 +884,7 @@ pub extern "C" fn sys_shutdown_socket(fd: i32, how: i32) -> i32 {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_recv(fd: i32, buf: *mut u8, len: usize, flags: i32) -> isize {
 	if flags == 0 {
-		let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+		let slice = unsafe { core::slice::from_raw_parts_mut(buf.cast(), len) };
 		crate::fd::read(fd, slice).map_or_else(
 			|e| -num::ToPrimitive::to_isize(&e).unwrap(),
 			|v| v.try_into().unwrap(),

--- a/src/syscalls/socket.rs
+++ b/src/syscalls/socket.rs
@@ -962,7 +962,7 @@ pub unsafe extern "C" fn sys_recvfrom(
 	addr: *mut sockaddr,
 	addrlen: *mut socklen_t,
 ) -> isize {
-	let slice = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+	let slice = unsafe { core::slice::from_raw_parts_mut(buf.cast(), len) };
 	let obj = get_object(fd);
 	obj.map_or_else(
 		|e| -num::ToPrimitive::to_isize(&e).unwrap(),


### PR DESCRIPTION
Currently, when using an uninitialized buffer for `read` or `recvfrom`, as would be typical in C or required for `Read::read_buf`, it is casted from `*mut u8` at the FFI boundary in `sys_read`/`sys_readv`/`sys_recvfrom` to a `&[u8]`. I think this is unsound. Instead, use `&[MaybeUninit<u8>]` internally.

I use `&[u8]` instead of `core::io::BorrowedCursor<'_>`, because there are currently no cases where the initialized portion needs to be separately tracked.

Since `smoltcp::socket::tcp::Socket::recv_slice` takes a `&[u8]`, inline it and refactor. As a bonus, this avoids a copy and clear in the error case and it makes it more clear that packets are dropped when given an insufficiently large buffer.

This PR enables implementing `std::io::Read::read_buf` for `std::fs::File` and `std::io::Stdin` on Hermit. That effort is tracked in https://github.com/rust-lang/rust/issues/136756.