### PR TITLE
fix(aarch64/interrupts): clippy::unwrap_or_default

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -133,9 +133,7 @@ pub(crate) extern "C" fn do_fiq(_state: &State) -> *mut usize {
 
 		GicV3::end_interrupt(irqid);
 
-		return core_scheduler()
-			.scheduler()
-			.unwrap_or(core::ptr::null_mut());
+		return core_scheduler().scheduler().unwrap_or_default();
 	}
 
 	core::ptr::null_mut()
@@ -161,9 +159,7 @@ pub(crate) extern "C" fn do_irq(_state: &State) -> *mut usize {
 
 		GicV3::end_interrupt(irqid);
 
-		return core_scheduler()
-			.scheduler()
-			.unwrap_or(core::ptr::null_mut());
+		return core_scheduler().scheduler().unwrap_or_default();
 	}
 
 	core::ptr::null_mut()


### PR DESCRIPTION
So this Clippy suggestion is only shown when using build std???

This shows the suggestion:

```bash
cargo clippy --target=aarch64-unknown-none-softfloat -Zbuild-std=core,alloc
```

This does not:

```bash
cargo clippy --target=aarch64-unknown-none-softfloat
```

How peculiar!