### PR TITLE
fix(virtio): allow exact buffer size in send_packet

### DIFF
--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -273,7 +273,7 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 		// what we are about to add
 		self.inner.send_vqs.poll();
 
-		assert!(len < usize::try_from(self.inner.send_vqs.buf_size).unwrap());
+		assert!(len <= usize::try_from(self.inner.send_vqs.buf_size).unwrap());
 		let mut packet = Vec::with_capacity_in(len, DeviceAlloc);
 		let result = unsafe {
 			let result = f(packet.spare_capacity_mut().assume_init_mut());


### PR DESCRIPTION
The assert in the `send_packet` function for the length of the buffer, only allowed buffers which were larger than the message. I think we should allow exactly sized buffers.