### PR TITLE
fix(aarch64): migrate to fdt crate and remove hermit-dtb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,12 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-dtb"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e0de208fa9b99664812350b33072d0d9b3a63caaebb03eeb23316eeedfb8d0"
-
-[[package]]
 name = "hermit-entry"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +779,6 @@ dependencies = [
  "fuse-abi",
  "hashbrown",
  "heapless 0.9.1",
- "hermit-dtb",
  "hermit-entry",
  "hermit-macro",
  "hermit-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,6 @@ memory_addresses = { version = "0.2.3", default-features = false, features = [
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = { version = "0.0.14", default-features = false }
 arm-gic = { version = "0.6" }
-hermit-dtb = { version = "0.1" }
 semihosting = { version = "0.1", optional = true }
 memory_addresses = { version = "0.2.3", default-features = false, features = [
 	"aarch64",

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -66,20 +66,9 @@ pub fn get_limit() -> usize {
 
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
-	use hermit_dtb::Dtb;
-
-	let dtb = unsafe {
-		Dtb::from_raw(core::ptr::with_exposed_provenance(
-			env::boot_info().hardware_info.device_tree.unwrap().get() as usize,
-		))
-		.expect(".dtb file has invalid header")
-	};
-
-	dtb.enum_subnodes("/cpus")
-		.filter(|name| name.contains("cpu@"))
-		.count()
-		.try_into()
-		.unwrap()
+	let fdt = env::fdt().unwrap();
+	let cpu_count = fdt.cpus().count();
+	u32::try_from(cpu_count).unwrap()
 }
 
 #[cfg(feature = "smp")]
@@ -147,8 +136,6 @@ pub fn boot_next_processor() {
 		use core::arch::asm;
 		use core::hint::spin_loop;
 
-		use hermit_dtb::Dtb;
-
 		use crate::kernel::start::{TTBR0, smp_start};
 		use crate::mm::virtual_to_physical;
 
@@ -160,24 +147,17 @@ pub fn boot_next_processor() {
 			trace!("Virtual address of smp_start 0x{virt_start:x}");
 			trace!("Physical address of smp_start 0x{phys_start:x}");
 
-			let dtb = unsafe {
-				Dtb::from_raw(core::ptr::with_exposed_provenance(
-					env::boot_info().hardware_info.device_tree.unwrap().get() as usize,
-				))
-				.expect(".dtb file has invalid header")
-			};
+			let fdt = env::fdt().unwrap();
+			let psci_node = fdt.find_node("/psci").unwrap();
 
-			let cpu_on = u32::from_be_bytes(
-				dtb.get_property("/psci", "cpu_on")
-					.unwrap()
-					.try_into()
-					.unwrap(),
-			);
+			let cpu_on = psci_node.property("cpu_on").unwrap().as_usize().unwrap();
+			let cpu_on = u32::try_from(cpu_on).unwrap();
 			trace!("CPU_ON: 0x{cpu_on:x}");
-			let method =
-				core::str::from_utf8(dtb.get_property("/psci", "method").unwrap_or(b"unknown"))
-					.unwrap()
-					.replace('\0', "");
+
+			let method = psci_node
+				.property("method")
+				.map(|node| node.as_str().unwrap())
+				.unwrap_or("unknown");
 
 			let ttbr0: *mut u8;
 			unsafe {


### PR DESCRIPTION
This PR removes the last dependency on hermit-dtb, completing the migration to the fdt crate, allowing us to archive the hermit-dtb repository.