### PR TITLE
Fuse Lseek: Don't panic on negative offset

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -234,7 +234,7 @@ pub(crate) mod ops {
 				nid,
 				fuse_lseek_in {
 					fh,
-					offset: offset.try_into().unwrap(),
+					offset: i64::try_from(offset).unwrap() as u64,
 					whence: num::ToPrimitive::to_u32(&whence).unwrap(),
 					..Default::default()
 				},


### PR DESCRIPTION
A C application crashed on negative offsets.

In Linux, this field [is clearly defined as an `uint64_t`](https://github.com/torvalds/linux/blob/e04c78d86a9699d136910cfc0bdcf01087e3267e/include/uapi/linux/fuse.h#L1132), but I'm not sure if this is just the interface definition, or something fixed.

Unfortunately, I couldn't find any documentation on this. What I found was:
- https://man7.org/linux/man-pages/man4/fuse.4.html -> `FUSE_LSEEK` is not documented yet :-/
- libfuse uses `off_t` for all things offset https://libfuse.github.io/doxygen/structfuse__operations.html which is specified [as a _signed_ integer](https://man7.org/linux/man-pages/man3/off_t.3type.html)

So I don't know if this is correct or not, but maybe someone else knows more (@stlankes)