### PR TITLE
x86_64: feature - preemptive multithreading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ vga = []
 virtio = ["dep:virtio"]
 virtio-net = ["net", "virtio"]
 vsock = ["virtio", "pci"]
+preemptive-multithreading = []
 
 [lints.rust]
 rust_2018_idioms = "warn"


### PR DESCRIPTION
This PR adds a simple preemptive multi-threading feature, which automatically sets a timer to run the scheduler.reschedule() function at least once every 100us.

Known issues for now:

- [ ] `usleep` does not work correctly in threads 