### PR TITLE
cleanup: poll_on no longer required in new_idle

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -126,24 +126,6 @@ pub fn init() {
 }
 
 /// Blocks the current thread on `f`, running the executor when idling.
-pub(crate) fn poll_on<F, T>(future: F) -> io::Result<T>
-where
-	F: Future<Output = io::Result<T>>,
-{
-	let mut cx = Context::from_waker(Waker::noop());
-	let mut future = pin!(future);
-
-	loop {
-		// run background tasks
-		run();
-
-		if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
-			return t;
-		}
-	}
-}
-
-/// Blocks the current thread on `f`, running the executor when idling.
 pub(crate) fn block_on<F, T>(future: F, timeout: Option<Duration>) -> io::Result<T>
 where
 	F: Future<Output = io::Result<T>>,


### PR DESCRIPTION
While trying to understand the code of the executor a bit better, I found an old async { } block that is no longer required to be async (since https://github.com/hermit-os/kernel/commit/fbc604400191f19587a66e87596fc337d7ff53a4) and cleaned it out.