### PR TITLE
fix(riscv64): improved interrupt_handling with virtio_mmio devices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,8 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package httpd --no-default-features --features ci,hermit/dhcpv4,hermit/tcp qemu ${{ matrix.flags }} --microvm --netdev virtio-net-mmio
         if: matrix.arch == 'x86_64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package httpd --no-default-features --features ci,hermit/dhcpv4,hermit/tcp qemu ${{ matrix.flags }} --netdev virtio-net-mmio
+        if: matrix.arch == 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package httpd --features ci,hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.flags }} --netdev rtl8139
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package testudp --features hermit/udp,hermit/dhcpv4 qemu ${{ matrix.flags }} --netdev virtio-net-pci

--- a/src/arch/riscv64/kernel/interrupts.rs
+++ b/src/arch/riscv64/kernel/interrupts.rs
@@ -30,7 +30,7 @@ static INTERRUPT_HANDLERS: OnceCell<HashMap<u8, InterruptHandlerQueue, RandomSta
 /// Init Interrupts
 pub(crate) fn install() {
 	unsafe {
-		// Intstall trap handler
+		// Install trap handler
 		trapframe::init();
 		// Enable external interrupts
 		sie::set_sext();

--- a/src/arch/riscv64/kernel/interrupts.rs
+++ b/src/arch/riscv64/kernel/interrupts.rs
@@ -192,7 +192,6 @@ fn external_handler() {
 	// Claim interrupt
 	let base_ptr = PLIC_BASE.lock();
 	let context = PLIC_CONTEXT.lock();
-	//let claim_address = *base_ptr + 0x20_2004;
 	let claim_address = *base_ptr + 0x20_0004 + 0x1000 * (*context as usize);
 	let irq = unsafe { core::ptr::read_volatile(claim_address as *mut u32) };
 

--- a/src/arch/riscv64/kernel/interrupts.rs
+++ b/src/arch/riscv64/kernel/interrupts.rs
@@ -195,8 +195,6 @@ fn external_handler() {
 	let claim_address = *base_ptr + 0x20_0004 + 0x1000 * (*context as usize);
 	let irq = unsafe { core::ptr::read_volatile(claim_address as *mut u32) };
 
-	external_eoi();
-
 	if irq != 0 {
 		debug!("External INT: {}", irq);
 		let mut cur_int = CURRENT_INTERRUPTS.lock();
@@ -204,6 +202,8 @@ fn external_handler() {
 		if cur_int.len() > 1 {
 			warn!("More than one external interrupt is pending!");
 		}
+		// Release lock early
+		drop(cur_int);
 
 		// Call handler
 		if let Some(handlers) = INTERRUPT_HANDLERS.get() {
@@ -216,24 +216,18 @@ fn external_handler() {
 		crate::executor::run();
 
 		core_scheduler().reschedule();
-	}
-}
 
-/// End of external interrupt
-fn external_eoi() {
-	unsafe {
-		let base_ptr = PLIC_BASE.lock();
-		let context = PLIC_CONTEXT.lock();
-		let claim_address = *base_ptr + 0x20_0004 + 0x1000 * (*context as usize);
-
-		let mut cur_int = CURRENT_INTERRUPTS.lock();
-		let irq = cur_int.pop().unwrap_or(0);
-		if irq != 0 {
-			debug!("EOI INT: {}", irq);
-			// Complete interrupt
+		// Complete interrupt after handling
+		unsafe {
 			core::ptr::write_volatile(claim_address as *mut u32, irq);
-		} else {
-			warn!("Called EOI without active interrupt");
+		}
+
+		// Remove from active interrupts
+		let mut cur_int = CURRENT_INTERRUPTS.lock();
+		if let Some(active_irq) = cur_int.pop() {
+			if active_irq != irq {
+				warn!("Interrupt mismatch during EOI!");
+			}
 		}
 	}
 }


### PR DESCRIPTION
The function external_eoi() was removed to prevent premature end-of-interrupt (EOI) signaling before the interrupt was fully processed. 
In the previous implementation, external_eoi() was called too early, which could lead to lost or duplicated interrupts.
Additionally, the new implementation reduces redundant lock acquisitions (by external_eoi() and external_handler()) and improves efficiency by consolidating the interrupt handling into a single function. 
This ensures correct processing order and improves system stability, particularly for Virtio-MMIO-based network communication.