### PR TITLE
fix: test TAP devices in CI

### DIFF
--- a/xtask/hermit-ifup
+++ b/xtask/hermit-ifup
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This script brings up the TAP device for QEMU.
+# The device itself is created and destroyed by QEMU.
+# Usage: .. -netdev tap,script=hermit-ifup,..
+
+ip address add dev "$1" local 10.0.5.1/24 broadcast 10.0.5.255
+ip link set "$1" up


### PR DESCRIPTION
This PR

1. adds a very helpful hermit-ifup script for automated TAP device configuration with QEMU,
2. adds TAP device support to xtask,
3. test TAP devices in CI, and
4. disables the malfunctioning VIRTIO_NET_F_CSUM and VIRTIO_NET_F_GUEST_CSUM features.

CSUM and GUEST_CSUM have been advertised by us for a long time, but we did not notice any failures since few devices advertise the features; thus the features have not been negotiated before.
Apart from devices like the Bluefield, vhost also supports this feature nowadays, which is why using TAP devices would break in some circumstances.
A proper fix for these features is underway in https://github.com/hermit-os/kernel/pull/1488.