### PR TITLE
refactor(virtqueue): Don't swallow errors on incorrect pop order

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -427,16 +427,12 @@ impl UsedDeviceWritableBuffer {
 					self.remaining_written_len -= u32::try_from(size_of::<T>()).unwrap();
 					Some(unsafe { cast.assume_init() })
 				}
-				Err(sized) => {
-					// Unlikely and wrong usage, we should not optimize for this case
-					self.elems.insert(0, BufferElem::Sized(sized));
-					None
+				Err(_) => {
+					panic!("Attempted to downcast element to wrong type");
 				}
 			}
 		} else {
-			// Unlikely and wrong usage, we should not optimize for this case
-			self.elems.insert(0, elem);
-			None
+			panic!("Attempted to pop elements in order different from insertion");
 		}
 	}
 
@@ -460,9 +456,7 @@ impl UsedDeviceWritableBuffer {
 			unsafe { vector.set_len(new_len.try_into().unwrap()) };
 			Some(vector)
 		} else {
-			// Unlikely and wrong usage, we should not optimize for this case
-			self.elems.insert(0, elem);
-			None
+			panic!("Attempted to pop elements in order different from insertion");
 		}
 	}
 }


### PR DESCRIPTION
Currently, callers have no way to know whether `pop_front_*` methods returning `None` means that no data was received yet or whether they were trying to pop in the wrong order, e.g. trying to read a packet payload before the header. This would keep repeating infinitely if a driver was reading in the wrong order.

This is always an irrecoverable programming mistake, so let's panic.