### PR TITLE
fix(aarch64): PL031 read is always little endian

### DIFF
--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -45,7 +45,7 @@ fn rtc_read(off: usize) -> u32 {
 		);
 	}
 
-	value
+	u32::from_le(value)
 }
 
 pub fn init() {


### PR DESCRIPTION
Fixes the RTC reading on aarch64_be.