### PR TITLE
perf(drivers): remove `virt_to_phys`

### DIFF
--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -595,11 +595,6 @@ pub fn virtual_to_physical(virtual_address: VirtAddr) -> Option<PhysAddr> {
 	get_physical_address::<BasePageSize>(virtual_address)
 }
 
-#[cfg(any(feature = "fuse", feature = "vsock", feature = "tcp", feature = "udp"))]
-pub fn virt_to_phys(virtual_address: VirtAddr) -> PhysAddr {
-	virtual_to_physical(virtual_address).unwrap()
-}
-
 pub fn map<S: PageSize>(
 	mut virtual_address: VirtAddr,
 	mut physical_address: PhysAddr,

--- a/src/arch/riscv64/mm/paging.rs
+++ b/src/arch/riscv64/mm/paging.rs
@@ -582,11 +582,6 @@ pub fn virtual_to_physical(virtual_address: VirtAddr) -> Option<PhysAddr> {
 	panic!("virtual_to_physical should never reach this point");
 }
 
-#[cfg(any(feature = "fuse", feature = "vsock", feature = "tcp", feature = "udp"))]
-pub fn virt_to_phys(virtual_address: VirtAddr) -> PhysAddr {
-	virtual_to_physical(virtual_address).unwrap()
-}
-
 pub fn map<S: PageSize>(
 	virtual_address: VirtAddr,
 	physical_address: PhysAddr,

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -121,11 +121,6 @@ pub fn virtual_to_physical(virtual_address: VirtAddr) -> Option<PhysAddr> {
 	}
 }
 
-#[cfg(any(feature = "fuse", feature = "vsock", feature = "tcp", feature = "udp"))]
-pub fn virt_to_phys(virtual_address: VirtAddr) -> PhysAddr {
-	virtual_to_physical(virtual_address).unwrap()
-}
-
 /// Maps a continuous range of pages.
 ///
 /// # Arguments

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -24,7 +24,7 @@ use crate::arch::kernel::core_local::core_scheduler;
 use crate::arch::kernel::interrupts::*;
 #[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
 use crate::arch::kernel::mmio as hardware;
-use crate::arch::mm::paging::{PageTableEntryFlags, virt_to_phys};
+use crate::arch::mm::paging::PageTableEntryFlags;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::NetworkDriver;
 #[cfg(all(any(feature = "tcp", feature = "udp"), feature = "pci"))]
@@ -643,7 +643,7 @@ pub fn init_device(
 		for i in 0..RX_BUF_NUM {
 			let word0 = (rxbuffer_list + u64::from(i * 8)).as_mut_ptr::<u32>();
 			let word1 = (rxbuffer_list + u64::from(i * 8 + 4)).as_mut_ptr::<u32>();
-			let buffer = virt_to_phys(rxbuffer + u64::from(i * RX_BUF_LEN));
+			let buffer = rxbuffer + u64::from(i * RX_BUF_LEN);
 			if (buffer.as_u64() & 0b11) != 0 {
 				error!("Wrong buffer alignment");
 				return Err(DriverError::InitGEMDevFail(GEMError::Unknown));
@@ -660,7 +660,7 @@ pub fn init_device(
 			core::ptr::write_volatile(word1, 0x0);
 		}
 
-		let rx_qbar: u32 = virt_to_phys(rxbuffer_list).as_u64().try_into().unwrap();
+		let rx_qbar: u32 = rxbuffer_list.as_u64().try_into().unwrap();
 		debug!("Set rx_qbar to {rx_qbar:x}");
 		(*gem).rx_qbar.set(rx_qbar);
 
@@ -668,7 +668,7 @@ pub fn init_device(
 		for i in 0..TX_BUF_NUM {
 			let word0 = (txbuffer_list + u64::from(i * 8)).as_mut_ptr::<u32>();
 			let word1 = (txbuffer_list + u64::from(i * 8 + 4)).as_mut_ptr::<u32>();
-			let buffer = virt_to_phys(txbuffer + u64::from(i * TX_BUF_LEN));
+			let buffer = txbuffer + u64::from(i * TX_BUF_LEN);
 
 			// This can fail if address of buffers is > 32 bit
 			// TODO: 64-bit addresses
@@ -682,7 +682,7 @@ pub fn init_device(
 			core::ptr::write_volatile(word1, word1_entry);
 		}
 
-		let tx_qbar: u32 = virt_to_phys(txbuffer_list).as_u64().try_into().unwrap();
+		let tx_qbar: u32 = txbuffer_list.as_u64().try_into().unwrap();
 		debug!("Set tx_qbar to {tx_qbar:x}");
 		(*gem).tx_qbar.set(tx_qbar);
 

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -6,12 +6,10 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
 
-use memory_addresses::VirtAddr;
 use pci_types::{Bar, CommandRegister, InterruptLine, MAX_BARS};
 use x86_64::instructions::port::Port;
 
 use crate::arch::kernel::interrupts::*;
-use crate::arch::mm::paging::virt_to_phys;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::Driver;
 use crate::drivers::error::DriverError;
@@ -522,12 +520,7 @@ pub(crate) fn init_device(
 
 	debug!("Allocate TxBuffer at {txbuffer:p} and RxBuffer at {rxbuffer:p}");
 
-	let phys_addr = |p| {
-		virt_to_phys(VirtAddr::from_ptr(p))
-			.as_u64()
-			.try_into()
-			.unwrap()
-	};
+	let phys_addr = |p: *const u8| u32::try_from(p.expose_provenance()).unwrap();
 
 	unsafe {
 		// register the receive buffer

--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -20,11 +20,9 @@ use core::mem::MaybeUninit;
 use core::{mem, ptr};
 
 use enum_dispatch::enum_dispatch;
-use memory_addresses::VirtAddr;
 use virtio::{le32, le64, pvirtq, virtq};
 
 use self::error::VirtqError;
-use crate::arch::mm::paging;
 use crate::drivers::virtio::virtqueue::packed::PackedVq;
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::mm::device_alloc::DeviceAlloc;
@@ -205,10 +203,9 @@ trait VirtqPrivate {
 	) -> Result<Box<[Self::Descriptor]>, VirtqError>;
 
 	fn indirect_desc(table: &[Self::Descriptor]) -> Self::Descriptor {
+		let addr = table.as_ptr().expose_provenance();
 		Self::Descriptor::incomplete_desc(
-			paging::virt_to_phys(VirtAddr::from_ptr(table.as_ptr()))
-				.as_u64()
-				.into(),
+			u64::try_from(addr).unwrap().into(),
 			(mem::size_of_val(table) as u32).into(),
 			virtq::DescF::INDIRECT,
 		)
@@ -249,10 +246,9 @@ trait VirtqPrivate {
 			send_desc_iter
 				.chain(recv_desc_iter)
 				.map(|(mem_descr, len, incomplete_flags)| {
+					let addr = mem_descr.addr().expose_provenance();
 					Self::Descriptor::incomplete_desc(
-						paging::virt_to_phys(VirtAddr::from_ptr(mem_descr.addr()))
-							.as_u64()
-							.into(),
+						u64::try_from(addr).unwrap().into(),
 						len.into(),
 						incomplete_flags | virtq::DescF::NEXT,
 					)

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -5,11 +5,11 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::Cell;
-use core::ops;
 use core::sync::atomic::{Ordering, fence};
+use core::{ops, ptr};
 
 use align_address::Align;
-use memory_addresses::VirtAddr;
+use memory_addresses::PhysAddr;
 #[cfg(not(feature = "pci"))]
 use virtio::mmio::NotificationData;
 #[cfg(feature = "pci")]
@@ -27,7 +27,6 @@ use super::{
 	AvailBufferToken, BufferType, MemDescrId, MemPool, TransferToken, UsedBufferToken, Virtq,
 	VirtqPrivate, VqIndex, VqSize,
 };
-use crate::arch::mm::paging;
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::mm::device_alloc::DeviceAlloc;
 
@@ -708,12 +707,10 @@ impl PackedVq {
 		let dev_event = Box::leak(dev_event);
 
 		// Provide memory areas of the queues data structures to the device
-		vq_handler.set_ring_addr(paging::virt_to_phys(VirtAddr::from(
-			descr_ring.raw_addr() as u64
-		)));
+		vq_handler.set_ring_addr(PhysAddr::from(descr_ring.raw_addr()));
 		// As usize is safe here, as the *mut EventSuppr raw pointer is a thin pointer of size usize
-		vq_handler.set_drv_ctrl_addr(paging::virt_to_phys(VirtAddr::from_ptr(drv_event)));
-		vq_handler.set_dev_ctrl_addr(paging::virt_to_phys(VirtAddr::from_ptr(dev_event)));
+		vq_handler.set_drv_ctrl_addr(PhysAddr::from(ptr::from_mut(drv_event).expose_provenance()));
+		vq_handler.set_dev_ctrl_addr(PhysAddr::from(ptr::from_mut(dev_event).expose_provenance()));
 
 		let mut drv_event = DrvNotif {
 			f_notif_idx: false,

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -7,7 +7,7 @@ use core::cell::UnsafeCell;
 use core::mem::{self, MaybeUninit};
 use core::ptr;
 
-use memory_addresses::VirtAddr;
+use memory_addresses::PhysAddr;
 #[cfg(not(feature = "pci"))]
 use virtio::mmio::NotificationData;
 #[cfg(feature = "pci")]
@@ -24,7 +24,6 @@ use super::{
 	VqIndex, VqSize,
 };
 use crate::arch::memory_barrier;
-use crate::arch::mm::paging;
 use crate::mm::device_alloc::DeviceAlloc;
 
 struct DescrRing {
@@ -288,16 +287,16 @@ impl SplitVq {
 		};
 
 		// Provide memory areas of the queues data structures to the device
-		vq_handler.set_ring_addr(paging::virt_to_phys(VirtAddr::from(
+		vq_handler.set_ring_addr(PhysAddr::from(
 			ptr::from_ref(descr_table_cell.as_ref()).expose_provenance(),
-		)));
+		));
 		// As usize is safe here, as the *mut EventSuppr raw pointer is a thin pointer of size usize
-		vq_handler.set_drv_ctrl_addr(paging::virt_to_phys(VirtAddr::from(
+		vq_handler.set_drv_ctrl_addr(PhysAddr::from(
 			ptr::from_ref(avail_ring_cell.as_ref()).expose_provenance(),
-		)));
-		vq_handler.set_dev_ctrl_addr(paging::virt_to_phys(VirtAddr::from(
+		));
+		vq_handler.set_dev_ctrl_addr(PhysAddr::from(
 			ptr::from_ref(used_ring_cell.as_ref()).expose_provenance(),
-		)));
+		));
 
 		let descr_ring = DescrRing {
 			read_idx: 0,


### PR DESCRIPTION
This is made possible by https://github.com/hermit-os/kernel/pull/1670.

I can't measure an improvement reliably, but this should be a strict performance improvement and also be visible on the flamegraph.