### PR TITLE
perf(virtqueue): Use smallvec for control descriptors

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -200,7 +200,7 @@ trait VirtqPrivate {
 
 	fn create_indirect_ctrl(
 		buffer_tkn: &AvailBufferToken,
-	) -> Result<Box<[Self::Descriptor]>, VirtqError>;
+	) -> Result<SmallVec<[Self::Descriptor; 4]>, VirtqError>;
 
 	fn indirect_desc(table: &[Self::Descriptor]) -> Self::Descriptor {
 		let addr = table.as_ptr().expose_provenance();
@@ -312,7 +312,7 @@ pub struct TransferToken<Descriptor> {
 	/// upon reuse.
 	buff_tkn: AvailBufferToken,
 	// Contains the [MemDescr] for the indirect table if the transfer is indirect.
-	ctrl_desc: Option<Box<[Descriptor]>>,
+	ctrl_desc: Option<SmallVec<[Descriptor; 4]>>,
 }
 
 /// Public Interface for TransferToken

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -10,6 +10,7 @@ use core::{ops, ptr};
 
 use align_address::Align;
 use memory_addresses::PhysAddr;
+use smallvec::SmallVec;
 #[cfg(not(feature = "pci"))]
 use virtio::mmio::NotificationData;
 #[cfg(feature = "pci")]
@@ -651,10 +652,8 @@ impl VirtqPrivate for PackedVq {
 
 	fn create_indirect_ctrl(
 		buffer_tkn: &AvailBufferToken,
-	) -> Result<Box<[Self::Descriptor]>, VirtqError> {
-		Ok(Self::descriptor_iter(buffer_tkn)?
-			.collect::<Vec<_>>()
-			.into_boxed_slice())
+	) -> Result<SmallVec<[Self::Descriptor; 4]>, VirtqError> {
+		Ok(Self::descriptor_iter(buffer_tkn)?.collect::<SmallVec<_>>())
 	}
 }
 

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -8,6 +8,7 @@ use core::mem::{self, MaybeUninit};
 use core::ptr;
 
 use memory_addresses::PhysAddr;
+use smallvec::SmallVec;
 #[cfg(not(feature = "pci"))]
 use virtio::mmio::NotificationData;
 #[cfg(feature = "pci")]
@@ -228,15 +229,14 @@ impl VirtqPrivate for SplitVq {
 	type Descriptor = virtq::Desc;
 	fn create_indirect_ctrl(
 		buffer_tkn: &AvailBufferToken,
-	) -> Result<Box<[Self::Descriptor]>, VirtqError> {
+	) -> Result<SmallVec<[Self::Descriptor; 4]>, VirtqError> {
 		Ok(Self::descriptor_iter(buffer_tkn)?
 			.zip(1..)
 			.map(|(descriptor, next_id)| Self::Descriptor {
 				next: next_id.into(),
 				..descriptor
 			})
-			.collect::<Vec<_>>()
-			.into_boxed_slice())
+			.collect::<SmallVec<_>>())
 	}
 }
 


### PR DESCRIPTION
Haven't measured the differences yet, and I wouldn't exactly bet that 4 is the correct number here, though I think it is correct (since it is TX + RX combined which are 2 each).