### PR TITLE
Minor enhancement of strace return value formatting

### DIFF
--- a/hermit-macro/src/system.rs
+++ b/hermit-macro/src/system.rs
@@ -116,7 +116,7 @@ fn emit_func(mut func: ItemFn, sig: &ParsedSig) -> Result<ItemFn> {
 		.map(|ident| format!("{ident} = {{:?}}"))
 		.collect::<Vec<_>>()
 		.join(", ");
-	let strace_format = format!("{}({input_format}) = ", sig.ident);
+	let strace_format = format!("{}({input_format} ", sig.ident);
 
 	let block = func.block;
 	func.block = parse_quote! {{
@@ -127,7 +127,7 @@ fn emit_func(mut func: ItemFn, sig: &ParsedSig) -> Result<ItemFn> {
 			print!(#strace_format, #(#input_idents),*);
 			let ret = #block;
 			#[cfg(feature = "strace")]
-			println!("{ret:?}");
+			println!(") = {ret:?}");
 			ret
 		}
 	}};
@@ -196,13 +196,13 @@ mod tests {
 					#[allow(clippy::diverging_sub_expression)]
 					{
 						#[cfg(feature = "strace")]
-						print!("sys_test(a = {:?}, b = {:?}) = ", a, b);
+						print!("sys_test(a = {:?}, b = {:?} ", a, b);
 						let ret = {
 							let c = i16::from(a) + b;
 							i32::from(c)
 						};
 						#[cfg(feature = "strace")]
-						println!("{ret:?}");
+						println!(") = {ret:?}");
 						ret
 					}
 				}
@@ -244,13 +244,13 @@ mod tests {
 					#[allow(clippy::diverging_sub_expression)]
 					{
 						#[cfg(feature = "strace")]
-						print!("sys_test(a = {:?}, b = {:?}) = ", a, b);
+						print!("sys_test(a = {:?}, b = {:?} ", a, b);
 						let ret = {
 							let c = i16::from(a) + b;
 							i32::from(c)
 						};
 						#[cfg(feature = "strace")]
-						println!("{ret:?}");
+						println!(") = {ret:?}");
 						ret
 					}
 				}


### PR DESCRIPTION
Probably very opinionated, but the strace output of a printf syscall looks like:

```
sys_write(fd = 1, buf = 0x1d35a90, len = 13) = hello world!
13
sys_malloc(size = 8, align = 1) = 0x400000009f80
```
At first sight, I got pretty confused what the `13` means.

This PR changes the output to, hopefully increasing the readability a little:
```
sys_write(fd = 1, buf = 0x1d35a90, len = 13) hello world!
-> 13
sys_malloc(size = 8, align = 1) -> 0x400000009f80
```