### PR TITLE
Added `O_CLOEXEC` flag to OpenOptions

### DIFF
--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -64,6 +64,8 @@ bitflags! {
 		const O_NONBLOCK = StatusFlags::O_NONBLOCK.bits();
 		const O_DIRECT = 0o40000;
 		const O_DIRECTORY = 0o200_000;
+		/// `O_CLOEXEC` has no functionality in Hermit and will be silently ignored
+		const O_CLOEXEC = 0o2_000_000;
 	}
 }
 


### PR DESCRIPTION
The main goal of this is to avoid crashes if this flag is set. The flag itself doesn't have any meaning in an unikernel, as we don't have `execve`  or similar process control functionality. 
However, programs [using our newlib](https://github.com/hermit-os/newlib/blob/9ef4bd93cf9cf2cee8d5a05c87b117591dcb4a35/newlib/libc/posix/opendir.c#L85) set this flag and crashe at https://github.com/hermit-os/kernel/blob/d7203edd9df40e42097f3af3568659361f3ddead/src/syscalls/mod.rs#L334