### PR TITLE
fix(virtio-net): advertise the control queue support

### DIFF
--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -500,6 +500,8 @@ impl VirtioNetDriver {
 			| virtio::net::F::MRG_RXBUF
 			// the link status can be announced
 			| virtio::net::F::STATUS
+			// control queue support
+			| virtio::net::F::CTRL_VQ
 			// Multiqueue support
 			| virtio::net::F::MQ;
 


### PR DESCRIPTION
This is also a required feature for the multiqueue support, which we do advertise.