### PR TITLE
Fixed interactive console output beeing stalled until newline

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -21,13 +21,15 @@ impl Console {
 		}
 	}
 
+	/// Writes a buffer to the console.
+	/// The content is buffered until a newline is encountered or the internal buffer is full.
+	/// To force early output, use [`flush`](Self::flush).
 	pub fn write(&mut self, buf: &[u8]) {
 		if SERIAL_BUFFER_SIZE - self.buffer.len() >= buf.len() {
 			// unwrap: we checked that buf fits in self.buffer
 			self.buffer.extend_from_slice(buf).unwrap();
 			if buf.contains(&b'\n') {
-				self.inner.write(&self.buffer);
-				self.buffer.clear();
+				self.flush();
 			}
 		} else {
 			self.inner.write(&self.buffer);
@@ -38,11 +40,16 @@ impl Console {
 				// unwrap: we checked that buf fits in self.buffer
 				self.buffer.extend_from_slice(buf).unwrap();
 				if buf.contains(&b'\n') {
-					self.inner.write(&self.buffer);
-					self.buffer.clear();
+					self.flush();
 				}
 			}
 		}
+	}
+
+	/// Immediately writes everything in the internal buffer to the output.
+	pub fn flush(&mut self) {
+		self.inner.write(&self.buffer);
+		self.buffer.clear();
 	}
 
 	pub fn read(&mut self) -> Option<u8> {

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -41,9 +41,11 @@ impl ObjectInterface for GenericStdin {
 				read_bytes += 1;
 
 				if read_bytes >= buf.len() {
+					guard.flush();
 					return Poll::Ready(Ok(read_bytes));
 				}
 			}
+			guard.flush();
 
 			if read_bytes > 0 {
 				Poll::Ready(Ok(read_bytes))


### PR DESCRIPTION
The console currently doesn't echo any characters entered until a newline, which makes interactive prompts a little hard to use.


Side note:
![image](https://github.com/user-attachments/assets/6b463ae1-9cda-437e-a84e-b4f1b42781a0)
