### PR TITLE
perf(virtio-net): Don't copy packets when num_buffers is 1

### DIFF
--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -340,7 +340,7 @@ impl NetworkDriver for GEMDriver {
 				};
 				trace!("BUFFER: {buffer:x?}");
 				self.rx_buffer_consumed(index as usize);
-				Some((RxToken::new(buffer.to_vec()), TxToken::new()))
+				Some((RxToken::new(buffer.to_vec_in(DeviceAlloc)), TxToken::new()))
 			}
 			None => None,
 		}

--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -23,6 +23,7 @@ use crate::arch::kernel::mmio as hardware;
 use crate::drivers::net::NetworkDriver;
 #[cfg(feature = "pci")]
 use crate::drivers::pci as hardware;
+use crate::mm::device_alloc::DeviceAlloc;
 
 /// Data type to determine the mac address
 #[derive(Debug, Clone)]
@@ -220,11 +221,11 @@ pub(crate) type RxHandle = usize;
 
 #[doc(hidden)]
 pub(crate) struct RxToken {
-	buffer: Vec<u8>,
+	buffer: Vec<u8, DeviceAlloc>,
 }
 
 impl RxToken {
-	pub(crate) fn new(buffer: Vec<u8>) -> Self {
+	pub(crate) fn new(buffer: Vec<u8, DeviceAlloc>) -> Self {
 		Self { buffer }
 	}
 }


### PR DESCRIPTION
Currently, we would copy every single received packet from `DeviceAlloc` to a new `Vec` that is allocated with `GlobalAlloc`. If we use `DeviceAlloc` for the payload of the `RxToken`, we can avoid copying all packets for the special (and common) case of `num_buffers = 1`.

While at it, I refactored the code to make it more readable and avoid allocating the intermediate `Vec` that would be collected into a flattened `Vec<u8>` anyways.

My benchmarking shows that this increases throughput over TCP by roughly ~20%.