### PR TITLE
Memory Allocator: Switch from talc to galloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "good_memory_allocator"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1651659e016ea4259760966432aebcc96c81e26743fb018c59585ddd677127e"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +873,7 @@ dependencies = [
  "float-cmp",
  "free-list",
  "fuse-abi",
+ "good_memory_allocator",
  "hashbrown",
  "heapless 0.9.1",
  "hermit-entry",
@@ -881,7 +897,6 @@ dependencies = [
  "smallvec",
  "smoltcp",
  "take-static",
- "talc",
  "thiserror",
  "time",
  "tock-registers 0.10.0",
@@ -1909,15 +1924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf67eb0a80961fdb5df5e14b75c5b9fc93bdbf88b00d0260b7eec55041c4fe01"
 dependencies = [
  "call-once",
-]
-
-[[package]]
-name = "talc"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ enum_dispatch = "0.3"
 fdt = { version = "0.1", features = ["pretty-printing"] }
 free-list = "0.3"
 fuse-abi = { version = "0.2", features = ["linux"], optional = true }
+good_memory_allocator = { version = "0.1.7", default-features = false }
 hashbrown = { version = "0.16", default-features = false }
 heapless = "0.9"
 hermit-entry = { version = "0.10", features = ["kernel"] }
@@ -139,7 +140,6 @@ shell-words = { version = "1.1", default-features = false }
 simple-shell = { version = "0.0.1", optional = true }
 smallvec = { version = "1", features = ["const_new"] }
 take-static = "0.1"
-talc = { version = "4" }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
 volatile = "0.6"

--- a/src/mm/allocator.rs
+++ b/src/mm/allocator.rs
@@ -3,14 +3,14 @@
 
 use core::alloc::{GlobalAlloc, Layout};
 
-use hermit_sync::RawInterruptTicketMutex;
-use talc::{ErrOnOom, Span, Talc, Talck};
+use good_memory_allocator::Allocator;
+use hermit_sync::InterruptTicketMutex;
 
-pub struct LockedAllocator(Talck<RawInterruptTicketMutex, ErrOnOom>);
+pub struct LockedAllocator(InterruptTicketMutex<Allocator>);
 
 impl LockedAllocator {
 	pub const fn new() -> Self {
-		Self(Talc::new(ErrOnOom).lock())
+		Self(InterruptTicketMutex::new(Allocator::empty()))
 	}
 
 	#[inline]
@@ -22,9 +22,8 @@ impl LockedAllocator {
 	}
 
 	pub unsafe fn init(&self, heap_bottom: *mut u8, heap_size: usize) {
-		let arena = Span::from_base_size(heap_bottom, heap_size);
 		unsafe {
-			self.0.lock().claim(arena).unwrap();
+			self.0.lock().init(heap_bottom as usize, heap_size);
 		}
 	}
 }
@@ -34,22 +33,24 @@ impl LockedAllocator {
 unsafe impl GlobalAlloc for LockedAllocator {
 	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
 		let layout = Self::align_layout(layout);
-		unsafe { self.0.alloc(layout) }
+		unsafe { self.0.lock().alloc(layout) }
 	}
 
-	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-		let layout = Self::align_layout(layout);
-		unsafe { self.0.dealloc(ptr, layout) }
+	unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+		// TODO: do we need to consider the layout here? galloc docs don't mention this.
+		unsafe { self.0.lock().dealloc(ptr) }
 	}
 
 	unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
 		let layout = Self::align_layout(layout);
-		unsafe { self.0.alloc_zeroed(layout) }
+		let ptr = unsafe { self.0.lock().alloc(layout) };
+		unsafe { core::ptr::write_bytes(ptr, 0, layout.size()) };
+		ptr
 	}
 
 	unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
 		let layout = Self::align_layout(layout);
-		unsafe { self.0.realloc(ptr, layout, new_size) }
+		unsafe { self.0.lock().realloc(ptr, layout, new_size) }
 	}
 }
 


### PR DESCRIPTION
I found major performance issues with the current talc allocator. This one replaces it with [galloc](https://github.com/MaderNoob/galloc).

Just like https://github.com/hermit-os/kernel/pull/1935, this PR is for now only intended for testing purposes. Finding the right allocator requires deeper investigations and benchmarking. 