### PR TITLE
docs(virtio-net): remove outdated doc comment

### DIFF
--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -169,8 +169,6 @@ fn fill_queue(vq: &mut VirtQueue, num_bufs: u16, buf_size: u32) {
 /// to the respective queue structures.
 pub struct TxQueues {
 	vqs: Vec<VirtQueue>,
-	/// Indicates, whether the Driver/Device are using multiple
-	/// queues for communication.
 	buf_size: u32,
 }
 


### PR DESCRIPTION
is_multi was removed in 71e97e93589b49a181557232e4bfc1bd271936ed, but the field's doc comment was not.