### PR TITLE
feat(fd): implement `fcntl(F_GETFL)`

### DIFF
--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -47,12 +47,6 @@ pub(crate) enum SocketOption {
 	TcpNoDelay,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, PartialEq)]
-pub(crate) enum IoCtl {
-	NonBlocking,
-}
-
 pub(crate) type FileDescriptor = i32;
 
 bitflags! {
@@ -259,9 +253,8 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 		Err(io::Error::ENOSYS)
 	}
 
-	/// The `ioctl` function manipulates the underlying device parameters of special
-	/// files.
-	async fn ioctl(&self, _cmd: IoCtl, _value: bool) -> io::Result<()> {
+	/// Sets the file status flags.
+	async fn set_status_flags(&self, _status_flags: StatusFlags) -> io::Result<()> {
 		Err(io::Error::ENOSYS)
 	}
 

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -253,6 +253,11 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 		Err(io::Error::ENOSYS)
 	}
 
+	/// Returns the file status flags.
+	async fn status_flags(&self) -> io::Result<StatusFlags> {
+		Err(io::Error::ENOSYS)
+	}
+
 	/// Sets the file status flags.
 	async fn set_status_flags(&self, _status_flags: StatusFlags) -> io::Result<()> {
 		Err(io::Error::ENOSYS)

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -65,10 +65,17 @@ bitflags! {
 		const O_CREAT = 0o0100;
 		const O_EXCL = 0o0200;
 		const O_TRUNC = 0o1000;
-		const O_APPEND = 0o2000;
-		const O_NONBLOCK = 0o4000;
 		const O_DIRECT = 0o40000;
 		const O_DIRECTORY = 0o200_000;
+	}
+}
+
+bitflags! {
+	/// File status flags.
+	#[derive(Debug, Copy, Clone, Default)]
+	pub struct StatusFlags: i32 {
+		const O_APPEND = 0o2000;
+		const O_NONBLOCK = 0o4000;
 	}
 }
 

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -434,6 +434,16 @@ impl Socket {
 		}
 	}
 
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		let status_flags = if self.is_nonblocking {
+			fd::StatusFlags::O_NONBLOCK
+		} else {
+			fd::StatusFlags::empty()
+		};
+
+		Ok(status_flags)
+	}
+
 	async fn set_status_flags(&mut self, status_flags: fd::StatusFlags) -> io::Result<()> {
 		self.is_nonblocking = status_flags.contains(fd::StatusFlags::O_NONBLOCK);
 		Ok(())
@@ -500,6 +510,10 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 
 	async fn shutdown(&self, how: i32) -> io::Result<()> {
 		self.read().await.shutdown(how).await
+	}
+
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		self.read().await.status_flags().await
 	}
 
 	async fn set_status_flags(&self, status_flags: fd::StatusFlags) -> io::Result<()> {

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -12,7 +12,7 @@ use smoltcp::time::Duration;
 
 use crate::executor::block_on;
 use crate::executor::network::{Handle, NIC};
-use crate::fd::{Endpoint, IoCtl, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
+use crate::fd::{self, Endpoint, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
 use crate::{DEFAULT_KEEP_ALIVE_INTERVAL, io};
 
 /// further receives will be disallowed
@@ -434,20 +434,9 @@ impl Socket {
 		}
 	}
 
-	async fn ioctl(&mut self, cmd: IoCtl, value: bool) -> io::Result<()> {
-		if cmd == IoCtl::NonBlocking {
-			if value {
-				trace!("set device to nonblocking mode");
-				self.is_nonblocking = true;
-			} else {
-				trace!("set device to blocking mode");
-				self.is_nonblocking = false;
-			}
-
-			Ok(())
-		} else {
-			Err(io::Error::EINVAL)
-		}
+	async fn set_status_flags(&mut self, status_flags: fd::StatusFlags) -> io::Result<()> {
+		self.is_nonblocking = status_flags.contains(fd::StatusFlags::O_NONBLOCK);
+		Ok(())
 	}
 }
 
@@ -513,7 +502,7 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 		self.read().await.shutdown(how).await
 	}
 
-	async fn ioctl(&self, cmd: IoCtl, value: bool) -> io::Result<()> {
-		self.write().await.ioctl(cmd, value).await
+	async fn set_status_flags(&self, status_flags: fd::StatusFlags) -> io::Result<()> {
+		self.write().await.set_status_flags(status_flags).await
 	}
 }

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -215,6 +215,16 @@ impl Socket {
 		}
 	}
 
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		let status_flags = if self.nonblocking {
+			fd::StatusFlags::O_NONBLOCK
+		} else {
+			fd::StatusFlags::empty()
+		};
+
+		Ok(status_flags)
+	}
+
 	async fn set_status_flags(&mut self, status_flags: fd::StatusFlags) -> io::Result<()> {
 		self.nonblocking = status_flags.contains(fd::StatusFlags::O_NONBLOCK);
 		Ok(())
@@ -256,6 +266,10 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 
 	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		self.read().await.write(buf).await
+	}
+
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		self.read().await.status_flags().await
 	}
 
 	async fn set_status_flags(&self, status_flags: fd::StatusFlags) -> io::Result<()> {

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -9,7 +9,7 @@ use smoltcp::wire::IpEndpoint;
 
 use crate::executor::block_on;
 use crate::executor::network::{Handle, NIC};
-use crate::fd::{Endpoint, IoCtl, ListenEndpoint, ObjectInterface, PollEvent};
+use crate::fd::{self, Endpoint, ListenEndpoint, ObjectInterface, PollEvent};
 use crate::io;
 
 #[derive(Debug)]
@@ -215,20 +215,9 @@ impl Socket {
 		}
 	}
 
-	async fn ioctl(&mut self, cmd: IoCtl, value: bool) -> io::Result<()> {
-		if cmd == IoCtl::NonBlocking {
-			if value {
-				info!("set device to nonblocking mode");
-				self.nonblocking = true;
-			} else {
-				info!("set device to blocking mode");
-				self.nonblocking = false;
-			}
-
-			Ok(())
-		} else {
-			Err(io::Error::EINVAL)
-		}
+	async fn set_status_flags(&mut self, status_flags: fd::StatusFlags) -> io::Result<()> {
+		self.nonblocking = status_flags.contains(fd::StatusFlags::O_NONBLOCK);
+		Ok(())
 	}
 }
 
@@ -269,7 +258,7 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 		self.read().await.write(buf).await
 	}
 
-	async fn ioctl(&self, cmd: IoCtl, value: bool) -> io::Result<()> {
-		self.write().await.ioctl(cmd, value).await
+	async fn set_status_flags(&self, status_flags: fd::StatusFlags) -> io::Result<()> {
+		self.write().await.set_status_flags(status_flags).await
 	}
 }

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -296,6 +296,16 @@ impl Socket {
 		Ok(())
 	}
 
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		let status_flags = if self.is_nonblocking {
+			fd::StatusFlags::O_NONBLOCK
+		} else {
+			fd::StatusFlags::empty()
+		};
+
+		Ok(status_flags)
+	}
+
 	async fn set_status_flags(&mut self, status_flags: fd::StatusFlags) -> io::Result<()> {
 		self.is_nonblocking = status_flags.contains(fd::StatusFlags::O_NONBLOCK);
 		Ok(())
@@ -448,6 +458,10 @@ impl ObjectInterface for async_lock::RwLock<Socket> {
 
 	async fn shutdown(&self, how: i32) -> io::Result<()> {
 		self.read().await.shutdown(how).await
+	}
+
+	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
+		self.read().await.status_flags().await
 	}
 
 	async fn set_status_flags(&self, status_flags: fd::StatusFlags) -> io::Result<()> {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -21,7 +21,7 @@ pub use self::tasks::*;
 pub use self::timer::*;
 use crate::executor::block_on;
 use crate::fd::{
-	AccessPermission, EventFlags, FileDescriptor, IoCtl, OpenOption, PollFd, dup_object,
+	self, AccessPermission, EventFlags, FileDescriptor, IoCtl, OpenOption, PollFd, dup_object,
 	dup_object2, get_object, isatty, remove_object,
 };
 use crate::fs::{self, FileAttr};
@@ -537,7 +537,7 @@ pub extern "C" fn sys_fcntl(fd: i32, cmd: i32, arg: i32) -> i32 {
 
 	if cmd == F_SETFD && arg == FD_CLOEXEC {
 		0
-	} else if cmd == F_SETFL && arg == OpenOption::O_NONBLOCK.bits() {
+	} else if cmd == F_SETFL && arg == fd::StatusFlags::O_NONBLOCK.bits() {
 		let obj = get_object(fd);
 		obj.map_or_else(
 			|e| -num::ToPrimitive::to_i32(&e).unwrap(),


### PR DESCRIPTION
This implements `fcntl(F_GETFL)` in three steps:

1. Move file status flags (`O_APPEND` and `O_NONBLOCK`) from `OpenOptions` into a new `fd::StatusFlags` type as per POSIX.
2. Replace `ObjectInterface::ioctl(&self, cmd: IoCtl, value: bool)` with `ObjectInterface::set_status_flags(&self, status_flags: fd::StatusFlags)`, as that seems more straightforward for adding methods compared to adding more values to `IoCtl` and handling those in the implementors.
3. Implement `fcntl(F_GETFL)` by adding `ObjectInterface::status_flags(&self)`.


This closes https://github.com/hermit-os/kernel/issues/1383.