### PR TITLE
switch to crate arm_pl031 to read the realtime clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arm_pl031"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13696b1c2b59992f4223e0ae5bb173c81c63039367ca90eee845346ad2a13421"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +676,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "arm-gic",
+ "arm_pl031",
  "async-lock",
  "async-trait",
  "bit_field",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ memory_addresses = { version = "0.2.2", default-features = false, features = [
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = { version = "0.0.13", default-features = false }
 arm-gic = { version = "0.3" }
+arm_pl031 = {version = "0.2.1" }
 hermit-dtb = { version = "0.1" }
 semihosting = { version = "0.1", optional = true }
 memory_addresses = { version = "0.2.2", default-features = false, features = [


### PR DESCRIPTION
If the application is running on top of Qemu, the ARM PrimeCell Real Time Clock(PL031) can be used to determine the boot time. By this patch, the crate arm_pl031 is used as interface to the real time clock.

uhyve doesn't support the real-time clock. To detemine the unix timestamp, the boot time from bootinfo is used