### PR TITLE
fix(fs): only check for `O_CREAT` if file does not exist

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -450,7 +450,7 @@ impl MemDirectory {
 					} else {
 						return Err(io::Error::ENOENT);
 					}
-				} else if opt.contains(OpenOption::O_CREAT) || opt.contains(OpenOption::O_CREAT) {
+				} else if opt.contains(OpenOption::O_CREAT) {
 					let file = Box::new(RamFile::new(mode));
 					guard.insert(node_name, file.clone());
 					return Ok(Arc::new(RamFileInterface::new(file.data.clone())));

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -438,15 +438,7 @@ impl MemDirectory {
 
 			if components.is_empty() {
 				let mut guard = self.inner.write().await;
-				if opt.contains(OpenOption::O_CREAT) || opt.contains(OpenOption::O_CREAT) {
-					if guard.get(&node_name).is_some() {
-						return Err(io::Error::EEXIST);
-					} else {
-						let file = Box::new(RamFile::new(mode));
-						guard.insert(node_name, file.clone());
-						return Ok(Arc::new(RamFileInterface::new(file.data.clone())));
-					}
-				} else if let Some(file) = guard.get(&node_name) {
+				if let Some(file) = guard.get(&node_name) {
 					if opt.contains(OpenOption::O_DIRECTORY)
 						&& file.get_kind() != NodeKind::Directory
 					{
@@ -458,6 +450,10 @@ impl MemDirectory {
 					} else {
 						return Err(io::Error::ENOENT);
 					}
+				} else if opt.contains(OpenOption::O_CREAT) || opt.contains(OpenOption::O_CREAT) {
+					let file = Box::new(RamFile::new(mode));
+					guard.insert(node_name, file.clone());
+					return Ok(Arc::new(RamFileInterface::new(file.data.clone())));
 				} else {
 					return Err(io::Error::ENOENT);
 				}


### PR DESCRIPTION
> O_CREAT: If the file exists, this flag has no effect except as noted under O_EXCL below.

[open](https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html)

Closes https://github.com/hermit-os/kernel/issues/1641.