### PR TITLE
Fuse lseek fix

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -713,6 +713,7 @@ impl FuseFileHandleInner {
 			}
 
 			let rsp_offset = rsp.headers.op_header.offset;
+			self.offset = rsp.headers.op_header.offset.try_into().unwrap();
 
 			Ok(rsp_offset.try_into().unwrap())
 		} else {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -543,8 +543,7 @@ pub extern "C" fn sys_fcntl(fd: i32, cmd: i32, arg: i32) -> i32 {
 pub extern "C" fn sys_lseek(fd: FileDescriptor, offset: isize, whence: i32) -> isize {
 	let whence = u8::try_from(whence).unwrap();
 	let whence = SeekWhence::try_from(whence).unwrap();
-	crate::fd::lseek(fd, offset, whence)
-		.map_or_else(|e| isize::try_from(-i32::from(e)).unwrap(), |_| 0)
+	crate::fd::lseek(fd, offset, whence).unwrap_or_else(|e| isize::try_from(-i32::from(e)).unwrap())
 }
 
 #[repr(C)]


### PR DESCRIPTION
Fixes: https://github.com/hermit-os/kernel/issues/1768

Previously, lseek has not updated the internal offset.

Moreover, any successful call to lseek has returned 0. [POSIX states](https://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html) that _Upon successful completion, the resulting offset, as measured in bytes from the beginning of the file, shall be returned. Otherwise, -1 shall be returned, errno shall be set to indicate the error, and the file offset shall remain unchanged._
I think, we can omit the part with the errno and keep using negative numbers to encode an error, but returning the correct file offset seems to be an improvement. (However, in theory, this is a breaking ABI change, but it is very unlikely that any code relies on the current behaviour).