### PR TITLE
feat(socket): align order of addrinfo fields with newlib and POSIX

### DIFF
--- a/src/syscalls/socket.rs
+++ b/src/syscalls/socket.rs
@@ -305,8 +305,8 @@ pub struct addrinfo {
 	pub ai_socktype: i32,
 	pub ai_protocol: i32,
 	pub ai_addrlen: socklen_t,
-	pub ai_canonname: *mut c_char,
 	pub ai_addr: *mut sockaddr,
+	pub ai_canonname: *mut c_char,
 	pub ai_next: *mut addrinfo,
 }
 


### PR DESCRIPTION
This would require adjusting hermit-abi and the libc crate.

The order of the fields is not terribly important, but this is our last chance for changing before implementing getaddrinfo in https://github.com/hermit-os/kernel/pull/1782.