### PR TITLE
timespec: use i64 for tv_nsec as in POSIX

### DIFF
--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -431,15 +431,15 @@ impl From<fuse_attr> for FileAttr {
 			st_blocks: attr.blocks.try_into().unwrap(),
 			st_atim: timespec {
 				tv_sec: attr.atime as time_t,
-				tv_nsec: attr.atimensec as i32,
+				tv_nsec: i64::from(attr.atimensec),
 			},
 			st_mtim: timespec {
 				tv_sec: attr.mtime as time_t,
-				tv_nsec: attr.mtimensec as i32,
+				tv_nsec: i64::from(attr.mtimensec),
 			},
 			st_ctim: timespec {
 				tv_sec: attr.ctime as time_t,
-				tv_nsec: attr.ctimensec as i32,
+				tv_nsec: i64::from(attr.ctimensec),
 			},
 			..Default::default()
 		}

--- a/src/syscalls/semaphore.rs
+++ b/src/syscalls/semaphore.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn sys_sem_timedwait(sem: *mut sem_t, ts: *const timespec)
 
 			let ts = &*ts;
 			let ms: i64 = (ts.tv_sec - current_ts.tv_sec) * 1000
-				+ (i64::from(ts.tv_nsec) - i64::from(current_ts.tv_nsec)) / 1_000_000;
+				+ (ts.tv_nsec - current_ts.tv_nsec) / 1_000_000;
 
 			if ms > 0 {
 				sem_timedwait(sem, ms.try_into().unwrap())

--- a/src/time.rs
+++ b/src/time.rs
@@ -51,21 +51,21 @@ pub struct timespec {
 	/// seconds
 	pub tv_sec: time_t,
 	/// nanoseconds
-	pub tv_nsec: i32,
+	pub tv_nsec: i64,
 }
 
 impl timespec {
 	pub fn from_usec(microseconds: i64) -> Self {
 		Self {
 			tv_sec: (microseconds / 1_000_000),
-			tv_nsec: ((microseconds % 1_000_000) * 1000) as i32,
+			tv_nsec: ((microseconds % 1_000_000) * 1000),
 		}
 	}
 
 	pub fn into_usec(&self) -> Option<i64> {
 		self.tv_sec
 			.checked_mul(1_000_000)
-			.and_then(|usec| usec.checked_add((self.tv_nsec / 1000).into()))
+			.and_then(|usec| usec.checked_add(self.tv_nsec / 1000))
 	}
 }
 


### PR DESCRIPTION
Reference: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/time.h.html

> The <time.h> header shall declare the timespec structure, which shall include at least the following members:
> ```
> time_t  tv_sec    Whole seconds.
> long    tv_nsec   Nanoseconds [0, 999999999].
> ```

Without this fix, we observed funny time measurements using newlib.
