### PR TITLE
add support of virtio console according to the VirtIO standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,10 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package stdin qemu
         if: matrix.arch == 'x86_64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package stdin --features hermit/console qemu --devices virtio-console-pci
+        if: matrix.arch != 'riscv64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package stdin --features hermit/console --no-default-features qemu --devices virtio-console-mmio
+        if: matrix.arch != 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package rusty_demo --features fs qemu ${{ matrix.flags }} --devices virtio-fs-pci
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} --package rusty_demo --features fs --smp 4 qemu ${{ matrix.flags }} --devices virtio-fs-pci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ harness = false
 default = ["pci", "pci-ids", "acpi", "fsgsbase", "smp", "tcp", "dhcpv4", "fuse", "vsock"]
 acpi = []
 common-os = []
+console = []
 dhcpv4 = ["smoltcp", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]
 dns = ["smoltcp", "smoltcp/socket-dns"]
 fs = ["fuse"]

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -10,7 +10,11 @@ use volatile::VolatileRef;
 use crate::arch::aarch64::kernel::interrupts::GIC;
 use crate::arch::aarch64::mm::paging::{self, PageSize};
 #[cfg(feature = "console")]
+use crate::console::IoDevice;
+#[cfg(feature = "console")]
 use crate::drivers::console::VirtioConsoleDriver;
+#[cfg(feature = "console")]
+use crate::drivers::console::VirtioUART;
 #[cfg(any(feature = "tcp", feature = "udp"))]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::virtio::transport::mmio::{self as mmio_virtio, VirtioDriver};
@@ -237,8 +241,7 @@ pub fn init_drivers() {
 			info!("Switch to virtio console");
 			crate::console::CONSOLE
 				.lock()
-				.inner
-				.switch_to_virtio_console();
+				.replace_device(IoDevice::Virtio(VirtioUART::new()));
 		}
 	}
 }

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -1,6 +1,9 @@
 pub mod core_local;
 pub mod interrupts;
-#[cfg(all(not(feature = "pci"), any(feature = "tcp", feature = "udp")))]
+#[cfg(all(
+	not(feature = "pci"),
+	any(feature = "tcp", feature = "udp", feature = "console")
+))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;
@@ -39,10 +42,7 @@ impl Console {
 		let base = env::boot_info()
 			.hardware_info
 			.serial_port_base
-			.map(|uartport| uartport.get())
-			.unwrap_or_default()
-			.try_into()
-			.unwrap();
+			.map(|uartport| uartport.get());
 
 		let serial_port = SerialPort::new(base);
 
@@ -61,6 +61,11 @@ impl Console {
 
 	pub fn is_empty(&self) -> bool {
 		true
+	}
+
+	#[cfg(feature = "console")]
+	pub fn switch_to_virtio_console(&mut self) {
+		self.serial_port.switch_to_virtio_console();
 	}
 
 	pub fn register_waker(&mut self, _waker: &Waker) {}

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -18,64 +18,14 @@ pub mod systemtime;
 use alloc::alloc::{Layout, alloc};
 use core::arch::global_asm;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
-use core::task::Waker;
 use core::{ptr, str};
 
 use memory_addresses::arch::aarch64::{PhysAddr, VirtAddr};
 
 use crate::arch::aarch64::kernel::core_local::*;
-use crate::arch::aarch64::kernel::serial::SerialPort;
 use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
 use crate::config::*;
 use crate::env;
-
-const SERIAL_PORT_BAUDRATE: u32 = 115_200;
-
-pub(crate) struct Console {
-	serial_port: SerialPort,
-}
-
-impl Console {
-	pub fn new() -> Self {
-		CoreLocal::install();
-
-		let base = env::boot_info()
-			.hardware_info
-			.serial_port_base
-			.map(|uartport| uartport.get());
-
-		let serial_port = SerialPort::new(base);
-
-		serial_port.init(SERIAL_PORT_BAUDRATE);
-
-		Self { serial_port }
-	}
-
-	pub fn write(&mut self, buf: &[u8]) {
-		self.serial_port.write_buf(buf);
-	}
-
-	pub fn read(&mut self) -> Option<u8> {
-		None
-	}
-
-	pub fn is_empty(&self) -> bool {
-		true
-	}
-
-	#[cfg(feature = "console")]
-	pub fn switch_to_virtio_console(&mut self) {
-		self.serial_port.switch_to_virtio_console();
-	}
-
-	pub fn register_waker(&mut self, _waker: &Waker) {}
-}
-
-impl Default for Console {
-	fn default() -> Self {
-		Self::new()
-	}
-}
 
 #[repr(align(8))]
 pub(crate) struct AlignedAtomicU32(AtomicU32);

--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -1,88 +1,52 @@
 use core::arch::asm;
+use core::mem::MaybeUninit;
 
-#[cfg(all(feature = "pci", feature = "console"))]
-use crate::drivers::pci::get_console_driver;
-#[cfg(all(not(feature = "pci"), feature = "console"))]
-use crate::kernel::mmio::get_console_driver;
-use crate::syscalls::interfaces::serial_buf_hypercall;
-
-enum SerialInner {
-	None,
-	Uart(u32),
-	Uhyve,
-	#[cfg(feature = "console")]
-	Virtio,
+pub(crate) struct SerialDevice {
+	pub addr: u32,
 }
 
-pub struct SerialPort {
-	inner: SerialInner,
-}
+impl SerialDevice {
+	pub fn new() -> Self {
+		let base = crate::env::boot_info()
+			.hardware_info
+			.serial_port_base
+			.map(|uartport| uartport.get())
+			.unwrap();
 
-impl SerialPort {
-	pub fn new(port_address: Option<u64>) -> Self {
-		if crate::env::is_uhyve() {
-			Self {
-				inner: SerialInner::Uhyve,
+		Self { addr: base as u32 }
+	}
+
+	pub fn write(&self, buf: &[u8]) {
+		let port = core::ptr::with_exposed_provenance_mut::<u8>(self.addr as usize);
+		for &byte in buf {
+			// LF newline characters need to be extended to CRLF over a real serial port.
+			if byte == b'\n' {
+				unsafe {
+					asm!(
+						"strb w8, [{port}]",
+						port = in(reg) port,
+						in("x8") b'\r',
+						options(nostack),
+					);
+				}
 			}
-		} else if let Some(port_address) = port_address {
-			Self {
-				inner: SerialInner::Uart(port_address.try_into().unwrap()),
-			}
-		} else {
-			Self {
-				inner: SerialInner::None,
+
+			unsafe {
+				asm!(
+					"strb w8, [{port}]",
+					port = in(reg) port,
+					in("x8") byte,
+					options(nostack),
+				);
 			}
 		}
 	}
 
-	#[cfg(feature = "console")]
-	pub fn switch_to_virtio_console(&mut self) {
-		self.inner = SerialInner::Virtio;
+	pub fn read(&self, _buf: &mut [MaybeUninit<u8>]) -> crate::io::Result<usize> {
+		Ok(0)
 	}
 
-	pub fn write_buf(&mut self, buf: &[u8]) {
-		match &mut self.inner {
-			SerialInner::None => {
-				// No serial port configured, do nothing.
-			}
-			SerialInner::Uhyve => {
-				serial_buf_hypercall(buf);
-			}
-			SerialInner::Uart(port_address) => {
-				let port = core::ptr::with_exposed_provenance_mut::<u8>(*port_address as usize);
-				for &byte in buf {
-					// LF newline characters need to be extended to CRLF over a real serial port.
-					if byte == b'\n' {
-						unsafe {
-							asm!(
-								"strb w8, [{port}]",
-								port = in(reg) port,
-								in("x8") b'\r',
-								options(nostack),
-							);
-						}
-					}
-
-					unsafe {
-						asm!(
-							"strb w8, [{port}]",
-							port = in(reg) port,
-							in("x8") byte,
-							options(nostack),
-						);
-					}
-				}
-			}
-			#[cfg(feature = "console")]
-			SerialInner::Virtio => {
-				if let Some(console_driver) = get_console_driver() {
-					let _ = console_driver.lock().write(buf);
-				}
-			}
-		}
-	}
-
-	pub fn init(&self, _baudrate: u32) {
-		// We don't do anything here (yet).
+	pub fn can_read(&self) -> bool {
+		false
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -13,6 +13,7 @@ cfg_if::cfg_if! {
 		#[cfg(feature = "pci")]
 		pub(crate) use self::aarch64::kernel::pci;
 		pub(crate) use self::aarch64::kernel::processor;
+		pub(crate) use self::aarch64::kernel::serial::SerialDevice;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 		pub(crate) use self::aarch64::kernel::scheduler;
 		#[cfg(not(feature = "common-os"))]
@@ -39,6 +40,7 @@ cfg_if::cfg_if! {
 		#[cfg(feature = "pci")]
 		pub(crate) use self::x86_64::kernel::pci;
 		pub(crate) use self::x86_64::kernel::processor;
+		pub(crate) use self::x86_64::kernel::serial::SerialDevice;
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(target_os = "none")]
@@ -60,6 +62,7 @@ cfg_if::cfg_if! {
 		#[cfg(feature = "pci")]
 		pub(crate) use self::riscv64::kernel::pci;
 		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
+		pub(crate) use self::riscv64::kernel::serial::SerialDevice;
 		pub(crate) use self::riscv64::kernel::{
 			boot_processor_init,
 			core_local,

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
 use core::ptr::NonNull;
 
@@ -216,6 +218,7 @@ pub fn init_drivers() {
 				// Verify the device-ID to find the network card
 				let id = mmio.as_ptr().device_id().read();
 
+				#[cfg(any(feature = "tcp", feature = "udp"))]
 				if id != virtio::Id::Net {
 					debug!("It's not a network card at {mmio:p}");
 					return;

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -1,39 +1,62 @@
 #![allow(dead_code)]
 
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 use core::ptr::NonNull;
 
 use fdt::Fdt;
 use memory_addresses::PhysAddr;
 #[cfg(all(
-	any(feature = "tcp", feature = "udp"),
+	any(feature = "tcp", feature = "udp", feature = "console"),
 	feature = "gem-net",
 	not(feature = "pci")
 ))]
 use memory_addresses::VirtAddr;
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 use volatile::VolatileRef;
 
 use crate::arch::riscv64::kernel::get_dtb_ptr;
 use crate::arch::riscv64::kernel::interrupts::init_plic;
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 use crate::arch::riscv64::kernel::mmio::MmioDriver;
 use crate::arch::riscv64::mm::paging::{self, PageSize};
+#[cfg(feature = "console")]
+use crate::console::IoDevice;
+#[cfg(feature = "console")]
+use crate::drivers::console::VirtioUART;
+#[cfg(all(feature = "console", not(feature = "pci")))]
+use crate::drivers::mmio::get_console_driver;
 #[cfg(all(
 	any(feature = "tcp", feature = "udp"),
 	feature = "gem-net",
 	not(feature = "pci")
 ))]
 use crate::drivers::net::gem;
+#[cfg(all(feature = "console", feature = "pci"))]
+use crate::drivers::pci::get_console_driver;
 #[cfg(all(
-	any(feature = "tcp", feature = "udp"),
+	any(feature = "tcp", feature = "udp", feature = "console"),
 	not(feature = "pci"),
 	not(feature = "gem-net")
 ))]
 use crate::drivers::virtio::transport::mmio::{self as mmio_virtio, VirtioDriver};
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 use crate::kernel::mmio::register_driver;
 
 static mut PLATFORM_MODEL: Model = Model::Unknown;
@@ -172,7 +195,10 @@ pub fn init_drivers() {
 			}
 
 			// Init virtio-mmio
-			#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+			#[cfg(all(
+				any(feature = "tcp", feature = "udp", feature = "console"),
+				not(feature = "pci")
+			))]
 			if let Some(virtio_node) = fdt.find_compatible(&["virtio,mmio"]) {
 				debug!("Found virtio mmio device");
 				let virtio_region = virtio_node
@@ -218,31 +244,57 @@ pub fn init_drivers() {
 				// Verify the device-ID to find the network card
 				let id = mmio.as_ptr().device_id().read();
 
-				#[cfg(any(feature = "tcp", feature = "udp"))]
-				if id != virtio::Id::Net {
-					debug!("It's not a network card at {mmio:p}");
-					return;
-				}
-
-				info!("Found network card at {mmio:p}");
-
 				// crate::mm::physicalmem::reserve(
 				// 	PhysAddr::from(current_address.align_down(BasePageSize::SIZE as usize)),
 				// 	BasePageSize::SIZE as usize,
 				// );
 
-				#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "gem-net")))]
-				if let Ok(VirtioDriver::Network(drv)) =
-					mmio_virtio::init_device(mmio, irq.try_into().unwrap())
-				{
-					register_driver(MmioDriver::VirtioNet(hermit_sync::InterruptSpinMutex::new(
-						drv,
-					)));
+				match id {
+					#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "gem-net")))]
+					virtio::Id::Net => {
+						debug!("Found virtio network card at {mmio:p}");
+
+						if let Ok(VirtioDriver::Network(drv)) =
+							mmio_virtio::init_device(mmio, irq.try_into().unwrap())
+						{
+							register_driver(MmioDriver::VirtioNet(
+								hermit_sync::InterruptSpinMutex::new(drv),
+							));
+						}
+					}
+					#[cfg(feature = "console")]
+					virtio::Id::Console => {
+						debug!("Found virtio console at {mmio:p}");
+
+						if let Ok(VirtioDriver::Console(drv)) =
+							mmio_virtio::init_device(mmio, irq.try_into().unwrap())
+						{
+							register_driver(MmioDriver::VirtioConsole(
+								hermit_sync::InterruptSpinMutex::new(*drv),
+							));
+						}
+					}
+					_ => {
+						warn!("Found unknown virtio device with ID {id:?} at {mmio:p}");
+					}
 				}
 			}
 		}
 	}
 
-	#[cfg(all(feature = "tcp", not(feature = "pci")))]
+	#[cfg(all(
+		any(feature = "tcp", feature = "udp", feature = "console"),
+		not(feature = "pci")
+	))]
 	super::mmio::MMIO_DRIVERS.finalize();
+
+	#[cfg(feature = "console")]
+	{
+		if get_console_driver().is_some() {
+			info!("Switch to virtio console");
+			crate::console::CONSOLE
+				.lock()
+				.replace_device(IoDevice::Virtio(VirtioUART::new()));
+		}
+	}
 }

--- a/src/arch/riscv64/kernel/mmio.rs
+++ b/src/arch/riscv64/kernel/mmio.rs
@@ -1,10 +1,14 @@
+#![allow(dead_code)]
+
 use alloc::vec::Vec;
 
 use hermit_sync::InterruptSpinMutex;
 
+#[cfg(feature = "console")]
+use crate::drivers::console::VirtioConsoleDriver;
 #[cfg(feature = "gem-net")]
 use crate::drivers::net::gem::GEMDriver;
-#[cfg(not(feature = "gem-net"))]
+#[cfg(all(not(feature = "gem-net"), any(feature = "tcp", feature = "udp")))]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::init_cell::InitCell;
 
@@ -13,25 +17,41 @@ pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::n
 pub(crate) enum MmioDriver {
 	#[cfg(feature = "gem-net")]
 	GEMNet(InterruptSpinMutex<GEMDriver>),
-	#[cfg(not(feature = "gem-net"))]
+	#[cfg(all(not(feature = "gem-net"), any(feature = "tcp", feature = "udp")))]
 	VirtioNet(InterruptSpinMutex<VirtioNetDriver>),
+	#[cfg(feature = "console")]
+	VirtioConsole(InterruptSpinMutex<VirtioConsoleDriver>),
 }
 
 impl MmioDriver {
+	#[allow(unreachable_patterns)]
 	#[cfg(feature = "gem-net")]
 	fn get_network_driver(&self) -> Option<&InterruptSpinMutex<GEMDriver>> {
 		match self {
 			Self::GEMNet(drv) => Some(drv),
+			_ => None,
 		}
 	}
 
-	#[cfg(not(feature = "gem-net"))]
+	#[allow(unreachable_patterns)]
+	#[cfg(all(not(feature = "gem-net"), any(feature = "tcp", feature = "udp")))]
 	fn get_network_driver(&self) -> Option<&InterruptSpinMutex<VirtioNetDriver>> {
 		match self {
 			Self::VirtioNet(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
+	#[cfg(feature = "console")]
+	fn get_console_driver(&self) -> Option<&InterruptSpinMutex<VirtioConsoleDriver>> {
+		match self {
+			Self::VirtioConsole(drv) => Some(drv),
+			#[cfg(any(feature = "tcp", feature = "udp"))]
+			_ => None,
 		}
 	}
 }
+
 pub(crate) fn register_driver(drv: MmioDriver) {
 	MMIO_DRIVERS.with(|mmio_drivers| mmio_drivers.unwrap().push(drv));
 }
@@ -44,10 +64,18 @@ pub(crate) fn get_network_driver() -> Option<&'static InterruptSpinMutex<GEMDriv
 		.find_map(|drv| drv.get_network_driver())
 }
 
-#[cfg(not(feature = "gem-net"))]
+#[cfg(all(not(feature = "gem-net"), any(feature = "tcp", feature = "udp")))]
 pub(crate) fn get_network_driver() -> Option<&'static InterruptSpinMutex<VirtioNetDriver>> {
 	MMIO_DRIVERS
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_network_driver())
+}
+
+#[cfg(feature = "console")]
+pub(crate) fn get_console_driver() -> Option<&'static InterruptSpinMutex<VirtioConsoleDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_console_driver())
 }

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -1,7 +1,10 @@
 pub mod core_local;
 mod devicetree;
 pub mod interrupts;
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(all(
+	any(feature = "tcp", feature = "udp", feature = "console"),
+	not(feature = "pci")
+))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;
@@ -52,6 +55,9 @@ impl Console {
 	}
 
 	pub fn register_waker(&mut self, _waker: &Waker) {}
+
+	#[allow(dead_code)]
+	pub fn switch_to_virtio_console(&mut self) {}
 }
 
 impl Default for Console {

--- a/src/arch/riscv64/kernel/serial.rs
+++ b/src/arch/riscv64/kernel/serial.rs
@@ -1,0 +1,23 @@
+use core::mem::MaybeUninit;
+
+pub(crate) struct SerialDevice;
+
+impl SerialDevice {
+	pub fn new() -> Self {
+		Self {}
+	}
+
+	pub fn write(&self, buf: &[u8]) {
+		for byte in buf {
+			sbi_rt::console_write_byte(*byte);
+		}
+	}
+
+	pub fn read(&self, _buf: &mut [MaybeUninit<u8>]) -> crate::io::Result<usize> {
+		Ok(0)
+	}
+
+	pub fn can_read(&self) -> bool {
+		false
+	}
+}

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -18,7 +18,10 @@ pub mod apic;
 pub mod core_local;
 pub mod gdt;
 pub mod interrupts;
-#[cfg(all(not(feature = "pci"), any(feature = "tcp", feature = "udp")))]
+#[cfg(all(
+	not(feature = "pci"),
+	any(feature = "console", feature = "tcp", feature = "udp")
+))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;
@@ -78,6 +81,11 @@ impl Console {
 
 	pub fn register_waker(&mut self, waker: &Waker) {
 		self.serial_port.register_waker(waker);
+	}
+
+	#[cfg(all(feature = "pci", feature = "console"))]
+	pub fn switch_to_virtio_console(&mut self) {
+		self.serial_port.switch_to_virtio_console();
 	}
 }
 

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -4,6 +4,8 @@ use core::task::Waker;
 use crate::arch::x86_64::kernel::apic;
 use crate::arch::x86_64::kernel::core_local::increment_irq_counter;
 use crate::arch::x86_64::kernel::interrupts::{self, IDT};
+#[cfg(all(feature = "pci", feature = "console"))]
+use crate::drivers::pci::get_console_driver;
 use crate::executor::WakerRegistration;
 use crate::syscalls::interfaces::serial_buf_hypercall;
 
@@ -12,6 +14,8 @@ const SERIAL_IRQ: u8 = 36;
 enum SerialInner {
 	Uart(uart_16550::SerialPort),
 	Uhyve,
+	#[cfg(all(feature = "console", feature = "pci"))]
+	Virtio,
 }
 
 pub struct SerialPort {
@@ -71,7 +75,18 @@ impl SerialPort {
 					s.send(data);
 				}
 			}
+			#[cfg(all(feature = "console", feature = "pci"))]
+			SerialInner::Virtio => {
+				if let Some(console_driver) = get_console_driver() {
+					let _ = console_driver.lock().write(buf);
+				}
+			}
 		}
+	}
+
+	#[cfg(all(feature = "pci", feature = "console"))]
+	pub fn switch_to_virtio_console(&mut self) {
+		self.inner = SerialInner::Virtio;
 	}
 }
 

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -1,109 +1,87 @@
 use alloc::collections::VecDeque;
-use core::task::Waker;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
-use crate::arch::x86_64::kernel::apic;
-use crate::arch::x86_64::kernel::core_local::increment_irq_counter;
-use crate::arch::x86_64::kernel::interrupts::{self, IDT};
-#[cfg(all(feature = "pci", feature = "console"))]
-use crate::drivers::pci::get_console_driver;
-use crate::executor::WakerRegistration;
-use crate::syscalls::interfaces::serial_buf_hypercall;
+use hermit_sync::{InterruptTicketMutex, Lazy};
 
-const SERIAL_IRQ: u8 = 36;
+#[cfg(feature = "pci")]
+use crate::arch::x86_64::kernel::interrupts;
+#[cfg(feature = "pci")]
+use crate::drivers::InterruptLine;
 
-enum SerialInner {
-	Uart(uart_16550::SerialPort),
-	Uhyve,
-	#[cfg(all(feature = "console", feature = "pci"))]
-	Virtio,
+#[cfg(feature = "pci")]
+const SERIAL_IRQ: u8 = 4;
+
+static UART_DEVICE: Lazy<InterruptTicketMutex<UartDevice>> =
+	Lazy::new(|| unsafe { InterruptTicketMutex::new(UartDevice::new()) });
+
+struct UartDevice {
+	pub uart: uart_16550::SerialPort,
+	pub buffer: VecDeque<u8>,
 }
 
-pub struct SerialPort {
-	inner: SerialInner,
-	buffer: VecDeque<u8>,
-	waker: WakerRegistration,
+impl UartDevice {
+	pub unsafe fn new() -> Self {
+		let base = crate::env::boot_info()
+			.hardware_info
+			.serial_port_base
+			.unwrap()
+			.get();
+		let mut uart = unsafe { uart_16550::SerialPort::new(base) };
+		uart.init();
+
+		Self {
+			uart,
+			buffer: VecDeque::new(),
+		}
+	}
 }
 
-impl SerialPort {
-	pub unsafe fn new(base: u16) -> Self {
-		if crate::env::is_uhyve() {
-			Self {
-				inner: SerialInner::Uhyve,
-				buffer: VecDeque::new(),
-				waker: WakerRegistration::new(),
-			}
+pub(crate) struct SerialDevice;
+
+impl SerialDevice {
+	pub fn new() -> Self {
+		Self {}
+	}
+
+	pub fn write(&self, buf: &[u8]) {
+		let mut guard = UART_DEVICE.lock();
+
+		for &data in buf {
+			guard.uart.send(data);
+		}
+	}
+
+	pub fn read(&self, buf: &mut [MaybeUninit<u8>]) -> crate::io::Result<usize> {
+		let mut guard = UART_DEVICE.lock();
+		if guard.buffer.is_empty() {
+			Ok(0)
 		} else {
-			let mut serial = unsafe { uart_16550::SerialPort::new(base) };
-			serial.init();
-			Self {
-				inner: SerialInner::Uart(serial),
-				buffer: VecDeque::new(),
-				waker: WakerRegistration::new(),
-			}
+			let min = core::cmp::min(buf.len(), guard.buffer.len());
+			let drained = guard.buffer.drain(..min).collect::<Vec<_>>();
+			buf[..min].write_copy_of_slice(drained.as_slice());
+			Ok(min)
 		}
 	}
 
-	pub fn buffer_input(&mut self) {
-		if let SerialInner::Uart(s) = &mut self.inner {
-			let c = s.receive();
-			if c == b'\r' {
-				self.buffer.push_back(b'\n');
-			} else {
-				self.buffer.push_back(c);
-			}
-			self.waker.wake();
-		}
-	}
-
-	pub fn register_waker(&mut self, waker: &Waker) {
-		self.waker.register(waker);
-	}
-
-	pub fn read(&mut self) -> Option<u8> {
-		self.buffer.pop_front()
-	}
-
-	pub fn is_empty(&self) -> bool {
-		self.buffer.is_empty()
-	}
-
-	pub fn send(&mut self, buf: &[u8]) {
-		match &mut self.inner {
-			SerialInner::Uhyve => serial_buf_hypercall(buf),
-			SerialInner::Uart(s) => {
-				for &data in buf {
-					s.send(data);
-				}
-			}
-			#[cfg(all(feature = "console", feature = "pci"))]
-			SerialInner::Virtio => {
-				if let Some(console_driver) = get_console_driver() {
-					let _ = console_driver.lock().write(buf);
-				}
-			}
-		}
-	}
-
-	#[cfg(all(feature = "pci", feature = "console"))]
-	pub fn switch_to_virtio_console(&mut self) {
-		self.inner = SerialInner::Virtio;
+	pub fn can_read(&self) -> bool {
+		!UART_DEVICE.lock().buffer.is_empty()
 	}
 }
 
-extern "x86-interrupt" fn serial_interrupt(_stack_frame: crate::interrupts::ExceptionStackFrame) {
-	crate::console::CONSOLE.lock().inner.buffer_input();
-	increment_irq_counter(SERIAL_IRQ);
-	crate::executor::run();
+#[cfg(feature = "pci")]
+pub(crate) fn get_serial_handler() -> (InterruptLine, fn()) {
+	fn serial_handler() {
+		let mut guard = UART_DEVICE.lock();
+		if let Ok(c) = guard.uart.try_receive() {
+			guard.buffer.push_back(c);
+		}
 
-	apic::eoi();
-}
-
-pub(crate) fn install_serial_interrupt() {
-	unsafe {
-		let mut idt = IDT.lock();
-		idt[SERIAL_IRQ]
-			.set_handler_fn(serial_interrupt)
-			.set_stack_index(0);
+		drop(guard);
+		crate::console::CONSOLE_WAKER.lock().wake();
 	}
-	interrupts::add_irq_name(SERIAL_IRQ - 32, "COM1");
+
+	interrupts::add_irq_name(SERIAL_IRQ, "COM1");
+
+	(SERIAL_IRQ, serial_handler)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,4 +20,4 @@ pub(crate) const DEFAULT_KEEP_ALIVE_INTERVAL: u64 = 75000;
 pub(crate) const VSOCK_PACKET_SIZE: u32 = 8192;
 
 #[cfg(feature = "console")]
-pub(crate) const CONSOLE_PACKET_SIZE: u32 = 1024;
+pub(crate) const CONSOLE_PACKET_SIZE: u32 = 8192;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,8 @@ pub(crate) const USER_STACK_SIZE: usize = 0x0010_0000;
 #[cfg(any(
 	all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 	feature = "fuse",
-	feature = "vsock"
+	feature = "vsock",
+	feature = "console"
 ))]
 pub(crate) const VIRTIO_MAX_QUEUE_SIZE: u16 = if cfg!(feature = "pci") { 2048 } else { 1024 };
 
@@ -17,3 +18,6 @@ pub(crate) const DEFAULT_KEEP_ALIVE_INTERVAL: u64 = 75000;
 
 #[cfg(feature = "vsock")]
 pub(crate) const VSOCK_PACKET_SIZE: u32 = 8192;
+
+#[cfg(feature = "console")]
+pub(crate) const CONSOLE_PACKET_SIZE: u32 = 1024;

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,22 +1,99 @@
-use core::task::Waker;
+#![allow(dead_code)]
+
+use core::mem::MaybeUninit;
 use core::{fmt, mem};
 
 use heapless::Vec;
 use hermit_sync::{InterruptTicketMutex, Lazy};
 
-use crate::arch;
+use crate::arch::SerialDevice;
+#[cfg(feature = "console")]
+use crate::drivers::console::VirtioUART;
+use crate::executor::WakerRegistration;
+use crate::io;
+#[cfg(not(target_arch = "riscv64"))]
+use crate::syscalls::interfaces::serial_buf_hypercall;
 
 const SERIAL_BUFFER_SIZE: usize = 256;
 
+pub(crate) enum IoDevice {
+	#[cfg(not(target_arch = "riscv64"))]
+	Uhyve(UhyveSerial),
+	Uart(SerialDevice),
+	#[cfg(feature = "console")]
+	Virtio(VirtioUART),
+}
+
+impl IoDevice {
+	pub fn write(&self, buf: &[u8]) {
+		match self {
+			#[cfg(not(target_arch = "riscv64"))]
+			IoDevice::Uhyve(s) => s.write(buf),
+			IoDevice::Uart(s) => s.write(buf),
+			#[cfg(feature = "console")]
+			IoDevice::Virtio(s) => s.write(buf),
+		}
+
+		#[cfg(all(target_arch = "x86_64", feature = "vga"))]
+		for &byte in buf {
+			// vga::write_byte() checks if VGA support has been initialized,
+			// so we don't need any additional if clause around it.
+			crate::arch::kernel::vga::write_byte(byte);
+		}
+	}
+
+	pub fn read(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		match self {
+			#[cfg(not(target_arch = "riscv64"))]
+			IoDevice::Uhyve(s) => s.read(buf),
+			IoDevice::Uart(s) => s.read(buf),
+			#[cfg(feature = "console")]
+			IoDevice::Virtio(s) => s.read(buf),
+		}
+	}
+
+	pub fn can_read(&self) -> bool {
+		match self {
+			#[cfg(not(target_arch = "riscv64"))]
+			IoDevice::Uhyve(s) => s.can_read(),
+			IoDevice::Uart(s) => s.can_read(),
+			#[cfg(feature = "console")]
+			IoDevice::Virtio(s) => s.can_read(),
+		}
+	}
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+pub(crate) struct UhyveSerial;
+
+#[cfg(not(target_arch = "riscv64"))]
+impl UhyveSerial {
+	pub const fn new() -> Self {
+		Self {}
+	}
+
+	pub fn write(&self, buf: &[u8]) {
+		serial_buf_hypercall(buf);
+	}
+
+	pub fn read(&self, _buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		Ok(0)
+	}
+
+	pub fn can_read(&self) -> bool {
+		false
+	}
+}
+
 pub(crate) struct Console {
-	pub inner: arch::kernel::Console,
+	device: IoDevice,
 	buffer: Vec<u8, SERIAL_BUFFER_SIZE>,
 }
 
 impl Console {
-	fn new() -> Self {
+	pub fn new(device: IoDevice) -> Self {
 		Self {
-			inner: arch::kernel::Console::new(),
+			device,
 			buffer: Vec::new(),
 		}
 	}
@@ -32,10 +109,10 @@ impl Console {
 				self.flush();
 			}
 		} else {
-			self.inner.write(&self.buffer);
+			self.device.write(&self.buffer);
 			self.buffer.clear();
 			if buf.len() >= SERIAL_BUFFER_SIZE {
-				self.inner.write(buf);
+				self.device.write(buf);
 			} else {
 				// unwrap: we checked that buf fits in self.buffer
 				self.buffer.extend_from_slice(buf).unwrap();
@@ -48,20 +125,23 @@ impl Console {
 
 	/// Immediately writes everything in the internal buffer to the output.
 	pub fn flush(&mut self) {
-		self.inner.write(&self.buffer);
-		self.buffer.clear();
+		if !self.buffer.is_empty() {
+			self.device.write(&self.buffer);
+			self.buffer.clear();
+		}
 	}
 
-	pub fn read(&mut self) -> Option<u8> {
-		self.inner.read()
+	pub fn read(&mut self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		self.device.read(buf)
 	}
 
-	pub fn is_empty(&self) -> bool {
-		self.inner.is_empty()
+	pub fn can_read(&self) -> bool {
+		self.device.can_read()
 	}
 
-	pub fn register_waker(&mut self, waker: &Waker) {
-		self.inner.register_waker(waker);
+	#[cfg(feature = "console")]
+	pub fn replace_device(&mut self, device: IoDevice) {
+		self.device = device;
 	}
 }
 
@@ -79,8 +159,20 @@ impl fmt::Write for Console {
 	}
 }
 
-pub(crate) static CONSOLE: Lazy<InterruptTicketMutex<Console>> =
-	Lazy::new(|| InterruptTicketMutex::new(Console::new()));
+pub(crate) static CONSOLE_WAKER: InterruptTicketMutex<WakerRegistration> =
+	InterruptTicketMutex::new(WakerRegistration::new());
+pub(crate) static CONSOLE: Lazy<InterruptTicketMutex<Console>> = Lazy::new(|| {
+	crate::CoreLocal::install();
+
+	#[cfg(not(target_arch = "riscv64"))]
+	if crate::env::is_uhyve() {
+		InterruptTicketMutex::new(Console::new(IoDevice::Uhyve(UhyveSerial::new())))
+	} else {
+		InterruptTicketMutex::new(Console::new(IoDevice::Uart(SerialDevice::new())))
+	}
+	#[cfg(target_arch = "riscv64")]
+	InterruptTicketMutex::new(Console::new(IoDevice::Uart(SerialDevice::new())))
+});
 
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments<'_>) {

--- a/src/drivers/console/mmio.rs
+++ b/src/drivers/console/mmio.rs
@@ -1,0 +1,65 @@
+//! A module containing a virtio console driver.
+//!
+//! The module contains ...
+
+use virtio::console::Config;
+use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
+use volatile::VolatileRef;
+
+use crate::drivers::InterruptLine;
+use crate::drivers::console::{ConsoleDevCfg, RxQueue, TxQueue, VirtioConsoleDriver};
+use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+
+// Backend-dependent interface for Virtio console driver
+impl VirtioConsoleDriver {
+	pub fn new(
+		dev_id: u16,
+		mut registers: VolatileRef<'static, DeviceRegisters>,
+		irq: InterruptLine,
+	) -> Result<VirtioConsoleDriver, VirtioError> {
+		let dev_cfg_raw: &'static Config = unsafe {
+			&*registers
+				.borrow_mut()
+				.as_mut_ptr()
+				.config()
+				.as_raw_ptr()
+				.cast::<Config>()
+				.as_ptr()
+		};
+		let dev_cfg_raw = VolatileRef::from_ref(dev_cfg_raw);
+		let dev_cfg = ConsoleDevCfg {
+			raw: dev_cfg_raw,
+			dev_id,
+			features: virtio::console::F::empty(),
+		};
+		let isr_stat = IsrStatus::new(registers.borrow_mut());
+		let notif_cfg = NotifCfg::new(registers.borrow_mut());
+
+		Ok(VirtioConsoleDriver {
+			dev_cfg,
+			com_cfg: ComCfg::new(registers, 1),
+			isr_stat,
+			notif_cfg,
+			irq,
+			recv_vq: RxQueue::new(),
+			send_vq: TxQueue::new(),
+		})
+	}
+
+	/// Initializes virtio console device by mapping configuration layout to
+	/// respective structs (configuration structs are:
+	///
+	/// Returns a driver instance of
+	/// [VirtioConsoleDriver](structs.virtionetdriver.html) or an [VirtioError](enums.virtioerror.html).
+	pub fn init(
+		dev_id: u16,
+		registers: VolatileRef<'static, DeviceRegisters>,
+		irq: InterruptLine,
+	) -> Result<VirtioConsoleDriver, VirtioError> {
+		let mut drv = VirtioConsoleDriver::new(dev_id, registers, irq)?;
+		drv.init_dev()
+			.map_err(|error_code| VirtioError::ConsoleDriver(error_code))?;
+		Ok(drv)
+	}
+}

--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -1,0 +1,363 @@
+#![allow(dead_code)]
+
+cfg_if::cfg_if! {
+	if #[cfg(feature = "pci")] {
+		mod pci;
+	} else {
+		mod mmio;
+	}
+}
+
+use alloc::vec::Vec;
+
+use hermit_sync::without_interrupts;
+use smallvec::SmallVec;
+use virtio::FeatureBits;
+use virtio::console::Config;
+use volatile::VolatileRef;
+use volatile::access::ReadOnly;
+
+use crate::VIRTIO_MAX_QUEUE_SIZE;
+use crate::drivers::error::DriverError;
+use crate::drivers::virtio::error::VirtioConsoleError;
+#[cfg(not(feature = "pci"))]
+use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+#[cfg(feature = "pci")]
+use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::virtqueue::split::SplitVq;
+use crate::drivers::virtio::virtqueue::{
+	AvailBufferToken, BufferElem, BufferType, UsedBufferToken, VirtQueue, Virtq, VqIndex, VqSize,
+};
+use crate::drivers::{Driver, InterruptLine};
+use crate::mm::device_alloc::DeviceAlloc;
+
+fn fill_queue(vq: &mut VirtQueue, num_packets: u16, packet_size: u32) {
+	for _ in 0..num_packets {
+		let buff_tkn = match AvailBufferToken::new(
+			{
+				let mut vec = SmallVec::new();
+				vec.push(BufferElem::Vector(Vec::with_capacity_in(
+					packet_size.try_into().unwrap(),
+					DeviceAlloc,
+				)));
+				vec
+			},
+			SmallVec::new(),
+		) {
+			Ok(tkn) => tkn,
+			Err(_vq_err) => {
+				panic!("Setup of console queue failed, which should not happen!");
+			}
+		};
+
+		// BufferTokens are directly provided to the queue
+		// TransferTokens are directly dispatched
+		// Transfers will be awaited at the queue
+		if let Err(err) = vq.dispatch(buff_tkn, false, BufferType::Direct) {
+			error!("{err:#?}");
+			break;
+		}
+	}
+}
+
+pub(crate) struct RxQueue {
+	vq: Option<VirtQueue>,
+	packet_size: u32,
+}
+
+impl RxQueue {
+	pub fn new() -> Self {
+		Self {
+			vq: None,
+
+			packet_size: crate::CONSOLE_PACKET_SIZE,
+		}
+	}
+
+	pub fn add(&mut self, mut vq: VirtQueue) {
+		const BUFF_PER_PACKET: u16 = 1;
+		let num_packets: u16 = u16::from(vq.size()) / BUFF_PER_PACKET;
+		info!("num_packets {num_packets}");
+		fill_queue(&mut vq, num_packets, self.packet_size);
+
+		self.vq = Some(vq);
+	}
+
+	pub fn enable_notifs(&mut self) {
+		if let Some(ref mut vq) = self.vq {
+			vq.enable_notifs();
+		}
+	}
+
+	pub fn disable_notifs(&mut self) {
+		if let Some(ref mut vq) = self.vq {
+			vq.disable_notifs();
+		}
+	}
+
+	fn get_next(&mut self) -> Option<UsedBufferToken> {
+		self.vq.as_mut().unwrap().try_recv().ok()
+	}
+
+	pub fn process_packet<F>(&mut self, mut f: F)
+	where
+		F: FnMut(&[u8]),
+	{
+		while let Some(mut buffer_tkn) = self.get_next() {
+			let packet = buffer_tkn.used_recv_buff.pop_front_vec().unwrap();
+
+			if let Some(ref mut vq) = self.vq {
+				f(&packet[..]);
+
+				fill_queue(vq, 1, self.packet_size);
+			} else {
+				panic!("Invalid length of receive queue");
+			}
+		}
+	}
+}
+
+pub(crate) struct TxQueue {
+	vq: Option<VirtQueue>,
+	/// Indicates, whether the Driver/Device are using multiple
+	/// queues for communication.
+	packet_length: u32,
+}
+
+impl TxQueue {
+	pub fn new() -> Self {
+		Self {
+			vq: None,
+			packet_length: crate::CONSOLE_PACKET_SIZE,
+		}
+	}
+
+	pub fn add(&mut self, vq: VirtQueue) {
+		self.vq = Some(vq);
+	}
+
+	pub fn enable_notifs(&mut self) {
+		if let Some(ref mut vq) = self.vq {
+			vq.enable_notifs();
+		}
+	}
+
+	pub fn disable_notifs(&mut self) {
+		if let Some(ref mut vq) = self.vq {
+			vq.disable_notifs();
+		}
+	}
+
+	fn poll(&mut self) {
+		if let Some(ref mut vq) = self.vq {
+			while vq.try_recv().is_ok() {}
+		}
+	}
+
+	/// Provides a slice to copy the packet and transfer the packet
+	/// to the send queue. The caller has to create the header
+	/// for the vsock interface.
+	pub fn send_packet(&mut self, buf: &[u8]) {
+		// We need to poll to get the queue to remove elements from the table and make space for
+		// what we are about to add
+		self.poll();
+		if let Some(ref mut vq) = self.vq {
+			assert!(buf.len() < usize::try_from(self.packet_length).unwrap());
+			let mut packet = Vec::with_capacity_in(buf.len(), DeviceAlloc);
+			packet.extend_from_slice(buf);
+
+			let buff_tkn = AvailBufferToken::new(
+				{
+					let mut vec = SmallVec::new();
+					vec.push(BufferElem::Vector(packet));
+					vec
+				},
+				SmallVec::new(),
+			)
+			.unwrap();
+
+			vq.dispatch(buff_tkn, false, BufferType::Direct).unwrap();
+		} else {
+			panic!("Unable to get send queue");
+		}
+	}
+}
+
+/// A wrapper struct for the raw configuration structure.
+/// Handling the right access to fields, as some are read-only
+/// for the driver.
+pub(crate) struct ConsoleDevCfg {
+	pub raw: VolatileRef<'static, Config, ReadOnly>,
+	pub dev_id: u16,
+	pub features: virtio::console::F,
+}
+
+pub(crate) struct VirtioConsoleDriver {
+	pub(super) dev_cfg: ConsoleDevCfg,
+	pub(super) com_cfg: ComCfg,
+	pub(super) isr_stat: IsrStatus,
+	pub(super) notif_cfg: NotifCfg,
+	pub(super) irq: InterruptLine,
+
+	pub(super) recv_vq: RxQueue,
+	pub(super) send_vq: TxQueue,
+}
+
+impl Driver for VirtioConsoleDriver {
+	fn get_interrupt_number(&self) -> InterruptLine {
+		self.irq
+	}
+
+	fn get_name(&self) -> &'static str {
+		"virtio"
+	}
+}
+
+impl VirtioConsoleDriver {
+	pub fn write(&mut self, buf: &[u8]) -> Result<(), DriverError> {
+		without_interrupts(|| {
+			self.send_vq.send_packet(buf);
+		});
+
+		Ok(())
+	}
+
+	pub fn read(&mut self) -> Result<Option<u8>, DriverError> {
+		// Logic to read data from the console
+		Ok(None)
+	}
+
+	/// Handle interrupt and acknowledge interrupt
+	pub fn handle_interrupt(&mut self) {
+		let status = self.isr_stat.is_queue_interrupt();
+
+		debug!("Virtion console receive interrupt!");
+
+		#[cfg(not(feature = "pci"))]
+		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
+			info!("Configuration changes are not possible! Aborting");
+			todo!("Implement possibility to change config on the fly...");
+		}
+
+		#[cfg(feature = "pci")]
+		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+			info!("Configuration changes are not possible! Aborting");
+			todo!("Implement possibility to change config on the fly...");
+		}
+
+		self.isr_stat.acknowledge();
+	}
+
+	#[cfg(feature = "pci")]
+	pub fn set_failed(&mut self) {
+		self.com_cfg.set_failed();
+	}
+
+	/// Negotiates a subset of features, understood and wanted by both the OS
+	/// and the device.
+	fn negotiate_features(
+		&mut self,
+		driver_features: virtio::console::F,
+	) -> Result<(), VirtioConsoleError> {
+		let device_features = virtio::console::F::from(self.com_cfg.dev_features());
+
+		if device_features.requirements_satisfied() {
+			info!("Feature set wanted by console driver are in conformance with specification.");
+		} else {
+			return Err(VirtioConsoleError::FeatureRequirementsNotMet(
+				device_features,
+			));
+		}
+
+		if device_features.contains(driver_features) {
+			// If device supports subset of features write feature set to common config
+			self.com_cfg.set_drv_features(driver_features.into());
+			Ok(())
+		} else {
+			Err(VirtioConsoleError::IncompatibleFeatureSets(
+				driver_features,
+				device_features,
+			))
+		}
+	}
+
+	pub fn init_dev(&mut self) -> Result<(), VirtioConsoleError> {
+		// Reset
+		self.com_cfg.reset_dev();
+
+		// Indicate device, that OS noticed it
+		self.com_cfg.ack_dev();
+
+		// Indicate device, that driver is able to handle it
+		self.com_cfg.set_drv();
+
+		let features = virtio::console::F::VERSION_1;
+		self.negotiate_features(features)?;
+
+		// Indicates the device, that the current feature set is final for the driver
+		// and will not be changed.
+		self.com_cfg.features_ok();
+
+		// Checks if the device has accepted final set. This finishes feature negotiation.
+		if self.com_cfg.check_features() {
+			info!(
+				"Features have been negotiated between virtio console device {:x} and driver.",
+				self.dev_cfg.dev_id
+			);
+			// Set feature set in device config fur future use.
+			self.dev_cfg.features = features;
+		} else {
+			return Err(VirtioConsoleError::FailFeatureNeg(self.dev_cfg.dev_id));
+		}
+
+		// create the queues and tell device about them
+		self.recv_vq.add(VirtQueue::Split(
+			SplitVq::new(
+				&mut self.com_cfg,
+				&self.notif_cfg,
+				VqSize::from(VIRTIO_MAX_QUEUE_SIZE),
+				VqIndex::from(0u16),
+				self.dev_cfg.features.into(),
+			)
+			.unwrap(),
+		));
+		// Interrupt for receiving packets is wanted
+		self.recv_vq.enable_notifs();
+
+		self.send_vq.add(VirtQueue::Split(
+			SplitVq::new(
+				&mut self.com_cfg,
+				&self.notif_cfg,
+				VqSize::from(VIRTIO_MAX_QUEUE_SIZE),
+				VqIndex::from(1u16),
+				self.dev_cfg.features.into(),
+			)
+			.unwrap(),
+		));
+		// Interrupt for communicating that a sent packet left, is not needed
+		self.send_vq.disable_notifs();
+
+		// At this point the device is "live"
+		self.com_cfg.drv_ok();
+
+		Ok(())
+	}
+}
+
+/// Error module of virtio console device driver.
+pub mod error {
+	/// Virtio console device error enum.
+	#[derive(Debug, Copy, Clone)]
+	pub enum VirtioConsoleError {
+		#[cfg(feature = "pci")]
+		NoDevCfg(u16),
+		/// The device did not acknowledge the negotiated feature set.
+		FailFeatureNeg(u16),
+		/// Set of features does not adhere to the requirements of features
+		/// indicated by the specification
+		FeatureRequirementsNotMet(virtio::console::F),
+		/// The first u64 contains the feature bits wanted by the driver.
+		/// but which are incompatible with the device feature set, second u64.
+		IncompatibleFeatureSets(virtio::console::F, virtio::console::F),
+	}
+}

--- a/src/drivers/console/pci.rs
+++ b/src/drivers/console/pci.rs
@@ -1,0 +1,94 @@
+use pci_types::CommandRegister;
+use virtio::console::Config;
+use volatile::VolatileRef;
+
+use crate::drivers::console::{ConsoleDevCfg, RxQueue, TxQueue, VirtioConsoleDriver};
+use crate::drivers::pci::PciDevice;
+use crate::drivers::virtio::error::{self, VirtioError};
+use crate::drivers::virtio::transport::pci::{self, PciCap, UniCapsColl};
+use crate::pci::PciConfigRegion;
+
+// Backend-dependent interface for Virtio console driver
+impl VirtioConsoleDriver {
+	fn map_cfg(cap: &PciCap) -> Option<ConsoleDevCfg> {
+		let dev_cfg = pci::map_dev_cfg::<Config>(cap)?;
+		let dev_cfg = VolatileRef::from_ref(dev_cfg);
+
+		Some(ConsoleDevCfg {
+			raw: dev_cfg,
+			dev_id: cap.dev_id(),
+			features: virtio::console::F::empty(),
+		})
+	}
+
+	/// Instantiates a new VirtioConsoleDriver struct, by checking the available
+	/// configuration structures and moving them into the struct.
+	pub fn new(
+		caps_coll: UniCapsColl,
+		device: &PciDevice<PciConfigRegion>,
+	) -> Result<Self, error::VirtioConsoleError> {
+		let device_id = device.device_id();
+
+		let UniCapsColl {
+			com_cfg,
+			notif_cfg,
+			isr_cfg,
+			dev_cfg_list,
+			..
+		} = caps_coll;
+
+		let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioConsoleDriver::map_cfg) else {
+			error!("No dev config. Aborting!");
+			return Err(error::VirtioConsoleError::NoDevCfg(device_id));
+		};
+
+		Ok(VirtioConsoleDriver {
+			dev_cfg,
+			com_cfg,
+			isr_stat: isr_cfg,
+			notif_cfg,
+			irq: device.get_irq().unwrap(),
+			recv_vq: RxQueue::new(),
+			send_vq: TxQueue::new(),
+		})
+	}
+
+	/// Initializes virtio console device
+	///
+	/// Returns a driver instance of VirtioConsoleDriver.
+	pub(crate) fn init(
+		device: &PciDevice<PciConfigRegion>,
+	) -> Result<VirtioConsoleDriver, VirtioError> {
+		// enable bus master mode
+		device.set_command(CommandRegister::BUS_MASTER_ENABLE);
+
+		let mut drv = match pci::map_caps(device) {
+			Ok(caps) => match VirtioConsoleDriver::new(caps, device) {
+				Ok(driver) => driver,
+				Err(console_err) => {
+					error!("Initializing new virtio console device driver failed. Aborting!");
+					return Err(VirtioError::ConsoleDriver(console_err));
+				}
+			},
+			Err(err) => {
+				error!("Mapping capabilities failed. Aborting!");
+				return Err(err);
+			}
+		};
+
+		match drv.init_dev() {
+			Ok(()) => {
+				info!(
+					"Console device with id {:x}, has been initialized by driver!",
+					drv.dev_cfg.dev_id
+				);
+
+				Ok(drv)
+			}
+			Err(console_err) => {
+				drv.set_failed();
+				Err(VirtioError::ConsoleDriver(console_err))
+			}
+		}
+	}
+}

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,5 +1,7 @@
 //! A module containing hermit-rs driver, hermit-rs driver trait and driver specific errors.
 
+#[cfg(feature = "console")]
+pub mod console;
 #[cfg(feature = "fuse")]
 pub mod fs;
 #[cfg(not(feature = "pci"))]
@@ -11,7 +13,8 @@ pub mod pci;
 #[cfg(any(
 	all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 	feature = "fuse",
-	feature = "vsock"
+	feature = "vsock",
+	feature = "console"
 ))]
 pub mod virtio;
 #[cfg(feature = "vsock")]
@@ -37,17 +40,25 @@ pub mod error {
 	#[cfg(any(
 		all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 		feature = "fuse",
-		feature = "vsock"
+		feature = "vsock",
+		feature = "console"
 	))]
 	use crate::drivers::virtio::error::VirtioError;
 
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "fuse", feature = "vsock"))]
+	#[cfg(any(
+		feature = "tcp",
+		feature = "udp",
+		feature = "fuse",
+		feature = "vsock",
+		feature = "console"
+	))]
 	#[derive(Debug)]
 	pub enum DriverError {
 		#[cfg(any(
 			all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 			feature = "fuse",
-			feature = "vsock"
+			feature = "vsock",
+			feature = "console"
 		))]
 		InitVirtioDevFail(VirtioError),
 		#[cfg(all(target_arch = "x86_64", feature = "rtl8139"))]
@@ -59,7 +70,8 @@ pub mod error {
 	#[cfg(any(
 		all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 		feature = "fuse",
-		feature = "vsock"
+		feature = "vsock",
+		feature = "console"
 	))]
 	impl From<VirtioError> for DriverError {
 		fn from(err: VirtioError) -> Self {
@@ -81,7 +93,13 @@ pub mod error {
 		}
 	}
 
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "fuse", feature = "vsock"))]
+	#[cfg(any(
+		feature = "tcp",
+		feature = "udp",
+		feature = "fuse",
+		feature = "vsock",
+		feature = "console"
+	))]
 	impl core::fmt::Display for DriverError {
 		#[allow(unused_variables)]
 		fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -89,7 +107,8 @@ pub mod error {
 				#[cfg(any(
 					all(any(feature = "tcp", feature = "udp"), not(feature = "rtl8139")),
 					feature = "fuse",
-					feature = "vsock"
+					feature = "vsock",
+					feature = "console"
 				))]
 				DriverError::InitVirtioDevFail(ref err) => {
 					write!(f, "Virtio driver failed: {err:?}")
@@ -130,7 +149,7 @@ pub(crate) fn init() {
 	#[cfg(all(
 		not(feature = "pci"),
 		target_arch = "aarch64",
-		any(feature = "tcp", feature = "udp")
+		any(feature = "tcp", feature = "udp", feature = "console")
 	))]
 	crate::arch::aarch64::kernel::mmio::init_drivers();
 

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -6,7 +6,13 @@ use core::fmt;
 
 use ahash::RandomState;
 use hashbrown::HashMap;
-#[cfg(any(feature = "tcp", feature = "udp", feature = "fuse", feature = "vsock"))]
+#[cfg(any(
+	feature = "tcp",
+	feature = "udp",
+	feature = "fuse",
+	feature = "vsock",
+	feature = "console"
+))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
 use memory_addresses::{PhysAddr, VirtAddr};
@@ -17,6 +23,8 @@ use pci_types::{
 };
 
 use crate::arch::pci::PciConfigRegion;
+#[cfg(feature = "console")]
+use crate::drivers::console::VirtioConsoleDriver;
 #[cfg(feature = "fuse")]
 use crate::drivers::fs::virtio_fs::VirtioFsDriver;
 #[cfg(any(feature = "tcp", feature = "udp"))]
@@ -34,7 +42,8 @@ use crate::drivers::net::virtio::VirtioNetDriver;
 		not(all(target_arch = "x86_64", feature = "rtl8139"))
 	),
 	feature = "fuse",
-	feature = "vsock"
+	feature = "vsock",
+	feature = "console"
 ))]
 use crate::drivers::virtio::transport::pci as pci_virtio;
 #[cfg(any(
@@ -43,7 +52,8 @@ use crate::drivers::virtio::transport::pci as pci_virtio;
 		not(all(target_arch = "x86_64", feature = "rtl8139"))
 	),
 	feature = "fuse",
-	feature = "vsock"
+	feature = "vsock",
+	feature = "console"
 ))]
 use crate::drivers::virtio::transport::pci::VirtioDriver;
 #[cfg(feature = "vsock")]
@@ -327,6 +337,8 @@ pub(crate) fn print_information() {
 pub(crate) enum PciDriver {
 	#[cfg(feature = "fuse")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
+	#[cfg(feature = "console")]
+	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "vsock")]
 	VirtioVsock(InterruptTicketMutex<VirtioVsockDriver>),
 	#[cfg(all(
@@ -351,6 +363,15 @@ impl PciDriver {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioNet(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
+	#[cfg(feature = "console")]
+	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioConsole(drv) => Some(drv),
 			_ => None,
 		}
 	}
@@ -440,6 +461,13 @@ impl PciDriver {
 
 				(irq_number, fuse_handler)
 			}
+			#[cfg(feature = "console")]
+			Self::VirtioConsole(drv) => {
+				fn console_handler() {}
+
+				let irq_number = drv.lock().get_interrupt_number();
+				(irq_number, console_handler)
+			}
 			_ => todo!(),
 		}
 	}
@@ -492,6 +520,14 @@ pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<RTL81
 		.find_map(|drv| drv.get_network_driver())
 }
 
+#[cfg(feature = "console")]
+pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_console_driver())
+}
+
 #[cfg(feature = "vsock")]
 pub(crate) fn get_vsock_driver() -> Option<&'static InterruptTicketMutex<VirtioVsockDriver>> {
 	PCI_DRIVERS
@@ -526,7 +562,8 @@ pub(crate) fn init() {
 					not(all(target_arch = "x86_64", feature = "rtl8139"))
 				),
 				feature = "fuse",
-				feature = "vsock"
+				feature = "vsock",
+				feature = "console"
 			))]
 			match pci_virtio::init_device(adapter) {
 				#[cfg(all(
@@ -535,6 +572,15 @@ pub(crate) fn init() {
 				))]
 				Ok(VirtioDriver::Network(drv)) => {
 					register_driver(PciDriver::VirtioNet(InterruptTicketMutex::new(drv)));
+				}
+				#[cfg(feature = "console")]
+				Ok(VirtioDriver::Console(drv)) => {
+					register_driver(PciDriver::VirtioConsole(InterruptTicketMutex::new(*drv)));
+					info!("Switch to virtio console");
+					crate::console::CONSOLE
+						.lock()
+						.inner
+						.switch_to_virtio_console();
 				}
 				#[cfg(feature = "vsock")]
 				Ok(VirtioDriver::Vsock(drv)) => {

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -3,7 +3,8 @@
 		not(feature = "tcp"),
 		not(feature = "udp"),
 		not(feature = "vsock"),
-		not(feature = "fuse")
+		not(feature = "fuse"),
+		not(feature = "console"),
 	),
 	expect(dead_code)
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod init_cell;
 pub mod io;
 pub mod mm;
 pub mod scheduler;
-#[cfg(all(feature = "shell", target_arch = "x86_64"))]
+#[cfg(feature = "shell")]
 mod shell;
 mod synch;
 pub mod syscalls;
@@ -136,7 +136,7 @@ extern "C" fn initd(_arg: usize) {
 
 	syscalls::init();
 	fs::init();
-	#[cfg(all(feature = "shell", target_arch = "x86_64"))]
+	#[cfg(feature = "shell")]
 	shell::init();
 
 	// Get the application arguments and environment variables.

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -391,7 +391,7 @@ impl Qemu {
 				}
 				device @ (Device::VirtioConsoleMmio | Device::VirtioConsolePci) => {
 					let device_arg = match device {
-						Device::VirtioConsoleMmio => "virtio-serial-mmio",
+						Device::VirtioConsoleMmio => "virtio-serial-device",
 						Device::VirtioConsolePci => "virtio-serial-pci,disable-legacy=on",
 						_ => unreachable!(),
 					};


### PR DESCRIPTION
 During runtime the kernel checks, if a virtio console device is available, initialize this device and use it to print kernel messages.
 
A device support at the early stage of the boot process is currently not possible.

This PR depends rust-osdev/virtio-spec-rs#1.

On `x86_64`,  I tested the PR with following command:

```sh
qemu-system-x86_64 -display none -kernel hermit-loader-x86_64 -initrd target/x86_64-unknown-hermit/debug/hello_world -device isa-debug-exit,iobase=0xf4,iosize=0x04 -smp 1 -m 1024M -global virtio-mmio.force-legacy=off -chardev stdio,id=charconsole0 -device virtio-serial-pci,disable-legacy=on -device virtconsole,chardev=charconsole0
```

In case of `aarch64`, I used following command.

```sh
qemu-system-aarch64 -display none -kernel hermit-loader-aarch64 -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/debug/hello_world -machine virt,gic-version=3 -cpu cortex-a72 -semihosting -smp 1 -m 256M -global virtio-mmio.force-legacy=off -chardev stdio,id=charconsole0 -device virtio-serial-device -device virtconsole,chardev=charconsole0
```

Closes https://github.com/hermit-os/kernel/issues/1751.