### PR TITLE
fix(drivers): initialize 64-bit RISC-V drivers before the executor

### DIFF
--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -128,5 +128,8 @@ pub(crate) fn init() {
 	))]
 	crate::arch::x86_64::kernel::mmio::init_drivers();
 
+	#[cfg(target_arch = "riscv64")]
+	crate::arch::riscv64::kernel::init_drivers();
+
 	crate::arch::interrupts::install_handlers();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,6 @@ extern "C" fn initd(_arg: usize) {
 	drivers::init();
 	crate::executor::init();
 
-	// Initialize MMIO Drivers if on riscv64
-	#[cfg(target_arch = "riscv64")]
-	riscv64::kernel::init_drivers();
-
 	syscalls::init();
 	fs::init();
 	#[cfg(all(feature = "shell", target_arch = "x86_64"))]


### PR DESCRIPTION
Issue found with @marcomaas1990.