### PR TITLE
refactor(drivers/net): Unify MTUs and fix buffer sizes for virtio-net

### DIFF
--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -26,7 +26,7 @@ use crate::arch::kernel::interrupts::*;
 use crate::arch::kernel::mmio as hardware;
 use crate::arch::mm::paging::PageTableEntryFlags;
 use crate::drivers::error::DriverError;
-use crate::drivers::net::NetworkDriver;
+use crate::drivers::net::{NetworkDriver, mtu};
 #[cfg(all(any(feature = "tcp", feature = "udp"), feature = "pci"))]
 use crate::drivers::pci as hardware;
 use crate::drivers::{Driver, InterruptLine};
@@ -705,7 +705,7 @@ pub fn init_device(
 
 	Ok(GEMDriver {
 		gem,
-		mtu: 1500,
+		mtu: mtu(),
 		irq,
 		mac,
 		rx_counter: 0,

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -5,6 +5,8 @@ pub mod rtl8139;
 #[cfg(not(all(target_arch = "x86_64", feature = "rtl8139")))]
 pub mod virtio;
 
+use core::str::FromStr;
+
 use smoltcp::phy::ChecksumCapabilities;
 
 #[allow(unused_imports)]
@@ -35,4 +37,22 @@ pub(crate) trait NetworkDriver: Driver {
 	fn set_polling_mode(&mut self, value: bool);
 	/// Handle interrupt and check if a packet is available
 	fn handle_interrupt(&mut self);
+}
+
+// Default IP level MTU to use.
+const DEFAULT_IP_MTU: u16 = 1500;
+
+/// Default MTU to use.
+///
+/// This is 1500 IP MTU and a 14-byte ethernet header.
+const DEFAULT_MTU: u16 = DEFAULT_IP_MTU + 14;
+
+/// Determines the MTU that should be used as configured by crate features
+/// or environment variables.
+pub(crate) fn mtu() -> u16 {
+	if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
+		u16::from_str(&my_mtu).unwrap()
+	} else {
+		DEFAULT_MTU
+	}
 }

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -13,7 +13,7 @@ use crate::arch::kernel::interrupts::*;
 use crate::arch::pci::PciConfigRegion;
 use crate::drivers::Driver;
 use crate::drivers::error::DriverError;
-use crate::drivers::net::NetworkDriver;
+use crate::drivers::net::{NetworkDriver, mtu};
 use crate::drivers::pci::PciDevice;
 use crate::executor::device::{RxToken, TxToken};
 use crate::mm::device_alloc::DeviceAlloc;
@@ -565,7 +565,7 @@ pub(crate) fn init_device(
 
 	Ok(RTL8139Driver {
 		iobase,
-		mtu: 1514,
+		mtu: mtu(),
 		irq,
 		mac,
 		tx_in_use: [false; NO_TX_BUFFERS],

--- a/src/drivers/net/virtio/mmio.rs
+++ b/src/drivers/net/virtio/mmio.rs
@@ -2,8 +2,6 @@
 //!
 //! The module contains ...
 
-use core::str::FromStr;
-
 use smoltcp::phy::ChecksumCapabilities;
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 use volatile::VolatileRef;
@@ -38,13 +36,6 @@ impl VirtioNetDriver<Uninit> {
 		let isr_stat = IsrStatus::new(registers.borrow_mut());
 		let notif_cfg = NotifCfg::new(registers.borrow_mut());
 
-		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap()
-		} else {
-			// fallback to the default MTU
-			1514
-		};
-
 		Ok(VirtioNetDriver {
 			dev_cfg,
 			com_cfg: ComCfg::new(registers, 1),
@@ -52,7 +43,6 @@ impl VirtioNetDriver<Uninit> {
 			notif_cfg,
 			inner: Uninit,
 			num_vqs: 0,
-			mtu,
 			irq,
 			checksums: ChecksumCapabilities::default(),
 		})

--- a/src/drivers/net/virtio/pci.rs
+++ b/src/drivers/net/virtio/pci.rs
@@ -2,8 +2,6 @@
 //!
 //! The module contains ...
 
-use core::str::FromStr;
-
 use pci_types::CommandRegister;
 use smoltcp::phy::ChecksumCapabilities;
 use volatile::VolatileRef;
@@ -50,13 +48,6 @@ impl VirtioNetDriver<Uninit> {
 			return Err(error::VirtioNetError::NoDevCfg(device_id));
 		};
 
-		let mtu = if let Some(my_mtu) = hermit_var!("HERMIT_MTU") {
-			u16::from_str(&my_mtu).unwrap()
-		} else {
-			// fallback to the default MTU
-			1514
-		};
-
 		Ok(VirtioNetDriver {
 			dev_cfg,
 			com_cfg,
@@ -64,7 +55,6 @@ impl VirtioNetDriver<Uninit> {
 			notif_cfg,
 			inner: Uninit,
 			num_vqs: 0,
-			mtu,
 			irq: device.get_irq().unwrap(),
 			checksums: ChecksumCapabilities::default(),
 		})


### PR DESCRIPTION
See "5.1.6.3.1 Driver Requirements: Setting Up Receive Buffers" in the VirtIO specification. We only need to allocate at least the MTU if GUEST_TSO4, GUEST_TSO6 or GUEST_UFO were negotiated, otherwise we SHOULD allocate at least 1514 (1526 minus 12 bytes header) for the payload. Currently we were allocating 65550 (MTU) and always receiving 1514 in that case.