### PR TITLE
perf(virtio-net): Reuse allocations for virtqueue packet buffers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,13 @@ pub const DEFAULT_STACK_SIZE: usize = 0x0001_0000;
 pub(crate) const USER_STACK_SIZE: usize = 0x0010_0000;
 
 #[cfg(any(
-	all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
+	all(
+		any(feature = "tcp", feature = "udp"),
+		not(any(
+			all(target_arch = "x86_64", feature = "rtl8139",),
+			all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")
+		))
+	),
 	feature = "fuse",
 	feature = "vsock"
 ))]

--- a/src/drivers/net/mod.rs
+++ b/src/drivers/net/mod.rs
@@ -2,7 +2,10 @@
 pub mod gem;
 #[cfg(all(target_arch = "x86_64", feature = "rtl8139"))]
 pub mod rtl8139;
-#[cfg(not(all(target_arch = "x86_64", feature = "rtl8139")))]
+#[cfg(not(any(
+	all(target_arch = "x86_64", feature = "rtl8139"),
+	all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")
+)))]
 pub mod virtio;
 
 use core::str::FromStr;

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -538,7 +538,7 @@ pub(crate) fn init() {
 					any(feature = "tcp", feature = "udp")
 				))]
 				Ok(VirtioDriver::Network(drv)) => {
-					register_driver(PciDriver::VirtioNet(InterruptTicketMutex::new(drv)));
+					register_driver(PciDriver::VirtioNet(InterruptTicketMutex::new(*drv)));
 				}
 				#[cfg(feature = "vsock")]
 				Ok(VirtioDriver::Vsock(drv)) => {

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -11,6 +11,7 @@ pub mod error {
 	pub use crate::drivers::fs::virtio_fs::error::VirtioFsError;
 	#[cfg(all(
 		not(all(target_arch = "x86_64", feature = "rtl8139")),
+		not(all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")),
 		any(feature = "tcp", feature = "udp")
 	))]
 	pub use crate::drivers::net::virtio::error::VirtioNetError;
@@ -33,6 +34,7 @@ pub mod error {
 		DevNotSupported(u16),
 		#[cfg(all(
 			not(all(target_arch = "x86_64", feature = "rtl8139")),
+			not(all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")),
 			any(feature = "tcp", feature = "udp")
 		))]
 		NetDriver(VirtioNetError),
@@ -88,6 +90,7 @@ pub mod error {
 				}
 				#[cfg(all(
 					not(all(target_arch = "x86_64", feature = "rtl8139")),
+					not(all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")),
 					any(feature = "tcp", feature = "udp")
 				))]
 				VirtioError::NetDriver(net_error) => match net_error {

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -16,7 +16,10 @@ use volatile::{VolatilePtr, VolatileRef};
 
 use crate::drivers::InterruptLine;
 use crate::drivers::error::DriverError;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(all(
+	not(all(target_arch = "riscv64", feature = "gem-net")),
+	any(feature = "tcp", feature = "udp")
+))]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::virtio::error::VirtioError;
 
@@ -360,7 +363,10 @@ impl IsrStatus {
 }
 
 pub(crate) enum VirtioDriver {
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(all(
+		not(all(target_arch = "riscv64", feature = "gem-net")),
+		any(feature = "tcp", feature = "udp")
+	))]
 	Network(VirtioNetDriver),
 }
 
@@ -380,7 +386,10 @@ pub(crate) fn init_device(
 
 	// Verify the device-ID to find the network card
 	match registers.as_ptr().device_id().read() {
-		#[cfg(any(feature = "tcp", feature = "udp"))]
+		#[cfg(all(
+			not(all(target_arch = "riscv64", feature = "gem-net")),
+			any(feature = "tcp", feature = "udp")
+		))]
 		virtio::Id::Net => match VirtioNetDriver::init(dev_id, registers, irq_no) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -819,7 +819,7 @@ pub(crate) fn init_device(
 				crate::arch::interrupts::add_irq_name(irq, "virtio");
 				info!("Virtio interrupt handler at line {irq}");
 
-				Ok(VirtioDriver::Network(virt_net_drv))
+				Ok(VirtioDriver::Network(Box::new(virt_net_drv)))
 			}
 			Err(virtio_error) => {
 				error!(
@@ -877,7 +877,7 @@ pub(crate) enum VirtioDriver {
 		not(all(target_arch = "x86_64", feature = "rtl8139")),
 		any(feature = "tcp", feature = "udp")
 	))]
-	Network(VirtioNetDriver),
+	Network(Box<VirtioNetDriver>),
 	#[cfg(feature = "vsock")]
 	Vsock(Box<VirtioVsockDriver>),
 	#[cfg(feature = "fuse")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,12 @@ pub mod fs;
 mod init_cell;
 pub mod io;
 pub mod mm;
+#[cfg(all(
+	not(all(target_arch = "x86_64", feature = "pci", feature = "rtl8139")),
+	not(all(target_arch = "riscv64", not(feature = "pci"), feature = "gem-net")),
+	any(feature = "tcp", feature = "udp")
+))]
+mod object_pool;
 pub mod scheduler;
 #[cfg(all(feature = "shell", target_arch = "x86_64"))]
 mod shell;

--- a/src/object_pool.rs
+++ b/src/object_pool.rs
@@ -1,0 +1,45 @@
+use alloc::vec::Vec;
+
+/// Allocator for new [`ObjectPool`] items.
+pub(crate) trait ObjectAllocator<T> {
+	/// Allocates a new object.
+	fn allocate(&self) -> T;
+}
+
+/// A generic object pool that is manually managed.
+///
+/// Objects are retrieved via [`ObjectPool::get`] and need to be manually
+/// returned via [`ObjectPool::put`]. Not returning an object is not
+/// problematic, but should usually be done to avoid re-allocating.
+pub(crate) struct ObjectPool<T, A: ObjectAllocator<T>> {
+	/// Underlying allocator that is used as a fallback source of items.
+	allocator: A,
+	/// Cache of items that were already allocated in the past and returned.
+	cache: Vec<T>,
+}
+
+impl<T, A> ObjectPool<T, A>
+where
+	A: ObjectAllocator<T>,
+{
+	/// Creates a new object pool with the given backing allocator.
+	pub fn new(allocator: A) -> Self {
+		Self {
+			allocator,
+			cache: Vec::new(),
+		}
+	}
+
+	/// Retrieve an object from the pool. This will take items from the cache
+	/// if any are available, otherwise it will allocate a new item.
+	pub fn get(&mut self) -> T {
+		self.cache
+			.pop()
+			.unwrap_or_else(|| self.allocator.allocate())
+	}
+
+	/// Returns an item back to the object pool.
+	pub(crate) fn put(&mut self, item: T) {
+		self.cache.push(item);
+	}
+}


### PR DESCRIPTION
This lets us get rid of the remaining DeviceAlloc allocations in receive_packet.