### PR TITLE
refactor: Remove dyn Any usage in BufferElem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ take-static = "0.1"
 talc = { version = "4" }
 time = { version = "0.3", default-features = false }
 volatile = "0.6"
-zerocopy = { version = "0.8", default-features = false }
+zerocopy = { version = "0.8", features = ["derive"], default-features = false }
 uhyve-interface = "0.1.3"
 
 [dependencies.smoltcp]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 	feature(specialization)
 )]
 #![feature(thread_local)]
+#![feature(vec_into_raw_parts)]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(custom_test_frameworks))]
 #![cfg_attr(all(target_os = "none", test), test_runner(crate::test_runner))]


### PR DESCRIPTION
This gets rid of the `Box<dyn Any>` in `BufferElem` and makes it a thin wrapper around `Vec<u8>`.