### PR TITLE
fix(scheduler): make `PerCoreScheduler::get_object` interrupt-safe again

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -465,9 +465,11 @@ impl PerCoreScheduler {
 	/// the shared reference
 	#[inline]
 	pub fn get_object(&self, fd: FileDescriptor) -> io::Result<Arc<dyn ObjectInterface>> {
-		let current_task = self.current_task.borrow();
-		let object_map = current_task.object_map.read();
-		object_map.get(&fd).cloned().ok_or(Errno::Badf)
+		without_interrupts(|| {
+			let current_task = self.current_task.borrow();
+			let object_map = current_task.object_map.read();
+			object_map.get(&fd).cloned().ok_or(Errno::Badf)
+		})
 	}
 
 	/// Creates a new map between file descriptor and their IO interface and


### PR DESCRIPTION
This was mistakenly removed in fbc604400191f19587a66e87596fc337d7ff53a4.