### PR TITLE
feat(net): Make networking support separate from TCP/UDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,32 +49,32 @@ default = ["kernel-stack", "pci", "pci-ids", "acpi", "fsgsbase", "smp", "tcp", "
 acpi = []
 common-os = []
 console = ["virtio"]
-dhcpv4 = ["smoltcp", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]
-dns = ["smoltcp", "smoltcp/socket-dns"]
+dhcpv4 = ["net", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]
+dns = ["net", "smoltcp/socket-dns"]
 fs = ["fuse"]
 fsgsbase = []
 fuse = ["virtio", "pci", "dep:fuse-abi", "fuse-abi/num_enum"]
-gem-net = ["tcp", "dep:tock-registers"]
+gem-net = ["net", "dep:tock-registers"]
 idle-poll = []
 kernel-stack = []
 log-target = []
-net = []
+net = ["smoltcp"]
 mman = []
 mmap = ["mman"] # Deprecated in favor of mman
 newlib = []
 nostd = []
 pci = ["virtio?/pci"]
-rtl8139 = ["tcp", "pci"]
+rtl8139 = ["net", "pci"]
 semihosting = ["dep:semihosting"]
 shell = ["simple-shell"]
 smp = []
 strace = []
-tcp = ["smoltcp", "smoltcp/socket-tcp"]
+tcp = ["net", "smoltcp/socket-tcp"]
 trace = ["smoltcp?/log", "smoltcp?/verbose"]
-udp = ["smoltcp", "smoltcp/socket-udp"]
+udp = ["net", "smoltcp/socket-udp"]
 vga = []
 virtio = ["dep:virtio"]
-virtio-net = ["virtio"]
+virtio-net = ["net", "virtio"]
 vsock = ["virtio", "pci"]
 
 [lints.rust]
@@ -158,6 +158,7 @@ features = [
 	# Enable IP fragmentation
 	"proto-ipv4-fragmentation",
 	"proto-ipv6-fragmentation",
+	"socket-raw",
 	#
 	# Assume a MTU size of 9000
 	#"fragmentation-buffer-size-8192",

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -3,7 +3,9 @@ use core::ptr::NonNull;
 
 use align_address::Align;
 use arm_gic::{IntId, Trigger};
-use hermit_sync::{InterruptTicketMutex, without_interrupts};
+#[cfg(feature = "console")]
+use hermit_sync::InterruptTicketMutex;
+use hermit_sync::without_interrupts;
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 use volatile::VolatileRef;
 
@@ -15,23 +17,17 @@ use crate::console::IoDevice;
 use crate::drivers::console::VirtioConsoleDriver;
 #[cfg(feature = "console")]
 use crate::drivers::console::VirtioUART;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "virtio-net")]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::virtio::transport::mmio::{self as mmio_virtio, VirtioDriver};
-#[cfg(all(
-	any(
-		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-		all(target_arch = "x86_64", feature = "rtl8139"),
-		feature = "virtio-net",
-	),
-	any(feature = "tcp", feature = "udp")
-))]
+#[cfg(feature = "virtio-net")]
 use crate::executor::device::NETWORK_DEVICE;
 use crate::init_cell::InitCell;
 use crate::mm::PhysAddr;
 
 pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 
+#[non_exhaustive]
 pub(crate) enum MmioDriver {
 	#[cfg(feature = "console")]
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
@@ -40,19 +36,21 @@ pub(crate) enum MmioDriver {
 impl MmioDriver {
 	#[cfg(feature = "console")]
 	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
-		match self {
-			Self::VirtioConsole(drv) => Some(drv),
-			#[cfg(any(feature = "tcp", feature = "udp"))]
-			_ => None,
+		#[allow(irrefutable_let_patterns)]
+		if let Self::VirtioConsole(drv) = self {
+			Some(drv)
+		} else {
+			None
 		}
 	}
 }
 
+#[cfg(feature = "console")]
 pub(crate) fn register_driver(drv: MmioDriver) {
 	MMIO_DRIVERS.with(|mmio_drivers| mmio_drivers.unwrap().push(drv));
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "virtio-net")]
 pub(crate) type NetworkDevice = VirtioNetDriver;
 
 #[cfg(feature = "console")]
@@ -125,7 +123,7 @@ pub fn init_drivers() {
 							let cpu_id: usize = 0;
 
 							match id {
-								#[cfg(any(feature = "tcp", feature = "udp"))]
+								#[cfg(feature = "virtio-net")]
 								virtio::Id::Net => {
 									debug!(
 										"Found network card at {mmio:p}, irq: {irq}, type: {irqtype}, flags: {irqflags}"

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -2,13 +2,7 @@ pub mod core_local;
 pub mod interrupts;
 #[cfg(feature = "kernel-stack")]
 pub mod kernel_stack;
-#[cfg(all(
-	not(feature = "pci"),
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console"
-	)
-))]
+#[cfg(all(not(feature = "pci"), any(feature = "virtio-net", feature = "console")))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -1,37 +1,15 @@
 #![allow(dead_code)]
 
-#[cfg(all(
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console"
-	),
-	not(feature = "pci")
-))]
+#[cfg(all(any(feature = "virtio-net", feature = "console"), not(feature = "pci")))]
 use core::ptr::NonNull;
 
 use fdt::Fdt;
 use memory_addresses::PhysAddr;
-#[cfg(all(
-	any(feature = "tcp", feature = "udp", feature = "console"),
-	feature = "gem-net",
-	not(feature = "pci")
-))]
+#[cfg(all(feature = "gem-net", not(feature = "pci")))]
 use memory_addresses::VirtAddr;
-#[cfg(all(
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console"
-	),
-	not(feature = "pci")
-))]
+#[cfg(all(any(feature = "virtio-net", feature = "console"), not(feature = "pci")))]
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
-#[cfg(all(
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console"
-	),
-	not(feature = "pci")
-))]
+#[cfg(all(any(feature = "virtio-net", feature = "console"), not(feature = "pci")))]
 use volatile::VolatileRef;
 
 use crate::arch::riscv64::kernel::get_dtb_ptr;
@@ -45,28 +23,17 @@ use crate::console::IoDevice;
 use crate::drivers::console::VirtioUART;
 #[cfg(all(feature = "console", not(feature = "pci")))]
 use crate::drivers::mmio::get_console_driver;
-#[cfg(all(
-	any(feature = "tcp", feature = "udp"),
-	feature = "gem-net",
-	not(feature = "pci")
-))]
+#[cfg(all(feature = "gem-net", not(feature = "pci")))]
 use crate::drivers::net::gem;
 #[cfg(all(feature = "console", feature = "pci"))]
 use crate::drivers::pci::get_console_driver;
 #[cfg(all(
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console"
-	),
+	any(feature = "virtio-net", feature = "console"),
 	not(feature = "pci"),
 	not(feature = "gem-net")
 ))]
 use crate::drivers::virtio::transport::mmio::{self as mmio_virtio, VirtioDriver};
-#[cfg(all(
-	any(feature = "tcp", feature = "udp"),
-	any(feature = "gem-net", feature = "virtio-net"),
-	not(feature = "pci"),
-))]
+#[cfg(all(any(feature = "gem-net", feature = "virtio-net"), not(feature = "pci"),))]
 use crate::executor::device::NETWORK_DEVICE;
 #[cfg(all(feature = "console", not(feature = "pci")))]
 use crate::kernel::mmio::register_driver;
@@ -205,13 +172,7 @@ pub fn init_drivers() {
 			}
 
 			// Init virtio-mmio
-			#[cfg(all(
-				any(
-					all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-					feature = "console"
-				),
-				not(feature = "pci")
-			))]
+			#[cfg(all(any(feature = "virtio-net", feature = "console"), not(feature = "pci")))]
 			if let Some(virtio_node) = fdt.find_compatible(&["virtio,mmio"]) {
 				debug!("Found virtio mmio device");
 				let virtio_region = virtio_node
@@ -273,11 +234,7 @@ pub fn init_drivers() {
 				}
 
 				match id {
-					#[cfg(all(
-						any(feature = "tcp", feature = "udp"),
-						feature = "virtio-net",
-						not(feature = "gem-net")
-					))]
+					#[cfg(all(feature = "virtio-net", not(feature = "gem-net")))]
 					virtio::Id::Net => {
 						debug!("Found virtio network card at {mmio:p}");
 
@@ -308,11 +265,7 @@ pub fn init_drivers() {
 	}
 
 	#[cfg(all(
-		any(
-			all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-			feature = "console",
-			feature = "gem-net"
-		),
+		any(feature = "virtio-net", feature = "console", feature = "gem-net"),
 		not(feature = "pci")
 	))]
 	super::mmio::MMIO_DRIVERS.finalize();

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -2,11 +2,7 @@ pub mod core_local;
 mod devicetree;
 pub mod interrupts;
 #[cfg(all(
-	any(
-		all(any(feature = "tcp", feature = "udp"), feature = "virtio-net"),
-		feature = "console",
-		feature = "gem-net"
-	),
+	any(feature = "virtio-net", feature = "console", feature = "gem-net"),
 	not(feature = "pci")
 ))]
 pub mod mmio;

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -18,13 +18,7 @@ pub mod gdt;
 pub mod interrupts;
 #[cfg(feature = "kernel-stack")]
 pub mod kernel_stack;
-#[cfg(all(
-	not(feature = "pci"),
-	any(
-		feature = "console",
-		all(feature = "virtio-net", any(feature = "tcp", feature = "udp"))
-	),
-))]
+#[cfg(all(not(feature = "pci"), any(feature = "console", feature = "virtio-net")))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,6 @@ pub(crate) const USER_STACK_SIZE: usize = 0x0010_0000;
 			all(target_arch = "x86_64", feature = "rtl8139"),
 		)),
 		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp")
 	),
 	feature = "fuse",
 	feature = "vsock",

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -8,22 +8,14 @@ use hashbrown::HashMap;
 pub(crate) use crate::arch::kernel::mmio::get_console_driver;
 #[cfg(any(
 	feature = "console",
-	all(
-		any(
-			all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-			feature = "virtio-net",
-		),
-		any(feature = "tcp", feature = "udp")
-	)
+	all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+	feature = "virtio-net",
 ))]
 use crate::drivers::Driver;
 use crate::drivers::{InterruptHandlerQueue, InterruptLine};
-#[cfg(all(
-	any(
-		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-		feature = "virtio-net",
-	),
-	any(feature = "tcp", feature = "udp")
+#[cfg(any(
+	all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+	feature = "virtio-net",
 ))]
 use crate::executor::device::NETWORK_DEVICE;
 
@@ -33,12 +25,9 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 	let mut handlers: HashMap<InterruptLine, InterruptHandlerQueue, RandomState> =
 		HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0));
 
-	#[cfg(all(
-		any(
-			all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-			feature = "virtio-net",
-		),
-		any(feature = "tcp", feature = "udp")
+	#[cfg(any(
+		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+		feature = "virtio-net",
 	))]
 	if let Some(device) = NETWORK_DEVICE.lock().as_ref() {
 		handlers

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -6,7 +6,7 @@ pub mod console;
 pub mod fs;
 #[cfg(not(feature = "pci"))]
 pub mod mmio;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 pub mod net;
 #[cfg(feature = "pci")]
 pub mod pci;
@@ -14,8 +14,7 @@ pub mod pci;
 	all(
 		not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 		not(all(target_arch = "x86_64", feature = "rtl8139")),
-		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp"),
+		feature = "virtio-net"
 	),
 	feature = "fuse",
 	feature = "vsock",
@@ -46,8 +45,7 @@ pub mod error {
 		all(
 			not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 			not(all(target_arch = "x86_64", feature = "rtl8139")),
-			feature = "virtio-net",
-			any(feature = "tcp", feature = "udp"),
+			feature = "virtio-net"
 		),
 		feature = "fuse",
 		feature = "vsock",
@@ -56,14 +54,9 @@ pub mod error {
 	use crate::drivers::virtio::error::VirtioError;
 
 	#[cfg(any(
-		all(
-			any(
-				all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-				all(target_arch = "x86_64", feature = "rtl8139"),
-				feature = "virtio-net",
-			),
-			any(feature = "tcp", feature = "udp"),
-		),
+		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+		all(target_arch = "x86_64", feature = "rtl8139"),
+		feature = "virtio-net",
 		feature = "fuse",
 		feature = "vsock",
 		feature = "console"
@@ -75,7 +68,6 @@ pub mod error {
 				not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 				not(all(target_arch = "x86_64", feature = "rtl8139")),
 				feature = "virtio-net",
-				any(feature = "tcp", feature = "udp"),
 			),
 			feature = "fuse",
 			feature = "vsock",
@@ -93,7 +85,6 @@ pub mod error {
 			not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 			not(all(target_arch = "x86_64", feature = "rtl8139")),
 			feature = "virtio-net",
-			any(feature = "tcp", feature = "udp"),
 		),
 		feature = "fuse",
 		feature = "vsock",
@@ -120,14 +111,9 @@ pub mod error {
 	}
 
 	#[cfg(any(
-		all(
-			any(
-				all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-				all(target_arch = "x86_64", feature = "rtl8139"),
-				feature = "virtio-net",
-			),
-			any(feature = "tcp", feature = "udp"),
-		),
+		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+		all(target_arch = "x86_64", feature = "rtl8139"),
+		feature = "virtio-net",
 		feature = "fuse",
 		feature = "vsock",
 		feature = "console"
@@ -145,7 +131,6 @@ pub mod error {
 						)),
 						not(all(target_arch = "x86_64", feature = "rtl8139")),
 						feature = "virtio-net",
-						any(feature = "tcp", feature = "udp"),
 					),
 					feature = "fuse",
 					feature = "vsock",
@@ -181,20 +166,12 @@ pub(crate) fn init() {
 	// Initialize PCI Drivers
 	#[cfg(feature = "pci")]
 	crate::drivers::pci::init();
-	#[cfg(all(
-		not(feature = "pci"),
-		target_arch = "x86_64",
-		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp")
-	))]
+	#[cfg(all(not(feature = "pci"), target_arch = "x86_64", feature = "virtio-net"))]
 	crate::arch::x86_64::kernel::mmio::init_drivers();
 	#[cfg(all(
 		not(feature = "pci"),
 		target_arch = "aarch64",
-		any(
-			feature = "console",
-			all(feature = "virtio-net", any(feature = "tcp", feature = "udp"))
-		)
+		any(feature = "console", feature = "virtio-net")
 	))]
 	crate::arch::aarch64::kernel::mmio::init_drivers();
 

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -23,12 +23,12 @@ use tock_registers::{register_bitfields, register_structs};
 
 use crate::arch::kernel::core_local::core_scheduler;
 use crate::arch::kernel::interrupts::*;
-#[cfg(all(any(feature = "tcp", feature = "udp"), not(feature = "pci")))]
+#[cfg(not(feature = "pci"))]
 use crate::arch::kernel::mmio as hardware;
 use crate::arch::mm::paging::PageTableEntryFlags;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::{NetworkDriver, mtu};
-#[cfg(all(any(feature = "tcp", feature = "udp"), feature = "pci"))]
+#[cfg(feature = "pci")]
 use crate::drivers::pci as hardware;
 use crate::drivers::{Driver, InterruptLine};
 use crate::mm::device_alloc::DeviceAlloc;

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -15,7 +15,6 @@ pub mod error {
 		not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 		not(all(target_arch = "x86_64", feature = "rtl8139")),
 		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp")
 	))]
 	pub use crate::drivers::net::virtio::error::VirtioNetError;
 	#[cfg(feature = "pci")]
@@ -39,7 +38,6 @@ pub mod error {
 			not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 			not(all(target_arch = "x86_64", feature = "rtl8139")),
 			feature = "virtio-net",
-			any(feature = "tcp", feature = "udp")
 		))]
 		NetDriver(VirtioNetError),
 		#[cfg(feature = "fuse")]
@@ -98,7 +96,6 @@ pub mod error {
 					not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 					not(all(target_arch = "x86_64", feature = "rtl8139")),
 					feature = "virtio-net",
-					any(feature = "tcp", feature = "udp")
 				))]
 				VirtioError::NetDriver(net_error) => match net_error {
 					#[cfg(feature = "pci")]

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -20,7 +20,7 @@ use crate::drivers::InterruptLine;
 #[cfg(feature = "console")]
 use crate::drivers::console::VirtioConsoleDriver;
 use crate::drivers::error::DriverError;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "virtio-net")]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::virtio::error::VirtioError;
 
@@ -364,7 +364,7 @@ impl IsrStatus {
 }
 
 pub(crate) enum VirtioDriver {
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(feature = "virtio-net")]
 	Network(VirtioNetDriver),
 	#[cfg(feature = "console")]
 	Console(Box<VirtioConsoleDriver>),
@@ -386,7 +386,7 @@ pub(crate) fn init_device(
 
 	// Verify the device-ID to find the network card
 	match registers.as_ptr().device_id().read() {
-		#[cfg(any(feature = "tcp", feature = "udp"))]
+		#[cfg(feature = "virtio-net")]
 		virtio::Id::Net => match VirtioNetDriver::init(dev_id, registers, irq_no) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -30,7 +30,6 @@ use crate::drivers::fs::virtio_fs::VirtioFsDriver;
 	not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 	not(all(target_arch = "x86_64", feature = "rtl8139")),
 	feature = "virtio-net",
-	any(feature = "tcp", feature = "udp"),
 ))]
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::pci::PciDevice;
@@ -816,7 +815,6 @@ pub(crate) fn init_device(
 			not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 			not(all(target_arch = "x86_64", feature = "rtl8139")),
 			feature = "virtio-net",
-			any(feature = "tcp", feature = "udp"),
 		))]
 		virtio::Id::Net => match VirtioNetDriver::init(device) {
 			Ok(virt_net_drv) => {
@@ -900,7 +898,6 @@ pub(crate) enum VirtioDriver {
 		not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
 		not(all(target_arch = "x86_64", feature = "rtl8139")),
 		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp"),
 	))]
 	Network(VirtioNetDriver),
 	#[cfg(feature = "console")]

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -6,7 +6,7 @@ use core::task::Poll::{Pending, Ready};
 use core::time::Duration;
 
 use async_trait::async_trait;
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 
 use crate::arch::kernel::core_local::core_scheduler;
@@ -16,7 +16,7 @@ use crate::fs::{FileAttr, SeekWhence};
 use crate::io;
 
 mod eventfd;
-#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+#[cfg(any(feature = "net", feature = "vsock"))]
 pub(crate) mod socket;
 pub(crate) mod stdio;
 
@@ -24,19 +24,21 @@ pub(crate) const STDIN_FILENO: FileDescriptor = 0;
 pub(crate) const STDOUT_FILENO: FileDescriptor = 1;
 pub(crate) const STDERR_FILENO: FileDescriptor = 2;
 
-#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+#[cfg(any(feature = "net", feature = "vsock"))]
 #[derive(Debug)]
 pub(crate) enum Endpoint {
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(feature = "net")]
 	Ip(IpEndpoint),
 	#[cfg(feature = "vsock")]
 	Vsock(socket::vsock::VsockEndpoint),
 }
 
-#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+#[cfg(any(feature = "net", feature = "vsock"))]
 #[derive(Debug)]
+#[non_exhaustive]
 pub(crate) enum ListenEndpoint {
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(feature = "net")]
+	#[cfg_attr(not(any(feature = "tcp", feature = "udp")), allow(unused))]
 	Ip(IpListenEndpoint),
 	#[cfg(feature = "vsock")]
 	Vsock(socket::vsock::VsockListenEndpoint),
@@ -232,56 +234,56 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	}
 
 	/// `accept` a connection on a socket
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn accept(&self) -> io::Result<(Arc<dyn ObjectInterface>, Endpoint)> {
 		Err(Errno::Inval)
 	}
 
 	/// initiate a connection on a socket
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn connect(&self, _endpoint: Endpoint) -> io::Result<()> {
 		Err(Errno::Inval)
 	}
 
 	/// `bind` a name to a socket
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn bind(&self, _name: ListenEndpoint) -> io::Result<()> {
 		Err(Errno::Inval)
 	}
 
 	/// `listen` for connections on a socket
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn listen(&self, _backlog: i32) -> io::Result<()> {
 		Err(Errno::Inval)
 	}
 
 	/// `setsockopt` sets options on sockets
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn setsockopt(&self, _opt: SocketOption, _optval: bool) -> io::Result<()> {
 		Err(Errno::Notsock)
 	}
 
 	/// `getsockopt` gets options on sockets
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn getsockopt(&self, _opt: SocketOption) -> io::Result<bool> {
 		Err(Errno::Notsock)
 	}
 
 	/// `getsockname` gets socket name
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn getsockname(&self) -> io::Result<Option<Endpoint>> {
 		Ok(None)
 	}
 
 	/// `getpeername` get address of connected peer
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	#[allow(dead_code)]
 	async fn getpeername(&self) -> io::Result<Option<Endpoint>> {
 		Ok(None)
 	}
 
 	/// receive a message from a socket
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn recvfrom(&self, _buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
 		Err(Errno::Nosys)
 	}
@@ -293,13 +295,13 @@ pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
 	/// If a peer address has been prespecified, either the message shall
 	/// be sent to the address specified by dest_addr (overriding the pre-specified peer
 	/// address).
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize> {
 		Err(Errno::Nosys)
 	}
 
 	/// shut down part of a full-duplex connection
-	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+	#[cfg(any(feature = "net", feature = "vsock"))]
 	async fn shutdown(&self, _how: i32) -> io::Result<()> {
 		Err(Errno::Nosys)
 	}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -97,7 +97,7 @@ pub(crate) trait PerCoreSchedulerExt {
 	/// Interrupt flag will be cleared during the reschedule
 	fn reschedule(self);
 
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(feature = "net")]
 	fn add_network_timer(self, wakeup_time: Option<u64>);
 
 	/// Terminate the current task on the current core.
@@ -172,7 +172,7 @@ impl PerCoreSchedulerExt for &mut PerCoreScheduler {
 		without_interrupts(|| self.scheduler());
 	}
 
-	#[cfg(any(feature = "tcp", feature = "udp"))]
+	#[cfg(feature = "net")]
 	fn add_network_timer(self, wakeup_time: Option<u64>) {
 		without_interrupts(|| {
 			self.blocked_tasks.add_network_timer(wakeup_time);

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -43,7 +43,7 @@ mod processor;
 #[cfg(feature = "newlib")]
 mod recmutex;
 mod semaphore;
-#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+#[cfg(any(feature = "net", feature = "vsock"))]
 pub mod socket;
 mod spinlock;
 mod system;

--- a/src/syscalls/socket/mod.rs
+++ b/src/syscalls/socket/mod.rs
@@ -4,6 +4,7 @@
 mod addrinfo;
 
 use alloc::boxed::Box;
+#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 use alloc::sync::Arc;
 use core::ffi::{c_char, c_void};
 use core::mem::{self, size_of};
@@ -13,21 +14,23 @@ use core::ops::DerefMut;
 
 use cfg_if::cfg_if;
 use num_enum::{IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
 
 use crate::errno::Errno;
+#[cfg(any(feature = "dns", feature = "tcp", feature = "udp"))]
+use crate::executor::network::NIC;
 #[cfg(any(feature = "tcp", feature = "udp"))]
-use crate::executor::network::{NIC, NetworkState};
+use crate::executor::network::NetworkState;
+#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
+use crate::fd::ObjectInterface;
 #[cfg(feature = "tcp")]
 use crate::fd::socket::tcp;
 #[cfg(feature = "udp")]
 use crate::fd::socket::udp;
 #[cfg(feature = "vsock")]
 use crate::fd::socket::vsock::{self, VsockEndpoint, VsockListenEndpoint};
-use crate::fd::{
-	self, Endpoint, ListenEndpoint, ObjectInterface, SocketOption, get_object, insert_object,
-};
+use crate::fd::{self, Endpoint, ListenEndpoint, SocketOption, get_object, insert_object};
 use crate::syscalls::block_on;
 
 #[derive(TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
@@ -300,7 +303,7 @@ pub struct sockaddr_in {
 	pub sin_zero: [c_char; 8],
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<sockaddr_in> for IpListenEndpoint {
 	fn from(addr: sockaddr_in) -> IpListenEndpoint {
 		let port = u16::from_be(addr.sin_port);
@@ -316,7 +319,7 @@ impl From<sockaddr_in> for IpListenEndpoint {
 	}
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<sockaddr_in> for IpEndpoint {
 	fn from(addr: sockaddr_in) -> IpEndpoint {
 		let port = u16::from_be(addr.sin_port);
@@ -327,7 +330,7 @@ impl From<sockaddr_in> for IpEndpoint {
 	}
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<IpEndpoint> for sockaddr_in {
 	fn from(endpoint: IpEndpoint) -> Self {
 		match endpoint.addr {
@@ -372,7 +375,7 @@ pub struct sockaddr_in6 {
 	pub sin6_scope_id: u32,
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<sockaddr_in6> for IpListenEndpoint {
 	fn from(addr: sockaddr_in6) -> IpListenEndpoint {
 		let port = u16::from_be(addr.sin6_port);
@@ -395,7 +398,7 @@ impl From<sockaddr_in6> for IpListenEndpoint {
 	}
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<sockaddr_in6> for IpEndpoint {
 	fn from(addr: sockaddr_in6) -> IpEndpoint {
 		let port = u16::from_be(addr.sin6_port);
@@ -414,7 +417,7 @@ impl From<sockaddr_in6> for IpEndpoint {
 	}
 }
 
-#[cfg(any(feature = "tcp", feature = "udp"))]
+#[cfg(feature = "net")]
 impl From<IpEndpoint> for sockaddr_in6 {
 	fn from(endpoint: IpEndpoint) -> Self {
 		match endpoint.addr {
@@ -567,18 +570,22 @@ pub unsafe extern "C" fn sys_getaddrbyname(
 pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 	debug!("sys_socket: domain {domain}, type {type_:?}, protocol {protocol}");
 
+	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	let Ok(Ok(domain)) = u8::try_from(domain).map(Af::try_from) else {
 		return -i32::from(Errno::Inval);
 	};
 
+	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	let Some((sock, sock_flags)) = Sock::from_bits(type_) else {
 		return -i32::from(Errno::Inval);
 	};
 
+	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	let Ok(Ok(proto)) = u8::try_from(protocol).map(Ipproto::try_from) else {
 		return -i32::from(Errno::Inval);
 	};
 
+	#[cfg(any(feature = "tcp", feature = "udp", feature = "vsock"))]
 	match (sock, proto) {
 		(_, Ipproto::Ip | Ipproto::Ipv6)
 		| (Sock::Stream, Ipproto::Tcp)
@@ -649,9 +656,9 @@ pub unsafe extern "C" fn sys_accept(fd: i32, addr: *mut sockaddr, addrlen: *mut 
 		|v| {
 			block_on((*v).accept(), None).map_or_else(
 				|e| -i32::from(e),
-				#[cfg_attr(not(any(feature = "tcp", feature = "udp")), expect(unused_variables))]
+				#[cfg_attr(not(feature = "net"), expect(unused_variables))]
 				|(obj, endpoint)| match endpoint {
-					#[cfg(any(feature = "tcp", feature = "udp"))]
+					#[cfg(feature = "net")]
 					Endpoint::Ip(endpoint) => {
 						let new_fd = insert_object(obj).unwrap();
 
@@ -727,7 +734,7 @@ pub unsafe extern "C" fn sys_bind(fd: i32, name: *const sockaddr, namelen: sockl
 	obj.map_or_else(
 		|e| -i32::from(e),
 		|v| match family {
-			#[cfg(any(feature = "tcp", feature = "udp"))]
+			#[cfg(feature = "net")]
 			Af::Inet => {
 				if namelen < u32::try_from(size_of::<sockaddr_in>()).unwrap() {
 					return -i32::from(Errno::Inval);
@@ -736,7 +743,7 @@ pub unsafe extern "C" fn sys_bind(fd: i32, name: *const sockaddr, namelen: sockl
 				block_on((*v).bind(ListenEndpoint::Ip(endpoint)), None)
 					.map_or_else(|e| -i32::from(e), |()| 0)
 			}
-			#[cfg(any(feature = "tcp", feature = "udp"))]
+			#[cfg(feature = "net")]
 			Af::Inet6 => {
 				if namelen < u32::try_from(size_of::<sockaddr_in6>()).unwrap() {
 					return -i32::from(Errno::Inval);
@@ -771,14 +778,14 @@ pub unsafe extern "C" fn sys_connect(fd: i32, name: *const sockaddr, namelen: so
 	};
 
 	let endpoint = match sa_family {
-		#[cfg(any(feature = "tcp", feature = "udp"))]
+		#[cfg(feature = "net")]
 		Af::Inet => {
 			if namelen < u32::try_from(size_of::<sockaddr_in>()).unwrap() {
 				return -i32::from(Errno::Inval);
 			}
 			Endpoint::Ip(IpEndpoint::from(unsafe { *name.cast::<sockaddr_in>() }))
 		}
-		#[cfg(any(feature = "tcp", feature = "udp"))]
+		#[cfg(feature = "net")]
 		Af::Inet6 => {
 			if namelen < u32::try_from(size_of::<sockaddr_in6>()).unwrap() {
 				return -i32::from(Errno::Inval);
@@ -820,7 +827,7 @@ pub unsafe extern "C" fn sys_getsockname(
 					let addrlen = unsafe { &mut *addrlen };
 
 					match endpoint {
-						#[cfg(any(feature = "tcp", feature = "udp"))]
+						#[cfg(feature = "net")]
 						Endpoint::Ip(endpoint) => match endpoint.addr {
 							IpAddress::Ipv4(_) => {
 								if *addrlen >= u32::try_from(size_of::<sockaddr_in>()).unwrap() {
@@ -833,7 +840,7 @@ pub unsafe extern "C" fn sys_getsockname(
 									-i32::from(Errno::Inval)
 								}
 							}
-							#[cfg(any(feature = "tcp", feature = "udp"))]
+							#[cfg(feature = "net")]
 							IpAddress::Ipv6(_) => {
 								if *addrlen >= u32::try_from(size_of::<sockaddr_in6>()).unwrap() {
 									let addr = unsafe { &mut *addr.cast() };
@@ -969,7 +976,7 @@ pub unsafe extern "C" fn sys_getpeername(
 					let addrlen = unsafe { &mut *addrlen };
 
 					match endpoint {
-						#[cfg(any(feature = "tcp", feature = "udp"))]
+						#[cfg(feature = "net")]
 						Endpoint::Ip(endpoint) => match endpoint.addr {
 							IpAddress::Ipv4(_) => {
 								if *addrlen >= u32::try_from(size_of::<sockaddr_in>()).unwrap() {
@@ -1040,7 +1047,7 @@ pub extern "C" fn sys_shutdown_socket(fd: i32, how: i32) -> i32 {
 pub unsafe extern "C" fn sys_recv(fd: i32, buf: *mut u8, len: usize, flags: i32) -> isize {
 	if flags == 0 {
 		let slice = unsafe { core::slice::from_raw_parts_mut(buf.cast(), len) };
-		crate::fd::read(fd, slice).map_or_else(
+		fd::read(fd, slice).map_or_else(
 			|e| isize::try_from(-i32::from(e)).unwrap(),
 			|v| v.try_into().unwrap(),
 		)
@@ -1066,7 +1073,7 @@ pub unsafe extern "C" fn sys_sendto(
 	}
 
 	cfg_if! {
-		if #[cfg(any(feature = "tcp", feature = "udp"))] {
+		if #[cfg(feature = "net")] {
 			let Ok(sa_family) = (unsafe { Af::try_from((*addr).sa_family) }) else {
 				return (-i32::from(Errno::Inval)).try_into().unwrap();
 			};
@@ -1132,7 +1139,7 @@ pub unsafe extern "C" fn sys_recvfrom(
 						let addrlen = unsafe { &mut *addrlen };
 
 						match endpoint {
-							#[cfg(any(feature = "tcp", feature = "udp"))]
+							#[cfg(feature = "net")]
 							Endpoint::Ip(endpoint) => match endpoint.addr {
 								IpAddress::Ipv4(_) => {
 									if *addrlen >= u32::try_from(size_of::<sockaddr_in>()).unwrap()


### PR DESCRIPTION
This makes `net` the new feature that toggles networking support. It is implicitly enabled by all the network drivers and the `tcp`/`udp`/`dns`/`dhcpv4` features.

TCP and UDP support is now optional and separate from networking support, which heavily simplifies the conditional compilation logic.