### PR TITLE
enable SMP support for aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,6 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package rusty_demo qemu ${{ matrix.flags }}
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package rusty_demo --smp 4 qemu ${{ matrix.flags }}
-        # https://github.com/hermit-os/kernel/issues/737
-        if: matrix.arch != 'aarch64'
         # https://github.com/hermit-os/kernel/issues/1286
         continue-on-error: ${{ matrix.arch == 'riscv64' }}
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package rusty_demo --smp 4 qemu ${{ matrix.flags }} --uefi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arm-gic"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4f82708c311e0f5d2eafc3447400f34bbb366fd02d4000b95358c1e4ded0ff"
+checksum = "dd58684ee8041735b64d9e731b18c5515397ee4487f56f7cb9a409c8cbd17839"
 dependencies = [
  "bitflags 2.9.0",
  "safe-mmio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ memory_addresses = { version = "0.2.2", default-features = false, features = [
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = { version = "0.0.14", default-features = false }
-arm-gic = { version = "0.3" }
+arm-gic = { version = "0.4" }
 hermit-dtb = { version = "0.1" }
 semihosting = { version = "0.1", optional = true }
 memory_addresses = { version = "0.2.2", default-features = false, features = [

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -6,7 +6,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use aarch64::regs::*;
 use ahash::RandomState;
-use arm_gic::gicv3::GicV3;
+use arm_gic::gicv3::{GicV3, SgiTarget};
 use arm_gic::{IntId, Trigger};
 use hashbrown::HashMap;
 use hermit_dtb::Dtb;
@@ -55,10 +55,7 @@ pub fn enable() {
 	}
 }
 
-/// Enable Interrupts and wait for the next interrupt (HLT instruction)
-/// According to <https://lists.freebsd.org/pipermail/freebsd-current/2004-June/029369.html>, this exact sequence of assembly
-/// instructions is guaranteed to be atomic.
-/// This is important, because another CPU could call wakeup_core right when we decide to wait for the next interrupt.
+/// Enable all interrupts and wait for the next interrupt (wfi instruction)
 #[inline]
 pub fn enable_and_wait() {
 	unsafe {
@@ -94,13 +91,8 @@ pub(crate) fn install_handlers() {
 		debug!("Handle timer interrupt");
 
 		// disable timer
-		unsafe {
-			asm!(
-				"msr cntp_cval_el0, xzr",
-				"msr cntp_ctl_el0, xzr",
-				options(nostack, nomem),
-			);
-		}
+		CNTP_CVAL_EL0.set(0);
+		CNTP_CTL_EL0.write(CNTP_CTL_EL0::ENABLE::CLEAR);
 	}
 
 	for (key, value) in get_interrupt_handlers().into_iter() {
@@ -237,8 +229,19 @@ pub(crate) extern "C" fn do_error(_state: &State) -> ! {
 	scheduler::abort()
 }
 
-pub fn wakeup_core(_core_to_wakeup: CoreId) {
-	todo!("wakeup_core stub");
+pub fn wakeup_core(core_id: CoreId) {
+	debug!("Wakeup core {core_id}");
+	let reschedid = IntId::sgi(SGI_RESCHED.into());
+
+	GicV3::send_sgi(
+		reschedid,
+		SgiTarget::List {
+			affinity3: 0,
+			affinity2: 0,
+			affinity1: 0,
+			target_list: 1 << core_id,
+		},
+	);
 }
 
 pub(crate) fn init() {
@@ -261,21 +264,31 @@ pub(crate) fn init() {
 	let (slice, _residual_slice) = residual_slice.split_at(core::mem::size_of::<u64>());
 	let gicr_size = u64::from_be_bytes(slice.try_into().unwrap());
 
-	let gicr_stride = dtb
-		.get_property("/intc", "redistributor-stride")
-		.map(|bytes| u64::from_be_bytes(bytes.try_into().unwrap()))
-		.unwrap_or(0);
-
 	let num_cpus = dtb
 		.enum_subnodes("/cpus")
 		.filter(|name| name.contains("cpu@"))
 		.count();
-	let cpu_id = core_id();
+	let cpu_id: usize = core_id().try_into().unwrap();
 
-	info!("Found {num_cpus} cpus!");
+	let compatible = core::str::from_utf8(
+		dtb.get_property("/intc", "compatible")
+			.unwrap_or(b"unknown"),
+	)
+	.unwrap()
+	.replace('\0', "");
+	let is_gic_v4 = if compatible == "arm,gic-v4" {
+		info!("Found GIC v4 with {num_cpus} cpus");
+		true
+	} else if compatible == "arm,gic-v3" {
+		info!("Found GIC v3 with {num_cpus} cpus");
+		false
+	} else {
+		panic!("{compatible} isn't supported")
+	};
+
 	info!("Found GIC Distributor interface at {gicd_start:p} (size {gicd_size:#X})");
 	info!(
-		"Found generic interrupt controller redistributor at {gicr_start:p} (size {gicr_size:#X}, stride {gicr_stride:#X})"
+		"Found generic interrupt controller redistributor at {gicr_start:p} (size {gicr_size:#X})"
 	);
 
 	let gicd_address =
@@ -301,16 +314,16 @@ pub(crate) fn init() {
 		flags,
 	);
 
-	GicV3::set_priority_mask(0xff);
 	let mut gic = unsafe {
 		GicV3::new(
 			gicd_address.as_mut_ptr(),
 			gicr_address.as_mut_ptr(),
 			num_cpus,
-			gicr_stride as usize,
+			is_gic_v4,
 		)
 	};
-	gic.setup(cpu_id as usize);
+	gic.setup(cpu_id);
+	GicV3::set_priority_mask(0xff);
 
 	for node in dtb.enum_subnodes("/") {
 		let parts: Vec<_> = node.split('@').collect();
@@ -349,25 +362,89 @@ pub(crate) fn init() {
 				} else {
 					panic!("Invalid interrupt type");
 				};
-				gic.set_interrupt_priority(timer_irqid, Some(cpu_id as usize), 0x00);
+				gic.set_interrupt_priority(timer_irqid, Some(cpu_id), 0x00);
 				if (irqflags & 0xf) == 4 || (irqflags & 0xf) == 8 {
-					gic.set_trigger(timer_irqid, Some(cpu_id as usize), Trigger::Level);
+					gic.set_trigger(timer_irqid, Some(cpu_id), Trigger::Level);
 				} else if (irqflags & 0xf) == 2 || (irqflags & 0xf) == 1 {
-					gic.set_trigger(timer_irqid, Some(cpu_id as usize), Trigger::Edge);
+					gic.set_trigger(timer_irqid, Some(cpu_id), Trigger::Edge);
 				} else {
 					panic!("Invalid interrupt level!");
 				}
-				gic.enable_interrupt(timer_irqid, Some(cpu_id as usize), true);
+				gic.enable_interrupt(timer_irqid, Some(cpu_id), true);
 			}
 		}
 	}
 
 	let reschedid = IntId::sgi(SGI_RESCHED.into());
-	gic.set_interrupt_priority(reschedid, Some(cpu_id as usize), 0x00);
-	gic.enable_interrupt(reschedid, Some(cpu_id as usize), true);
+	gic.set_interrupt_priority(reschedid, Some(cpu_id), 0x01);
+	gic.enable_interrupt(reschedid, Some(cpu_id), true);
 	IRQ_NAMES.lock().insert(SGI_RESCHED, "Reschedule");
 
 	*GIC.lock() = Some(gic);
+}
+
+// marks the given CPU core as awake
+pub fn init_cpu() {
+	let cpu_id: usize = core_id().try_into().unwrap();
+
+	if let Some(ref mut gic) = *GIC.lock() {
+		debug!("Mark cpu {cpu_id} as awake");
+
+		gic.setup(cpu_id);
+		GicV3::set_priority_mask(0xff);
+
+		let dtb = unsafe {
+			Dtb::from_raw(ptr::with_exposed_provenance(
+				env::boot_info().hardware_info.device_tree.unwrap().get() as usize,
+			))
+			.expect(".dtb file has invalid header")
+		};
+
+		for node in dtb.enum_subnodes("/") {
+			let parts: Vec<_> = node.split('@').collect();
+
+			if let Some(compatible) = dtb.get_property(parts.first().unwrap(), "compatible") {
+				if core::str::from_utf8(compatible).unwrap().contains("timer") {
+					let irq_slice = dtb
+						.get_property(parts.first().unwrap(), "interrupts")
+						.unwrap();
+					/* Secure Phys IRQ */
+					let (_irqtype, irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					let (_irq, irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					let (_irqflags, irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					/* Non-secure Phys IRQ */
+					let (irqtype, irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					let (irq, irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					let (irqflags, _irq_slice) = irq_slice.split_at(core::mem::size_of::<u32>());
+					let irqtype = u32::from_be_bytes(irqtype.try_into().unwrap());
+					let irq = u32::from_be_bytes(irq.try_into().unwrap());
+					let irqflags = u32::from_be_bytes(irqflags.try_into().unwrap());
+
+					// enable timer interrupt
+					let timer_irqid = if irqtype == 1 {
+						IntId::ppi(irq)
+					} else if irqtype == 0 {
+						IntId::spi(irq)
+					} else {
+						panic!("Invalid interrupt type");
+					};
+					gic.set_interrupt_priority(timer_irqid, Some(cpu_id), 0x00);
+					if (irqflags & 0xf) == 4 || (irqflags & 0xf) == 8 {
+						gic.set_trigger(timer_irqid, Some(cpu_id), Trigger::Level);
+					} else if (irqflags & 0xf) == 2 || (irqflags & 0xf) == 1 {
+						gic.set_trigger(timer_irqid, Some(cpu_id), Trigger::Edge);
+					} else {
+						panic!("Invalid interrupt level!");
+					}
+					gic.enable_interrupt(timer_irqid, Some(cpu_id), true);
+				}
+			}
+		}
+
+		let reschedid = IntId::sgi(SGI_RESCHED.into());
+		gic.set_interrupt_priority(reschedid, Some(cpu_id), 0x01);
+		gic.enable_interrupt(reschedid, Some(cpu_id), true);
+	}
 }
 
 static IRQ_NAMES: InterruptTicketMutex<HashMap<u8, &'static str, RandomState>> =

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -98,10 +98,6 @@ pub fn seed_entropy() -> Option<[u8; 32]> {
 	None
 }
 
-pub(crate) fn run_on_hypervisor() -> bool {
-	true
-}
-
 /// The halt function stops the processor until the next interrupt arrives
 pub fn halt() {
 	unsafe {
@@ -246,8 +242,5 @@ pub fn print_information() {
 	infoheader!(" CPU INFORMATION ");
 	infoentry!("Processor compatibility", str::from_utf8(reg).unwrap());
 	infoentry!("Counter frequency", *CPU_FREQUENCY);
-	if run_on_hypervisor() {
-		info!("Run on hypervisor");
-	}
 	infofooter!();
 }

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -1,10 +1,41 @@
+#![allow(dead_code)]
+
 use core::arch::{asm, naked_asm};
+#[cfg(feature = "smp")]
+use core::sync::atomic::AtomicPtr;
 
 use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
 use crate::arch::aarch64::kernel::scheduler::TaskStacks;
 use crate::{KERNEL_STACK_SIZE, env};
+
+/*
+ * Memory types available.
+ */
+#[allow(non_upper_case_globals)]
+const MT_DEVICE_nGnRnE: u64 = 0;
+#[allow(non_upper_case_globals)]
+const MT_DEVICE_nGnRE: u64 = 1;
+const MT_DEVICE_GRE: u64 = 2;
+const MT_NORMAL_NC: u64 = 3;
+const MT_NORMAL: u64 = 4;
+
+/*
+ * TCR flags
+ */
+const TCR_IRGN_WBWA: u64 = ((1) << 8) | ((1) << 24);
+const TCR_ORGN_WBWA: u64 = ((1) << 10) | ((1) << 26);
+const TCR_SHARED: u64 = ((3) << 12) | ((3) << 28);
+const TCR_TBI0: u64 = 1 << 37;
+const TCR_TBI1: u64 = 1 << 38;
+const TCR_ASID16: u64 = 1 << 36;
+const TCR_TG1_16K: u64 = 1 << 30;
+const TCR_TG1_4K: u64 = 0 << 30;
+const TCR_FLAGS: u64 = TCR_IRGN_WBWA | TCR_ORGN_WBWA | TCR_SHARED;
+
+/// Number of virtual address bits for 4KB page
+const VA_BITS: u64 = 48;
 
 unsafe extern "C" {
 	static vector_table: u8;
@@ -70,6 +101,111 @@ pub unsafe extern "C" fn _start(boot_info: Option<&'static RawBootInfo>, cpu_id:
 		cpu_online = sym super::CPU_ONLINE,
 		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
 		current_stack_address = sym super::CURRENT_STACK_ADDRESS,
+		pre_init = sym pre_init,
+	)
+}
+
+#[cfg(feature = "smp")]
+const fn tcr_size(x: u64) -> u64 {
+	((64 - x) << 16) | (64 - x)
+}
+
+#[cfg(feature = "smp")]
+const fn mair(attr: u64, mt: u64) -> u64 {
+	attr << (mt * 8)
+}
+
+#[cfg(feature = "smp")]
+pub(crate) static TTBR0: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
+
+#[cfg(feature = "smp")]
+#[unsafe(naked)]
+pub(crate) unsafe extern "C" fn smp_start() -> ! {
+	naked_asm!(
+		// disable interrupts
+		"msr daifset, #0b111",
+
+		// we want to use sp_el1!
+		"msr spsel, #1",
+
+		// reset thread id registers
+		"msr tpidr_el0, xzr",
+		"msr tpidr_el1, xzr",
+
+		// Disable the MMU
+		"dsb sy",
+		"mrs x2, sctlr_el1",
+		"bic x2, x2, #0x1",
+		"msr sctlr_el1, x2",
+		"isb",
+
+		"ic iallu",
+		"tlbi vmalle1is",
+		"dsb ish",
+
+		// Setup memory attribute type tables
+		"ldr x1, ={mair_el1}",
+		"msr mair_el1, x1",
+
+		// Setup translation control register (TCR)
+		"mrs x0, id_aa64mmfr0_el1",
+		"and x0, x0, 0xF",
+		"lsl x0, x0, 32",
+		"ldr x1, ={tcr_bits}",
+		"orr x0, x0, x1",
+		"mrs x1, id_aa64mmfr0_el1",
+		"bfi x0, x1, #32, #3",
+		"msr tcr_el1, x0",
+
+		// Enable FP/ASIMD in Architectural Feature Access Control Register,
+		"mov x0, 3",
+		"lsl x0, x0, 20",
+		"msr cpacr_el1, x0",
+
+		// Reset debug control register
+		"msr mdscr_el1, xzr",
+
+		// Memory barrier
+		"dsb sy",
+
+		// Overwrite RSP if `CURRENT_STACK_ADDRESS != 0`
+		"adrp x8, {current_stack_address}",
+		"ldr x4, [x8, #:lo12:{current_stack_address}]",
+		"cmp x4, 0",
+		"b.eq 3f",
+		"mov sp, x4",
+		"b 4f",
+		"3:",
+		"mov x4, sp",
+		"4:",
+		"str x4, [x8, #:lo12:{current_stack_address}]",
+
+		// Add stack top offset
+		"mov x8, {stack_top_offset}",
+		"add sp, sp, x8",
+
+		"msr ttbr1_el1, xzr",
+		"adrp x8, {ttbr0}",
+		"ldr x5, [x8, #:lo12:{ttbr0}]",
+		"msr ttbr0_el1, x5",
+
+		// Prepare system control register (SCTRL)
+		"ldr x0, =0x405d01d",
+		  "msr sctlr_el1, x0",
+
+		// initialize argument for pre_init
+		"mov x0, xzr",
+		"mrs x1, mpidr_el1",
+		"and x1, x1, #0xff",
+
+		// Jump to Rust code
+		"b {pre_init}",
+
+		mair_el1 = const mair(0x00, MT_DEVICE_nGnRnE) | mair(0x04, MT_DEVICE_nGnRE) | mair(0x0c, MT_DEVICE_GRE) | mair(0x44, MT_NORMAL_NC) | mair(0xff, MT_NORMAL),
+		tcr_bits = const tcr_size(VA_BITS) | TCR_TG1_4K | TCR_FLAGS,
+		stack_top_offset = const KERNEL_STACK_SIZE - TaskStacks::MARKER_SIZE,
+		current_stack_address = sym super::CURRENT_STACK_ADDRESS,
+		ttbr0 = sym TTBR0,
 		pre_init = sym pre_init,
 	)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,9 @@ fn boot_processor_main() -> ! {
 
 	#[cfg(feature = "pci")]
 	info!("Compiled with PCI support");
-	#[cfg(feature = "acpi")]
+	#[cfg(all(feature = "acpi", target_arch = "x86_64"))]
 	info!("Compiled with ACPI support");
-	#[cfg(feature = "fsgsbase")]
+	#[cfg(all(feature = "fsgsbase", target_arch = "x86_64"))]
 	info!("Compiled with FSGSBASE support");
 	#[cfg(feature = "smp")]
 	info!("Compiled with SMP support");

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -150,13 +150,18 @@ impl PerCoreSchedulerExt for &mut PerCoreScheduler {
 		}
 
 		let reschedid = IntId::sgi(SGI_RESCHED.into());
+		#[cfg(feature = "smp")]
+		let core_id = self.core_id;
+		#[cfg(not(feature = "smp"))]
+		let core_id = 0;
+
 		GicV3::send_sgi(
 			reschedid,
 			SgiTarget::List {
 				affinity3: 0,
 				affinity2: 0,
 				affinity1: 0,
-				target_list: 0b1,
+				target_list: 1 << core_id,
 			},
 		);
 


### PR DESCRIPTION
To realize SMP support, the entry point for new cores is implemented in `smp_start`. The boot core ask the hypervisor to wakeup new cores at this entry point.
    
In addition, the latest version of arm-gic is used, to support GIC v3 and v4.

This PR depends on #1703 and closes #737