### PR TITLE
network: don't wake tasks if NIC is busy

### DIFF
--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -246,8 +246,6 @@ pub(crate) fn wake_network_waker() {
 async fn network_run() {
 	future::poll_fn(|cx| {
 		let Some(mut guard) = NIC.try_lock() else {
-			// FIXME: only wake when progress can be made
-			cx.waker().wake_by_ref();
 			// another task is already using the NIC => don't check
 			return Poll::Pending;
 		};


### PR DESCRIPTION
Fixes an old FIXME.

A very quick wrk benchmark on the axum example seems to report a 50% performance improvement (both tests were made with #1939 applied, the effect may be different without this patch).

Before:

```
$ wrk http://localhost:8080/
Running 10s test @ http://localhost:8080/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    19.91ms   58.94ms 716.76ms   92.84%
    Req/Sec     1.10k   342.95     2.09k    72.50%
  21844 requests in 10.00s, 3.37MB read
Requests/sec:   2184.33
Transfer/sec:    345.57KB
```

After:
```
$ wrk http://localhost:8080/
Running 10s test @ http://localhost:8080/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    12.06ms   50.31ms 782.84ms   95.71%
    Req/Sec     1.69k   475.75     3.68k    79.00%
  33619 requests in 10.00s, 5.19MB read
Requests/sec:   3361.60
Transfer/sec:    531.81KB
```

