### PR TITLE
feat: add warn-prebuilt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ vga = []
 virtio = ["dep:virtio"]
 virtio-net = ["net", "virtio"]
 vsock = ["virtio", "pci"]
+warn-prebuilt = []
 
 [lints.rust]
 rust_2018_idioms = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,11 @@ extern "C" fn initd(_arg: usize) {
 	// give the IP thread time to initialize the network interface
 	core_scheduler().reschedule();
 
+	if cfg!(feature = "warn-prebuilt") {
+		warn!("This is a prebuilt Hermit kernel.");
+		warn!("For non-default device drivers and features, consider building a custom kernel.");
+	}
+
 	info!("Jumping into application");
 
 	#[cfg(not(test))]


### PR DESCRIPTION
Once we have a warning, we can go ahead with distributing prebuilt libraries.