### PR TITLE
fix(aarch64/kernel-stack): don't transmute args via memory

### DIFF
--- a/src/arch/x86_64/kernel/kernel_stack.rs
+++ b/src/arch/x86_64/kernel/kernel_stack.rs
@@ -1,105 +1,84 @@
-use core::arch::asm;
-use core::{mem, ptr};
+use core::mem;
 
 use crate::core_local::CoreLocal;
 
+#[unsafe(naked)]
+pub unsafe extern "C" fn call_with_stack(
+	rdi: usize,
+	rsi: usize,
+	rdx: usize,
+	rcx: usize,
+	r8: usize,
+	r9: usize,
+	f: unsafe extern "C" fn(
+		rdi: usize,
+		rsi: usize,
+		rdx: usize,
+		rcx: usize,
+		r8: usize,
+		r9: usize,
+	) -> usize,
+	stack_ptr: *mut (),
+) -> usize {
+	core::arch::naked_asm!(
+		// Save user stack pointer and switch to supplied stack
+		"cli",
+		"push r12",
+		"mov r12, rsp",
+		"mov rsp, [rsp + 24]",
+		"sti",
+		// Call f
+		"call [r12 + 16]",
+		// Switch back to previous stack
+		"cli",
+		"mov rsp, r12",
+		"pop r12",
+		"sti",
+		"ret",
+	)
+}
+
 macro_rules! kernel_function_impl {
-	($kernel_function:ident($($arg:ident: $A:ident),*) { $($operands:tt)* }) => {
+	($kernel_function:ident($($arg:ident: $A:ident),*; $($z:ident: usize),*)) => {
 		/// Executes `f` on the kernel stack.
 		#[allow(dead_code)]
 		pub unsafe fn $kernel_function<R, $($A),*>(f: unsafe extern "C" fn($($A),*) -> R, $($arg: $A),*) -> R {
 			unsafe {
-				assert!(mem::size_of::<R>() <= mem::size_of::<usize>());
-
 				$(
 					assert!(mem::size_of::<$A>() <= mem::size_of::<usize>());
-					let $arg = {
-						let mut reg = 0usize;
-						// SAFETY: $A is smaller than usize and directly fits in a register
-						// Since f takes $A as argument via C calling convention, any upper bytes do not matter.
-						ptr::write(ptr::from_mut(&mut reg).cast(), $arg);
-						reg
-					};
+				)*
+				assert!(mem::size_of::<R>() <= mem::size_of::<usize>());
+
+				let call_with_stack = mem::transmute::<*const (), unsafe extern "C" fn(
+					$($arg: $A,)*
+					$($z: usize,)*
+					f: unsafe extern "C" fn(
+						$($arg: $A,)*
+					) -> R,
+					stack_ptr: *mut (),
+				) -> R>(call_with_stack as *const ());
+
+				$(
+					let $z = 0usize;
 				)*
 
-				let ret: u64;
-				asm!(
-					// Save user stack pointer and switch to kernel stack
-					"cli",
-					"mov r12, rsp",
-					"mov rsp, {kernel_stack_ptr}",
-					"sti",
+				let kernel_stack = CoreLocal::get().kernel_stack.get().cast();
 
-					// To make sure, Rust manages the stack in `f` correctly,
-					// we keep all arguments and return values in registers
-					// until we switch the stack back. Thus follows the sizing
-					// requirements for arguments and return types.
-					"call {f}",
-
-					// Switch back to user stack
-					"cli",
-					"mov rsp, r12",
-					"sti",
-
-					f = in(reg) f,
-					kernel_stack_ptr = in(reg) CoreLocal::get().kernel_stack.get(),
-
-					$($operands)*
-
-					// user_stack_ptr saved in r12
-					out("r12") _,
-
-					// Return argument in rax
-					out("rax") ret,
-
-					clobber_abi("C"),
-				);
-
-				// SAFETY: R is smaller than usize and directly fits in rax
-				// Since f returns R, we can safely convert ret to R
-				mem::transmute_copy(&ret)
+				call_with_stack(
+					$($arg,)*
+					$($z,)*
+					f,
+					kernel_stack,
+				)
 			}
 		}
 	};
 }
 
-kernel_function_impl!(kernel_function0() {});
-
-kernel_function_impl!(kernel_function1(arg1: A1) {
-	in("rdi") arg1,
-});
-
-kernel_function_impl!(kernel_function2(arg1: A1, arg2: A2) {
-	in("rdi") arg1,
-	in("rsi") arg2,
-});
-
-kernel_function_impl!(kernel_function3(arg1: A1, arg2: A2, arg3: A3) {
-	in("rdi") arg1,
-	in("rsi") arg2,
-	in("rdx") arg3,
-});
-
-kernel_function_impl!(kernel_function4(arg1: A1, arg2: A2, arg3: A3, arg4: A4) {
-	in("rdi") arg1,
-	in("rsi") arg2,
-	in("rdx") arg3,
-	in("rcx") arg4,
-});
-
-kernel_function_impl!(kernel_function5(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) {
-	in("rdi") arg1,
-	in("rsi") arg2,
-	in("rdx") arg3,
-	in("rcx") arg4,
-	in("r8") arg5,
-});
-
-kernel_function_impl!(kernel_function6(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6) {
-	in("rdi") arg1,
-	in("rsi") arg2,
-	in("rdx") arg3,
-	in("rcx") arg4,
-	in("r8") arg5,
-	in("r9") arg6,
-});
+kernel_function_impl!(kernel_function0(; z1: usize, z2: usize, z3: usize, z4: usize, z5: usize, z6: usize));
+kernel_function_impl!(kernel_function1(arg1: A1; z2: usize, z3: usize, z4: usize, z5: usize, z6: usize));
+kernel_function_impl!(kernel_function2(arg1: A1, arg2: A2; z3: usize, z4: usize, z5: usize, z6: usize));
+kernel_function_impl!(kernel_function3(arg1: A1, arg2: A2, arg3: A3; z4: usize, z5: usize, z6: usize));
+kernel_function_impl!(kernel_function4(arg1: A1, arg2: A2, arg3: A3, arg4: A4; z5: usize, z6: usize));
+kernel_function_impl!(kernel_function5(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5; z6: usize));
+kernel_function_impl!(kernel_function6(arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6; ));


### PR DESCRIPTION
The aarch64 side of #1890, tested that this fixes the kernel-stack feature on aarch64_be :)