### PR TITLE
refactor(net): remove mutex indirection to network device

### DIFF
--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -24,6 +24,15 @@ use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 use crate::drivers::virtio::transport::mmio::VirtioDriver;
 use crate::env;
+#[cfg(all(
+	any(
+		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
+		all(target_arch = "x86_64", feature = "rtl8139"),
+		feature = "virtio-net",
+	),
+	any(feature = "tcp", feature = "udp")
+))]
+use crate::executor::device::NETWORK_DEVICE;
 use crate::init_cell::InitCell;
 use crate::mm::physicalmem::PHYSICAL_FREE_LIST;
 use crate::mm::virtualmem::KERNEL_FREE_LIST;
@@ -37,22 +46,11 @@ const IRQ_NUMBER: u8 = 44 - 32;
 static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 
 pub(crate) enum MmioDriver {
-	#[cfg(any(feature = "tcp", feature = "udp"))]
-	VirtioNet(InterruptTicketMutex<VirtioNetDriver>),
 	#[cfg(feature = "console")]
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 }
 
 impl MmioDriver {
-	#[allow(unreachable_patterns)]
-	#[cfg(any(feature = "tcp", feature = "udp"))]
-	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<VirtioNetDriver>> {
-		match self {
-			Self::VirtioNet(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[allow(unreachable_patterns)]
 	#[cfg(feature = "console")]
 	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
@@ -234,12 +232,7 @@ pub(crate) fn register_driver(drv: MmioDriver) {
 }
 
 #[cfg(any(feature = "tcp", feature = "udp"))]
-pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
-	MMIO_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_network_driver())
-}
+pub(crate) type NetworkDevice = VirtioNetDriver;
 
 #[cfg(feature = "console")]
 pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
@@ -257,7 +250,7 @@ pub(crate) fn init_drivers() {
 			warn!("Found MMIO device, but we guess the interrupt number {irq}!");
 			match mmio_virtio::init_device(mmio, irq) {
 				Ok(VirtioDriver::Network(drv)) => {
-					register_driver(MmioDriver::VirtioNet(InterruptTicketMutex::new(drv)));
+					*NETWORK_DEVICE.lock() = Some(drv);
 				}
 				Err(err) => error!("Could not initialize virtio-mmio device: {err}"),
 			}

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -1,13 +1,4 @@
-#[cfg(any(
-	feature = "console",
-	all(
-		any(
-			all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-			feature = "virtio-net",
-		),
-		any(feature = "tcp", feature = "udp")
-	)
-))]
+#[cfg(feature = "console")]
 use alloc::collections::VecDeque;
 
 use ahash::RandomState;
@@ -15,14 +6,6 @@ use hashbrown::HashMap;
 
 #[cfg(feature = "console")]
 pub(crate) use crate::arch::kernel::mmio::get_console_driver;
-#[cfg(all(
-	any(
-		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
-		feature = "virtio-net",
-	),
-	any(feature = "tcp", feature = "udp")
-))]
-pub(crate) use crate::arch::kernel::mmio::get_network_driver;
 #[cfg(any(
 	feature = "console",
 	all(
@@ -34,6 +17,7 @@ pub(crate) use crate::arch::kernel::mmio::get_network_driver;
 	)
 ))]
 use crate::drivers::Driver;
+use crate::drivers::{InterruptHandlerQueue, InterruptLine};
 #[cfg(all(
 	any(
 		all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci")),
@@ -41,8 +25,7 @@ use crate::drivers::Driver;
 	),
 	any(feature = "tcp", feature = "udp")
 ))]
-use crate::drivers::net::NetworkDriver;
-use crate::drivers::{InterruptHandlerQueue, InterruptLine};
+use crate::executor::device::NETWORK_DEVICE;
 
 pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandlerQueue, RandomState>
 {
@@ -57,22 +40,11 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 		),
 		any(feature = "tcp", feature = "udp")
 	))]
-	if let Some(drv) = get_network_driver() {
-		fn network_handler() {
-			if let Some(driver) = get_network_driver() {
-				driver.lock().handle_interrupt();
-			}
-		}
-
-		let irq_number = drv.lock().get_interrupt_number();
-
-		if let Some(map) = handlers.get_mut(&irq_number) {
-			map.push_back(network_handler);
-		} else {
-			let mut map: InterruptHandlerQueue = VecDeque::new();
-			map.push_back(network_handler);
-			handlers.insert(irq_number, map);
-		}
+	if let Some(device) = NETWORK_DEVICE.lock().as_ref() {
+		handlers
+			.entry(device.get_interrupt_number())
+			.or_default()
+			.push_back(crate::executor::network::network_handler);
 	}
 
 	#[cfg(feature = "console")]

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -318,7 +318,7 @@ impl NetworkDriver for GEMDriver {
 		self.next_rx_index().is_some()
 	}
 
-	fn receive_packet(&mut self) -> Option<(RxToken, TxToken)> {
+	fn receive_packet(&mut self) -> Option<(RxToken, TxToken<'_>)> {
 		debug!("receive_rx_buffer");
 
 		// Scan the buffer descriptor queue starting from rx_count
@@ -342,7 +342,10 @@ impl NetworkDriver for GEMDriver {
 				};
 				trace!("BUFFER: {buffer:x?}");
 				self.rx_buffer_consumed(index as usize);
-				Some((RxToken::new(buffer.to_vec_in(DeviceAlloc)), TxToken::new()))
+				Some((
+					RxToken::new(buffer.to_vec_in(DeviceAlloc)),
+					TxToken::new(self),
+				))
 			}
 			None => None,
 		}

--- a/src/drivers/net/loopback.rs
+++ b/src/drivers/net/loopback.rs
@@ -1,8 +1,6 @@
 use alloc::collections::vec_deque::VecDeque;
 use alloc::vec::Vec;
 
-use hermit_sync::InterruptTicketMutex;
-
 use crate::drivers::net::NetworkDriver;
 use crate::drivers::{Driver, InterruptLine};
 use crate::executor::device::{RxToken, TxToken};
@@ -40,10 +38,10 @@ impl NetworkDriver for LoopbackDriver {
 		u16::MAX
 	}
 
-	fn receive_packet(&mut self) -> Option<(RxToken, TxToken)> {
+	fn receive_packet(&mut self) -> Option<(RxToken, TxToken<'_>)> {
 		self.0
 			.pop_front()
-			.map(move |buffer| (RxToken::new(buffer), TxToken::new()))
+			.map(move |buffer| (RxToken::new(buffer), TxToken::new(self)))
 	}
 
 	fn send_packet<R, F>(&mut self, len: usize, f: F) -> R
@@ -70,5 +68,4 @@ impl NetworkDriver for LoopbackDriver {
 	}
 }
 
-pub(crate) static LOOPBACK: InterruptTicketMutex<LoopbackDriver> =
-	InterruptTicketMutex::new(LoopbackDriver::new());
+pub(crate) type NetworkDevice = LoopbackDriver;

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -265,7 +265,7 @@ impl NetworkDriver for RTL8139Driver {
 	}
 
 	/// Get buffer with the received packet
-	fn receive_packet(&mut self) -> Option<(RxToken, TxToken)> {
+	fn receive_packet(&mut self) -> Option<(RxToken, TxToken<'_>)> {
 		let cmd = unsafe { Port::<u8>::new(self.iobase + CR).read() };
 
 		if (cmd & CR_BUFE) == CR_BUFE {
@@ -303,7 +303,7 @@ impl NetworkDriver for RTL8139Driver {
 
 		self.consume_current_buffer();
 
-		Some((RxToken::new(vec_data), TxToken::new()))
+		Some((RxToken::new(vec_data), TxToken::new(self)))
 	}
 
 	fn set_polling_mode(&mut self, value: bool) {

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -294,7 +294,7 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 		result
 	}
 
-	fn receive_packet(&mut self) -> Option<(RxToken, TxToken)> {
+	fn receive_packet(&mut self) -> Option<(RxToken, TxToken<'_>)> {
 		let mut buffer_tkn = self.inner.recv_vqs.get_next()?;
 		// Safety: any buffers that do not start with a `Hdr` must have been consumed by the previous call
 		// to this function.
@@ -346,7 +346,7 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 				.unwrap();
 		}
 
-		Some((RxToken::new(combined_packets), TxToken::new()))
+		Some((RxToken::new(combined_packets), TxToken::new(self)))
 	}
 
 	fn set_polling_mode(&mut self, value: bool) {

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -6,18 +6,7 @@ use core::fmt;
 
 use ahash::RandomState;
 use hashbrown::HashMap;
-#[cfg(any(
-	all(
-		any(feature = "tcp", feature = "udp"),
-		any(
-			all(target_arch = "x86_64", feature = "rtl8139"),
-			feature = "virtio-net",
-		)
-	),
-	feature = "fuse",
-	feature = "vsock",
-	feature = "console"
-))]
+#[cfg(any(feature = "fuse", feature = "vsock", feature = "console"))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
 use memory_addresses::{PhysAddr, VirtAddr};
@@ -34,14 +23,6 @@ use crate::console::IoDevice;
 use crate::drivers::console::{VirtioConsoleDriver, VirtioUART};
 #[cfg(feature = "fuse")]
 use crate::drivers::fs::virtio_fs::VirtioFsDriver;
-#[cfg(all(
-	any(feature = "tcp", feature = "udp"),
-	any(
-		all(target_arch = "x86_64", feature = "rtl8139"),
-		feature = "virtio-net",
-	)
-))]
-use crate::drivers::net::NetworkDriver;
 #[cfg(all(target_arch = "x86_64", feature = "rtl8139"))]
 use crate::drivers::net::rtl8139::{self, RTL8139Driver};
 #[cfg(all(
@@ -76,6 +57,14 @@ use crate::drivers::virtio::transport::pci::VirtioDriver;
 use crate::drivers::vsock::VirtioVsockDriver;
 #[allow(unused_imports)]
 use crate::drivers::{Driver, InterruptHandlerQueue};
+#[cfg(all(
+	any(feature = "tcp", feature = "udp"),
+	any(
+		all(target_arch = "x86_64", feature = "rtl8139"),
+		feature = "virtio-net",
+	)
+))]
+use crate::executor::device::NETWORK_DEVICE;
 use crate::init_cell::InitCell;
 
 pub(crate) static PCI_DEVICES: InitCell<Vec<PciDevice<PciConfigRegion>>> =
@@ -358,52 +347,14 @@ pub(crate) enum PciDriver {
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "vsock")]
 	VirtioVsock(InterruptTicketMutex<VirtioVsockDriver>),
-	#[cfg(all(
-		not(all(target_arch = "x86_64", feature = "rtl8139")),
-		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp")
-	))]
-	VirtioNet(InterruptTicketMutex<VirtioNetDriver>),
-	#[cfg(all(
-		target_arch = "x86_64",
-		feature = "rtl8139",
-		any(feature = "tcp", feature = "udp")
-	))]
-	RTL8139Net(InterruptTicketMutex<RTL8139Driver>),
 }
 
 impl PciDriver {
-	#[cfg(all(
-		not(all(target_arch = "x86_64", feature = "rtl8139")),
-		feature = "virtio-net",
-		any(feature = "tcp", feature = "udp")
-	))]
-	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<VirtioNetDriver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::VirtioNet(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[cfg(feature = "console")]
 	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioConsole(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
-	#[cfg(all(
-		target_arch = "x86_64",
-		feature = "rtl8139",
-		any(feature = "tcp", feature = "udp")
-	))]
-	fn get_network_driver(&self) -> Option<&InterruptTicketMutex<RTL8139Driver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::RTL8139Net(drv) => Some(drv),
 			_ => None,
 		}
 	}
@@ -440,38 +391,6 @@ impl PciDriver {
 				let irq_number = drv.lock().get_interrupt_number();
 
 				(irq_number, vsock_handler)
-			}
-			#[cfg(all(
-				target_arch = "x86_64",
-				feature = "rtl8139",
-				any(feature = "tcp", feature = "udp")
-			))]
-			Self::RTL8139Net(drv) => {
-				fn rtl8139_handler() {
-					if let Some(driver) = get_network_driver() {
-						driver.lock().handle_interrupt();
-					}
-				}
-
-				let irq_number = drv.lock().get_interrupt_number();
-
-				(irq_number, rtl8139_handler)
-			}
-			#[cfg(all(
-				not(all(target_arch = "x86_64", feature = "rtl8139")),
-				feature = "virtio-net",
-				any(feature = "tcp", feature = "udp")
-			))]
-			Self::VirtioNet(drv) => {
-				fn network_handler() {
-					if let Some(driver) = get_network_driver() {
-						driver.lock().handle_interrupt();
-					}
-				}
-
-				let irq_number = drv.lock().get_interrupt_number();
-
-				(irq_number, network_handler)
 			}
 			#[cfg(feature = "fuse")]
 			Self::VirtioFs(drv) => {
@@ -532,6 +451,20 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 		}
 	}
 
+	#[cfg(all(
+		any(feature = "tcp", feature = "udp"),
+		any(
+			all(target_arch = "x86_64", feature = "rtl8139"),
+			feature = "virtio-net",
+		)
+	))]
+	if let Some(device) = NETWORK_DEVICE.lock().as_ref() {
+		handlers
+			.entry(device.get_interrupt_number())
+			.or_default()
+			.push_back(crate::executor::network::network_handler);
+	}
+
 	handlers
 }
 
@@ -540,24 +473,14 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 	feature = "virtio-net",
 	any(feature = "tcp", feature = "udp")
 ))]
-pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<VirtioNetDriver>> {
-	PCI_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_network_driver())
-}
+pub(crate) type NetworkDevice = VirtioNetDriver;
 
 #[cfg(all(
 	target_arch = "x86_64",
 	feature = "rtl8139",
 	any(feature = "tcp", feature = "udp")
 ))]
-pub(crate) fn get_network_driver() -> Option<&'static InterruptTicketMutex<RTL8139Driver>> {
-	PCI_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_network_driver())
-}
+pub(crate) type NetworkDevice = RTL8139Driver;
 
 #[cfg(feature = "console")]
 pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
@@ -611,9 +534,8 @@ pub(crate) fn init() {
 					feature = "virtio-net",
 					any(feature = "tcp", feature = "udp")
 				))]
-				Ok(VirtioDriver::Network(drv)) => {
-					register_driver(PciDriver::VirtioNet(InterruptTicketMutex::new(drv)));
-				}
+				Ok(VirtioDriver::Network(drv)) => *crate::executor::device::NETWORK_DEVICE.lock() = Some(drv),
+
 				#[cfg(feature = "console")]
 				Ok(VirtioDriver::Console(drv)) => {
 					register_driver(PciDriver::VirtioConsole(InterruptTicketMutex::new(*drv)));
@@ -646,7 +568,7 @@ pub(crate) fn init() {
 			);
 
 			if let Ok(drv) = rtl8139::init_device(adapter) {
-				register_driver(PciDriver::RTL8139Net(InterruptTicketMutex::new(drv)));
+				*crate::executor::device::NETWORK_DEVICE.lock() = Some(drv);
 			}
 		}
 	});

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -1,21 +1,5 @@
 #![cfg_attr(
-	all(
-		not(all(
-			any(feature = "tcp", feature = "udp"),
-			target_arch = "x86_64",
-			feature = "rtl8139",
-		)),
-		not(all(
-			any(feature = "tcp", feature = "udp"),
-			target_arch = "riscv64",
-			feature = "gem-net",
-			not(feature = "pci")
-		)),
-		not(all(any(feature = "tcp", feature = "udp"), feature = "virtio-net")),
-		not(feature = "vsock"),
-		not(feature = "fuse"),
-		not(feature = "console"),
-	),
+	not(any(feature = "vsock", feature = "fuse", feature = "console",)),
 	expect(dead_code)
 )]
 


### PR DESCRIPTION
Let the network interface own the network device instead of accessing it through a static reference to a mutex.