### PR TITLE
style: improve user-facing kernel messages

### DIFF
--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -111,8 +111,7 @@ pub fn application_processor_init() {
 }
 
 fn finish_processor_init() {
-	debug!("Initialized processor {}", core_id());
-
+	debug!("CPU {}: Initialized", core_id());
 	// Allocate stack for the CPU and pass the addresses.
 	let layout = Layout::from_size_align(KERNEL_STACK_SIZE, BasePageSize::SIZE as usize).unwrap();
 	let stack = unsafe { alloc(layout) };
@@ -139,8 +138,8 @@ pub fn boot_next_processor() {
 			let phys_start = virtual_to_physical(virt_start).unwrap();
 			assert!(virt_start.as_u64() == phys_start.as_u64());
 
-			trace!("Virtual address of smp_start 0x{virt_start:x}");
-			trace!("Physical address of smp_start 0x{phys_start:x}");
+			trace!("Virtual address of smp_start: 0x{virt_start:x}");
+			trace!("Physical address of smp_start: 0x{phys_start:x}");
 
 			let fdt = env::fdt().unwrap();
 			let psci_node = fdt.find_node("/psci").unwrap();
@@ -164,8 +163,7 @@ pub fn boot_next_processor() {
 			TTBR0.store(ttbr0, Ordering::Relaxed);
 
 			for cpu_id in 1..get_possible_cpus() {
-				debug!("Try to wake-up core {cpu_id}");
-
+				debug!("CPU {cpu_id}: Attempting to wake up...");
 				if method == "hvc" {
 					// call hypervisor to wakeup next core
 					unsafe {
@@ -177,7 +175,7 @@ pub fn boot_next_processor() {
 						asm!("smc #0", in("x0") cpu_on, in("x1") cpu_id, in("x2") phys_start.as_u64(), in("x3") cpu_id, options(nomem, nostack));
 					}
 				} else {
-					warn!("Method {method} isn't supported!");
+					warn!("CPU {cpu_id}: Wakeup method {method} not supported!");
 					return;
 				}
 

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -312,7 +312,8 @@ pub fn configure() {
 			out(reg) pmcr_el0,
 			options(nostack, nomem),
 		);
-		debug!("PMCR_EL0 (has RES1 bits and therefore mustn't be zero): {pmcr_el0:#X}");
+		// Has RES1 bits, therefore must not be zero.
+		debug!("PMCR_EL0 contents: {pmcr_el0:#X}");
 		pmcr_el0 |= (1 << 0) | (1 << 2) | (1 << 6);
 		asm!(
 			"msr pmcr_el0, {}",

--- a/src/arch/aarch64/kernel/scheduler.rs
+++ b/src/arch/aarch64/kernel/scheduler.rs
@@ -142,11 +142,11 @@ impl TaskStacks {
 		let frame_range = PHYSICAL_FREE_LIST
 			.lock()
 			.allocate(frame_layout)
-			.expect("Failed to allocate Physical Memory for TaskStacks");
+			.expect("Task stacks: Physical memory allocation failed!");
 		let phys_addr = PhysAddr::from(frame_range.start());
 
 		debug!(
-			"Create stacks at {:p} with a size of {} KB",
+			"Task stacks: Create at virtual {:p} (size: {}KB)",
 			virt_addr,
 			total_size >> 10
 		);
@@ -188,7 +188,7 @@ impl TaskStacks {
 
 	pub fn from_boot_stacks() -> TaskStacks {
 		let stack = VirtAddr::new(CURRENT_STACK_ADDRESS.load(Ordering::Relaxed) as u64);
-		debug!("Using boot stack {stack:p}");
+		debug!("Task stacks: Deriving from boot stack {stack:p}");
 
 		TaskStacks::Boot(BootStack { stack })
 	}
@@ -231,7 +231,7 @@ impl Drop for TaskStacks {
 			TaskStacks::Boot(_) => {}
 			TaskStacks::Common(stacks) => {
 				debug!(
-					"Deallocating stacks at {:p} with a size of {} KB",
+					"Task stacks: Deallocating at {:p} (size: {}KB)",
 					stacks.virt_addr,
 					stacks.total_size >> 10,
 				);

--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -63,13 +63,13 @@ pub fn init() {
 				let addr = PhysAddr::from(reg.starting_address.addr());
 				let size = u64::try_from(reg.size.unwrap()).unwrap();
 
-				debug!("Found RTC at {addr:p} (size {size:#X})");
+				debug!("RTC: Found at {addr:p} (size {size:#X})");
 
 				let layout = PageLayout::from_size(size.try_into().unwrap()).unwrap();
 				let page_range = KERNEL_FREE_LIST.lock().allocate(layout).unwrap();
 				let pl031_address = VirtAddr::from(page_range.start());
 				PL031_ADDRESS.set(pl031_address).unwrap();
-				debug!("Mapping RTC to virtual address {pl031_address:p}");
+				debug!("RTC: Mapping to virtual address {pl031_address:p}");
 
 				let mut flags = PageTableEntryFlags::empty();
 				flags.device().writable().execute_disable();

--- a/src/arch/riscv64/kernel/interrupts.rs
+++ b/src/arch/riscv64/kernel/interrupts.rs
@@ -56,7 +56,7 @@ static IRQ_NAMES: InterruptTicketMutex<HashMap<u8, &'static str, RandomState>> =
 
 #[allow(dead_code)]
 pub(crate) fn add_irq_name(irq_number: u8, name: &'static str) {
-	debug!("Register name \"{name}\"  for interrupt {irq_number}");
+	debug!("Assigning name \"{name}\" for interrupt {irq_number}");
 	IRQ_NAMES.lock().insert(irq_number, name);
 }
 

--- a/src/arch/riscv64/kernel/processor.rs
+++ b/src/arch/riscv64/kernel/processor.rs
@@ -289,6 +289,6 @@ pub fn set_oneshot_timer(wakeup_time: Option<u64>) {
 
 pub fn wakeup_core(core_to_wakeup: CoreId) {
 	let hart_id = HARTS_AVAILABLE.finalize()[core_to_wakeup as usize];
-	debug!("Wakeup core: {core_to_wakeup} , hart_id: {hart_id}");
+	debug!("Wakeup core: {core_to_wakeup}, hart_id: {hart_id}");
 	sbi_rt::send_ipi(sbi_rt::HartMask::from_mask_base(0b1, hart_id));
 }

--- a/src/arch/riscv64/kernel/scheduler.rs
+++ b/src/arch/riscv64/kernel/scheduler.rs
@@ -126,11 +126,11 @@ impl TaskStacks {
 		let frame_range = PHYSICAL_FREE_LIST
 			.lock()
 			.allocate(frame_layout)
-			.expect("Failed to allocate Physical Memory for TaskStacks");
+			.expect("Task stacks: Physical memory allocation failed!");
 		let phys_addr = PhysAddr::from(frame_range.start());
 
 		debug!(
-			"Create stacks at {:#X} with a size of {} KB",
+			"Task stacks: Create at virtual {:#X} (size: {}KB)",
 			virt_addr,
 			total_size >> 10
 		);
@@ -166,7 +166,7 @@ impl TaskStacks {
 		);
 
 		// clear user stack
-		debug!("Clearing user stack...");
+		debug!("Task stacks: Clearing user stack...");
 		unsafe {
 			ptr::write_bytes(
 				(virt_addr + KERNEL_STACK_SIZE + DEFAULT_STACK_SIZE + 3 * BasePageSize::SIZE)
@@ -177,7 +177,7 @@ impl TaskStacks {
 			);
 		}
 
-		debug!("Creating stacks finished");
+		debug!("Task stacks: Creation complete.");
 
 		TaskStacks::Common(CommonStack {
 			virt_addr,
@@ -247,7 +247,7 @@ impl Drop for TaskStacks {
 			TaskStacks::Boot(_) => {}
 			TaskStacks::Common(stacks) => {
 				debug!(
-					"Deallocating stacks at {:#X} with a size of {} KB",
+					"Task stacks: Deallocating at {:#X} (size: {}KB)",
 					stacks.virt_addr,
 					stacks.total_size >> 10,
 				);
@@ -447,7 +447,7 @@ pub fn timer_handler() {
 
 #[cfg(feature = "smp")]
 pub fn wakeup_handler() {
-	debug!("Received Wakeup Interrupt");
+	debug!("Wakeup interrupt received");
 	//increment_irq_counter(WAKEUP_INTERRUPT_NUMBER.into());
 	let core_scheduler = core_scheduler();
 	core_scheduler.check_input();

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -315,21 +315,21 @@ fn detect_rsdp(start_address: PhysAddr, end_address: PhysAddr) -> Result<&'stati
 
 		// Verify the basic checksum.
 		if verify_checksum(current_address, RSDP_CHECKSUM_LENGTH).is_err() {
-			debug!("Found an ACPI table at {current_address:#X}, but its RSDP checksum is invalid");
+			debug!("ACPI: Table found at {current_address:#X}, but its RSDP checksum is invalid");
 			continue;
 		}
 
 		// Verify the extended checksum if this is an ACPI 2.0-compliant table.
 		if rsdp.revision >= 2 && verify_checksum(current_address, RSDP_XCHECKSUM_LENGTH).is_err() {
 			debug!(
-				"Found an ACPI table at {current_address:#X}, but its RSDP extended checksum is invalid"
+				"ACPI: Table found at {current_address:#X}, but its RSDP extended checksum is invalid"
 			);
 			continue;
 		}
 
 		// We were successful! Return a pointer to the RSDT (whose 64-bit address is called XSDT in this structure).
 		info!(
-			"Found an ACPI revision {} table at {:#X} with OEM ID \"{}\"",
+			"ACPI: Revision {} table found at {:#X} with OEM ID \"{}\"",
 			rsdp.revision,
 			current_address,
 			rsdp.oem_id()
@@ -501,7 +501,7 @@ pub fn poweroff() {
 	if let (Some(mut pm1a_cnt_blk), Some(&slp_typa)) = (PM1A_CNT_BLK.get().cloned(), SLP_TYPA.get())
 	{
 		let bits = (u16::from(slp_typa) << 10) | SLP_EN;
-		debug!("Powering Off through ACPI (port {pm1a_cnt_blk:?}, bitmask {bits:#X})");
+		debug!("Powering off using ACPI (port {pm1a_cnt_blk:?}, bitmask {bits:#X})");
 		unsafe {
 			pm1a_cnt_blk.write(bits);
 		}
@@ -548,7 +548,10 @@ pub fn init() {
 		};
 
 		let table = AcpiTable::map(table_physical_address);
-		debug!("Found ACPI table: {}", table.header.signature());
+		debug!(
+			"ACPI: Found table with signature {}",
+			table.header.signature()
+		);
 
 		if table.header.signature() == "APIC" {
 			// The "Multiple APIC Description Table" (MADT) aka "APIC Table" (APIC)

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -87,7 +87,7 @@ impl ConfigRegionAccess for LegacyPciConfigRegion {
 pub(crate) fn init() {
 	#[cfg(feature = "acpi")]
 	if pcie::init_pcie() {
-		info!("Initialized PCIe");
+		info!("PCIe: Initialized");
 		return;
 	}
 
@@ -97,11 +97,11 @@ pub(crate) fn init() {
 		0..PCI_MAX_BUS_NUMBER,
 		PciConfigRegion::Pci(LegacyPciConfigRegion::new()),
 	);
-	info!("Initialized PCI");
+	info!("PCI: Initialized");
 }
 
 fn scan_bus(bus_range: Range<u8>, pci_config: PciConfigRegion) {
-	debug!("Scanning PCI buses {bus_range:?}");
+	info!("PCI: Scanning bus range {bus_range:?}");
 
 	// Hermit only uses PCI for network devices.
 	// Therefore, multifunction devices as well as additional bridges are not scanned.

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -111,11 +111,11 @@ impl TaskStacks {
 		let frame_range = PHYSICAL_FREE_LIST
 			.lock()
 			.allocate(frame_layout)
-			.expect("Failed to allocate Physical Memory for TaskStacks");
+			.expect("Task stacks: Physical memory allocation failed!");
 		let phys_addr = PhysAddr::from(frame_range.start());
 
 		debug!(
-			"Create stacks at {:p} with a size of {} KB",
+			"Task stacks: Create at virtual {:p} (size: {}KB)",
 			virt_addr,
 			total_size >> 10
 		);
@@ -170,11 +170,11 @@ impl TaskStacks {
 			tss.privilege_stack_table[0].as_u64() + Self::MARKER_SIZE as u64
 				- KERNEL_STACK_SIZE as u64,
 		);
-		debug!("Using boot stack {stack:p}");
+		debug!("Task stacks: Deriving from boot stack {stack:p}");
 		let ist1 = VirtAddr::new(
 			tss.interrupt_stack_table[0].as_u64() + Self::MARKER_SIZE as u64 - IST_SIZE as u64,
 		);
-		debug!("IST1 is located at {ist1:p}");
+		debug!("Task stacks: IST1 located at {ist1:p}");
 
 		TaskStacks::Boot(BootStack { stack, ist1 })
 	}
@@ -228,7 +228,7 @@ impl Drop for TaskStacks {
 			TaskStacks::Boot(_) => {}
 			TaskStacks::Common(stacks) => {
 				debug!(
-					"Deallocating stacks at {:p} with a size of {} KB",
+					"Task stacks: Deallocating at {:p} (size: {}KB)",
 					stacks.virt_addr,
 					stacks.total_size >> 10,
 				);

--- a/src/drivers/console/pci.rs
+++ b/src/drivers/console/pci.rs
@@ -38,7 +38,7 @@ impl VirtioConsoleDriver {
 		} = caps_coll;
 
 		let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioConsoleDriver::map_cfg) else {
-			error!("No dev config. Aborting!");
+			error!("virtio-console: No dev config present. Aborting!");
 			return Err(error::VirtioConsoleError::NoDevCfg(device_id));
 		};
 
@@ -66,12 +66,12 @@ impl VirtioConsoleDriver {
 			Ok(caps) => match VirtioConsoleDriver::new(caps, device) {
 				Ok(driver) => driver,
 				Err(console_err) => {
-					error!("Initializing new virtio console device driver failed. Aborting!");
+					error!("virtio-console: Driver initialization failed. Aborting!");
 					return Err(VirtioError::ConsoleDriver(console_err));
 				}
 			},
 			Err(err) => {
-				error!("Mapping capabilities failed. Aborting!");
+				error!("virtio-console: Mapping capabilities failed. Aborting!");
 				return Err(err);
 			}
 		};
@@ -79,7 +79,7 @@ impl VirtioConsoleDriver {
 		match drv.init_dev() {
 			Ok(()) => {
 				info!(
-					"Console device with id {:x}, has been initialized by driver!",
+					"Console device with ID {:x}, has been initialized by driver!",
 					drv.dev_cfg.dev_id
 				);
 

--- a/src/drivers/fs/virtio_fs.rs
+++ b/src/drivers/fs/virtio_fs.rs
@@ -70,9 +70,7 @@ impl VirtioFsDriver {
 		let device_features = virtio::fs::F::from(self.com_cfg.dev_features());
 
 		if device_features.requirements_satisfied() {
-			debug!(
-				"Feature set wanted by filesystem driver are in conformance with specification."
-			);
+			debug!("virtiofs: Feature set requested by driver is spec-conforming.");
 		} else {
 			return Err(VirtioFsError::FeatureRequirementsNotMet(device_features));
 		}
@@ -114,7 +112,7 @@ impl VirtioFsDriver {
 		// Checks if the device has accepted final set. This finishes feature negotiation.
 		if self.com_cfg.check_features() {
 			info!(
-				"Features have been negotiated between virtio filesystem device {:x} and driver.",
+				"virtiofs: Features negotiated between filesystem device {:x} and driver.",
 				self.dev_cfg.dev_id
 			);
 			// Set feature set in device config fur future use.
@@ -132,7 +130,7 @@ impl VirtioFsDriver {
 			.read()
 			.to_ne() + 1;
 		if vqnum == 0 {
-			error!("0 request queues requested from device. Aborting!");
+			error!("virtiofs: 0 request queues requested from device. Aborting!");
 			return Err(VirtioFsError::Unknown);
 		}
 

--- a/src/drivers/fs/virtio_pci.rs
+++ b/src/drivers/fs/virtio_pci.rs
@@ -39,7 +39,7 @@ impl VirtioFsDriver {
 		} = caps_coll;
 
 		let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioFsDriver::map_cfg) else {
-			error!("No dev config. Aborting!");
+			error!("virtiofs: No dev config present. Aborting!");
 			return Err(error::VirtioFsError::NoDevCfg(device_id));
 		};
 
@@ -59,19 +59,19 @@ impl VirtioFsDriver {
 			Ok(caps) => match VirtioFsDriver::new(caps, device) {
 				Ok(driver) => driver,
 				Err(fs_err) => {
-					error!("Initializing new network driver failed. Aborting!");
+					error!("virtiofs: Driver initialization failed. Aborting!");
 					return Err(VirtioError::FsDriver(fs_err));
 				}
 			},
 			Err(err) => {
-				error!("Mapping capabilities failed. Aborting!");
+				error!("virtiofs: Mapping capabilities failed. Aborting!");
 				return Err(err);
 			}
 		};
 
 		match drv.init_dev() {
 			Ok(()) => info!(
-				"Filesystem device with id {:x}, has been initialized by driver!",
+				"virtiofs: Driver initialized filesystem device with ID {:x}!",
 				drv.get_dev_id()
 			),
 			Err(fs_err) => {

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -247,13 +247,12 @@ impl NetworkDriver for GEMDriver {
 	}
 
 	fn has_packet(&self) -> bool {
-		debug!("has_packet");
-
+		trace!("has_packet");
 		self.next_rx_index().is_some()
 	}
 
 	fn set_polling_mode(&mut self, value: bool) {
-		debug!("set_polling_mode");
+		trace!("set_polling_mode");
 		if value {
 			// disable interrupts from the NIC
 			unsafe {
@@ -564,8 +563,7 @@ impl Drop for TxToken<'_> {
 
 impl Drop for GEMDriver {
 	fn drop(&mut self) {
-		debug!("Dropping GEMDriver!");
-
+		trace!("GEM: Dropping GEMDriver!");
 		unsafe {
 			// Software reset
 			// Clear the Network Control register
@@ -586,10 +584,8 @@ pub fn init_device(
 	phy_addr: u32,
 	mac: [u8; 6],
 ) -> Result<GEMDriver, DriverError> {
-	debug!("Init GEM at {gem_base:p}");
-
+	debug!("GEM: Initializing at {gem_base:p}...");
 	let gem = gem_base.as_mut_ptr::<Registers>();
-
 	unsafe {
 		// Initialize the Controller
 
@@ -719,7 +715,7 @@ pub fn init_device(
 			// TODO - Next Page does not seem to be emulated by QEMU
 
 			//info!("PHY auto-negotiation completed:\n Speed: {}\nDuplex");
-			debug!("PHY auto-negotiation completed: Partner Ability {partner_ability:x}");
+			debug!("GEM: PHY auto-negotiation complete. Partner Ability: {partner_ability:x}");
 		}
 	}
 
@@ -804,7 +800,7 @@ pub fn init_device(
 		(*gem).tx_qbar.set(tx_qbar);
 
 		// Configure Interrupts
-		debug!("Install interrupt handler for GEM");
+		debug!("GEM: Install interrupt handler");
 
 		(*gem).int_enable.write(Interrupts::FRAMERX::SET); // + Interrupts::TXCOMPL::SET
 

--- a/src/drivers/net/virtio/mmio.rs
+++ b/src/drivers/net/virtio/mmio.rs
@@ -67,7 +67,7 @@ impl VirtioNetDriver<Uninit> {
 				}
 			}
 		} else {
-			error!("Unable to create Driver. Aborting!");
+			error!("virtio-net: Driver initialization failed. Aborting!");
 			Err(VirtioError::Unknown)
 		}
 	}
@@ -77,7 +77,7 @@ impl VirtioNetDriver<Init> {
 	pub fn print_information(&mut self) {
 		self.com_cfg.print_information();
 		if self.dev_status() == virtio::net::S::LINK_UP {
-			info!("The link of the network device is up!");
+			info!("virtio-net: Link is up!");
 		}
 	}
 }

--- a/src/drivers/net/virtio/pci.rs
+++ b/src/drivers/net/virtio/pci.rs
@@ -44,7 +44,7 @@ impl VirtioNetDriver<Uninit> {
 		} = caps_coll;
 
 		let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioNetDriver::map_cfg) else {
-			error!("No dev config. Aborting!");
+			error!("virtio-net: No dev config present. Aborting!");
 			return Err(error::VirtioNetError::NoDevCfg(device_id));
 		};
 
@@ -78,12 +78,12 @@ impl VirtioNetDriver<Uninit> {
 			Ok(caps) => match VirtioNetDriver::new(caps, device) {
 				Ok(driver) => driver,
 				Err(vnet_err) => {
-					error!("Initializing new network driver failed. Aborting!");
+					error!("virtio-net: Driver initialization failed. Aborting!");
 					return Err(VirtioError::NetDriver(vnet_err));
 				}
 			},
 			Err(err) => {
-				error!("Mapping capabilities failed. Aborting!");
+				error!("virtio-net: Capability mapping failed. Aborting!");
 				return Err(err);
 			}
 		};
@@ -91,7 +91,7 @@ impl VirtioNetDriver<Uninit> {
 		let initialized_drv = match drv.init_dev() {
 			Ok(initialized_drv) => {
 				info!(
-					"Network device with id {:x}, has been initialized by driver!",
+					"virtio-net: Initialized network device with ID {:x}",
 					initialized_drv.get_dev_id()
 				);
 				initialized_drv
@@ -102,9 +102,9 @@ impl VirtioNetDriver<Uninit> {
 		};
 
 		if initialized_drv.is_link_up() {
-			info!("Virtio-net link is up after initialization.");
+			info!("virtio-net: Link is up after initialization.");
 		} else {
-			info!("Virtio-net link is down after initialization!");
+			info!("virtio-net: Link is down after initialization!");
 		}
 
 		Ok(initialized_drv)

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -519,7 +519,7 @@ pub(crate) fn init() {
 				#[cfg(feature = "console")]
 				Ok(VirtioDriver::Console(drv)) => {
 					register_driver(PciDriver::VirtioConsole(InterruptTicketMutex::new(*drv)));
-					info!("Switch to virtio console");
+					info!("virtio-console: Switch to console");
 					crate::console::CONSOLE
 						.lock()
 						.replace_device(IoDevice::Virtio(VirtioUART::new()));

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -59,19 +59,19 @@ pub mod error {
 				VirtioError::FromPci(pci_error) => match pci_error {
 					PciError::General(id) => write!(
 						f,
-						"Driver failed to initialize device with id: {id:#x}. Due to unknown reasosn!"
+						"Driver failed to initialize device with ID: {id:#x}. Reason: Unknown."
 					),
 					PciError::NoBar(id) => write!(
 						f,
-						"Driver failed to initialize device with id: {id:#x}. Reason: No BAR's found."
+						"Driver failed to initialize device with ID: {id:#x}. Reason: No BAR's found."
 					),
 					PciError::NoCapPtr(id) => write!(
 						f,
-						"Driver failed to initialize device with id: {id:#x}. Reason: No Capabilities pointer found."
+						"Driver failed to initialize device with ID: {id:#x}. Reason: No capabilities pointer found."
 					),
 					PciError::NoVirtioCaps(id) => write!(
 						f,
-						"Driver failed to initialize device with id: {id:#x}. Reason: No Virtio capabilities were found."
+						"Driver failed to initialize device with ID: {id:#x}. Reason: No virtio capabilities found."
 					),
 				},
 				#[cfg(feature = "pci")]
@@ -90,7 +90,7 @@ pub mod error {
 					"Virtio driver failed, for device {id:x}, due to a missing or malformed notification config!"
 				),
 				VirtioError::DevNotSupported(id) => {
-					write!(f, "Device with id {id:#x} not supported.")
+					write!(f, "Device with ID {id:#x} not supported.")
 				}
 				#[cfg(all(
 					not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -378,7 +378,7 @@ pub(crate) fn init_device(
 	let dev_id: u16 = 0;
 
 	if registers.as_ptr().version().read().to_ne() == 0x1 {
-		error!("Legacy interface isn't supported!");
+		error!("virtio: Legacy interface is not supported!");
 		return Err(DriverError::InitVirtioDevFail(
 			VirtioError::DevNotSupported(dev_id),
 		));
@@ -389,50 +389,50 @@ pub(crate) fn init_device(
 		#[cfg(feature = "virtio-net")]
 		virtio::Id::Net => match VirtioNetDriver::init(dev_id, registers, irq_no) {
 			Ok(virt_net_drv) => {
-				info!("Virtio network driver initialized.");
+				info!("virtio: virtio-net driver initialized.");
 
 				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {irq_no}");
+				info!("virtio: virtio-net interrupt handler at line {irq_no}");
 
 				Ok(VirtioDriver::Network(virt_net_drv))
 			}
 			Err(virtio_error) => {
-				error!("Virtio network driver could not be initialized with device");
+				error!("virtio: virtio-net driver could not be initialized with device.");
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
 		#[cfg(feature = "console")]
 		virtio::Id::Console => match VirtioConsoleDriver::init(dev_id, registers, irq_no) {
 			Ok(virt_console_drv) => {
-				info!("Virtio console driver initialized.");
+				info!("virtio: virtio-console driver initialized.");
 
 				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {}", irq_no);
+				info!("virtio: virtio-console interrupt handler at line {irq_no}");
 
 				Ok(VirtioDriver::Console(Box::new(virt_console_drv)))
 			}
 			Err(virtio_error) => {
-				error!("Virtio console driver could not be initialized with device");
+				error!("virtio: virtio-console driver could not be initialized with device.");
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
 		#[cfg(feature = "vsock")]
 		virtio::Id::Vsock => match VirtioVsockDriver::init(dev_id, registers, irq_no) {
 			Ok(virt_net_drv) => {
-				info!("Virtio sock driver initialized.");
+				info!("virtio: vsock driver initialized.");
 
 				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {}", irq_no);
+				info!("virtio: vsock interrupt handler at line {}", irq_no);
 
 				Ok(VirtioDriver::Vsock(virt_vsock_drv))
 			}
 			Err(virtio_error) => {
-				error!("Virtio sock driver could not be initialized with device");
+				error!("virtio: vsock driver could not be initialized with device.");
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
 		device_id => {
-			error!("Device with id {device_id:?} is currently not supported!");
+			error!("virtio: Device with ID {device_id:?} is not supported!");
 			// Return Driver error inidacting device is not supported
 			Err(DriverError::InitVirtioDevFail(
 				VirtioError::DevNotSupported(dev_id),

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -43,13 +43,13 @@ use crate::drivers::vsock::VirtioVsockDriver;
 /// returns a static reference to it.
 pub fn map_dev_cfg<T>(cap: &PciCap) -> Option<&'static mut T> {
 	if cap.cap.cfg_type != CapCfgType::Device {
-		error!("Capability of device config has wrong id. Mapping not possible...");
+		error!("virtio: Capability of device config has wrong id. Mapping not possible...");
 		return None;
 	};
 
 	if cap.bar_len() < cap.len() + cap.offset() {
 		error!(
-			"Device config of device {:x}, does not fit into memory specified by bar!",
+			"virtio: Device config of device {:x}, does not fit into memory specified by bar!",
 			cap.dev_id(),
 		);
 		return None;
@@ -58,7 +58,7 @@ pub fn map_dev_cfg<T>(cap: &PciCap) -> Option<&'static mut T> {
 	// Drivers MAY do this check. See Virtio specification v1.1. - 4.1.4.1
 	if cap.len() < u64::try_from(mem::size_of::<T>()).unwrap() {
 		error!(
-			"Device specific config from device {:x}, does not represent actual structure specified by the standard!",
+			"virtio: Device specific config from device {:x}, does not represent structure specified by the standard!",
 			cap.dev_id()
 		);
 		return None;
@@ -117,7 +117,7 @@ impl PciCap {
 	fn map_common_cfg(&self) -> Option<VolatileRef<'static, CommonCfg>> {
 		if self.bar.length < self.len() + self.offset() {
 			error!(
-				"Common config of the capability with id {} of device {:x} does not fit into memory specified by bar {:x}!",
+				"virtio: Common config of the capability with ID {} of device {:x} does not fit into memory specified by bar {:x}!",
 				self.cap.id, self.dev_id, self.bar.index
 			);
 			return None;
@@ -126,7 +126,7 @@ impl PciCap {
 		// Drivers MAY do this check. See Virtio specification v1.1. - 4.1.4.1
 		if self.len() < u64::try_from(mem::size_of::<CommonCfg>()).unwrap() {
 			error!(
-				"Common config of with id {}, does not represent actual structure specified by the standard!",
+				"virtio: Common config of with ID {}, does not represent actual structure specified by the standard!",
 				self.cap.id
 			);
 			return None;
@@ -147,7 +147,7 @@ impl PciCap {
 	fn map_isr_status(&self) -> Option<VolatileRef<'static, IsrStatusRaw>> {
 		if self.bar.length < self.len() + self.offset() {
 			error!(
-				"ISR status config with id {} of device {:x}, does not fit into memory specified by bar {:x}!",
+				"virtio: ISR status config with ID {} of device {:x}, does not fit into memory specified by bar {:x}!",
 				self.cap.id, self.dev_id, self.bar.index
 			);
 			return None;
@@ -443,7 +443,7 @@ impl NotifCfg {
 	fn new(cap: &PciCap) -> Option<Self> {
 		if cap.bar.length < cap.len() + cap.offset() {
 			error!(
-				"Notification config with id {} of device {:x}, does not fit into memory specified by bar {:x}!",
+				"virtio: Notification config with ID {} of device {:x}, does not fit into memory specified by bar {:x}!",
 				cap.cap.id, cap.dev_id, cap.bar.index
 			);
 			return None;
@@ -582,7 +582,7 @@ impl ShMemCfg {
 	fn new(cap: &PciCap) -> Option<Self> {
 		if cap.bar.length < cap.len() + cap.offset() {
 			error!(
-				"Shared memory config of with id {} of device {:x}, does not fit into memory specified by bar {:x}!",
+				"virtio: Shared memory config of with ID {} of device {:x}, does not fit into memory specified by bar {:x}!",
 				cap.cap.id, cap.dev_id, cap.bar.index
 			);
 			return None;
@@ -702,7 +702,7 @@ fn read_caps(device: &PciDevice<PciConfigRegion>) -> Result<Vec<PciCap>, PciErro
 		.collect::<Vec<_>>();
 
 	if capabilities.is_empty() {
-		error!("No virtio capability found for device {device_id:x}");
+		error!("virtio: No virtio capability found for device {device_id:x}");
 		Err(PciError::NoVirtioCaps(device_id))
 	} else {
 		Ok(capabilities)
@@ -714,7 +714,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 
 	// In case caplist pointer is not used, abort as it is essential
 	if !device.status().has_capability_list() {
-		error!("Found virtio device without capability list. Aborting!");
+		error!("virtio: Found virtio device without capability list. Aborting!");
 		return Err(VirtioError::FromPci(PciError::NoCapPtr(device_id)));
 	}
 
@@ -737,7 +737,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 					match pci_cap.map_common_cfg() {
 						Some(cap) => com_cfg = Some(ComCfg::new(cap, pci_cap.cap.id)),
 						None => error!(
-							"Common config capability with id {}, of device {:x}, could not be mapped!",
+							"virtio: Common config capability with ID {}, of device {:x}, could not be mapped!",
 							pci_cap.cap.id, device_id
 						),
 					}
@@ -748,7 +748,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 					match NotifCfg::new(&pci_cap) {
 						Some(notif) => notif_cfg = Some(notif),
 						None => error!(
-							"Notification config capability with id {}, of device {device_id:x} could not be used!",
+							"virtio: Notification config capability with ID {}, of device {device_id:x} could not be used!",
 							pci_cap.cap.id
 						),
 					}
@@ -759,7 +759,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 					match pci_cap.map_isr_status() {
 						Some(isr_stat) => isr_cfg = Some(IsrStatus::new(isr_stat, pci_cap.cap.id)),
 						None => error!(
-							"ISR status config capability with id {}, of device {device_id:x} could not be used!",
+							"virtio: ISR status config capability with ID {}, of device {device_id:x} could not be used!",
 							pci_cap.cap.id
 						),
 					}
@@ -768,7 +768,7 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 			CapCfgType::SharedMemory => match ShMemCfg::new(&pci_cap) {
 				Some(sh_mem) => sh_mem_cfg_list.push(sh_mem),
 				None => error!(
-					"Shared Memory config capability with id {}, of device {device_id:x} could not be used!",
+					"virtio: Shared Memory config capability with ID {}, of device {device_id:x} could not be used!",
 					pci_cap.cap.id,
 				),
 			},
@@ -798,9 +798,7 @@ pub(crate) fn init_device(
 	let device_id = device.device_id();
 
 	if device_id < 0x1040 {
-		warn!(
-			"Legacy/transitional Virtio device, with id: {device_id:#x} is NOT supported, skipping!"
-		);
+		warn!("virtio: Legacy virtio device with ID: {device_id:#x} is not supported, skipping!");
 
 		// Return Driver error inidacting device is not supported
 		return Err(DriverError::InitVirtioDevFail(
@@ -818,17 +816,17 @@ pub(crate) fn init_device(
 		))]
 		virtio::Id::Net => match VirtioNetDriver::init(device) {
 			Ok(virt_net_drv) => {
-				info!("Virtio network driver initialized.");
+				info!("virtio: virtio-net driver initialized.");
 
 				let irq = device.get_irq().unwrap();
 				crate::arch::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
+				info!("virtio: virtio-net interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Network(virt_net_drv))
 			}
 			Err(virtio_error) => {
 				error!(
-					"Virtio networkd driver could not be initialized with device: {device_id:x}"
+					"virtio: virtio-net driver could not be initialized with device: {device_id:x}"
 				);
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
@@ -836,32 +834,36 @@ pub(crate) fn init_device(
 		#[cfg(feature = "console")]
 		virtio::Id::Console => match VirtioConsoleDriver::init(device) {
 			Ok(virt_console_drv) => {
-				info!("Virtio console driver initialized.");
+				info!("virtio: virtio-console driver initialized.");
 
 				let irq = device.get_irq().unwrap();
 				crate::arch::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
+				info!("virtio: virtio-console interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Console(Box::new(virt_console_drv)))
 			}
 			Err(virtio_error) => {
-				error!("Virtio console driver could not be initialized with device: {device_id:x}");
+				error!(
+					"virtio: virtio-console driver could not be initialized with device: {device_id:x}"
+				);
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
 		#[cfg(feature = "vsock")]
 		virtio::Id::Vsock => match VirtioVsockDriver::init(device) {
 			Ok(virt_sock_drv) => {
-				info!("Virtio sock driver initialized.");
+				info!("virtio: virtio-sock driver initialized.");
 
 				let irq = device.get_irq().unwrap();
 				crate::arch::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
+				info!("virtio: virtio-sock interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Vsock(Box::new(virt_sock_drv)))
 			}
 			Err(virtio_error) => {
-				error!("Virtio sock driver could not be initialized with device: {device_id:x}");
+				error!(
+					"virtio: virtio-sock driver could not be initialized with device: {device_id:x}"
+				);
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
@@ -871,19 +873,19 @@ pub(crate) fn init_device(
 			// TODO: proper error handling on driver creation fail
 			match VirtioFsDriver::init(device) {
 				Ok(virt_fs_drv) => {
-					info!("Virtio filesystem driver initialized.");
+					info!("virtio: virtiofs driver initialized.");
 					Ok(VirtioDriver::FileSystem(virt_fs_drv))
 				}
 				Err(virtio_error) => {
 					error!(
-						"Virtio filesystem driver could not be initialized with device: {device_id:x}"
+						"virtio: virtiofs driver could not be initialized with device: {device_id:x}"
 					);
 					Err(DriverError::InitVirtioDevFail(virtio_error))
 				}
 			}
 		}
 		id => {
-			warn!("Virtio device {id:?} is not supported, skipping!");
+			warn!("virtio: Device {id:?} is not supported, skipping!");
 
 			// Return Driver error inidacting device is not supported
 			Err(DriverError::InitVirtioDevFail(

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -671,7 +671,7 @@ impl PackedVq {
 		// carry a feature u64 in order to check which features are used currently
 		// and adjust its ReadCtrl accordingly.
 		if features.contains(virtio::F::IN_ORDER) {
-			info!("PackedVq has no support for VIRTIO_F_IN_ORDER. Aborting...");
+			info!("virtqueue: PackedVq has no support for VIRTIO_F_IN_ORDER. Aborting...");
 			return Err(VirtqError::FeatureNotSupported(virtio::F::IN_ORDER));
 		}
 
@@ -731,7 +731,10 @@ impl PackedVq {
 
 		vq_handler.enable_queue();
 
-		info!("Created PackedVq: idx={}, size={}", index.0, vq_size);
+		info!(
+			"virtqueue: Created PackedVq: idx={}, size={}",
+			index.0, vq_size
+		);
 
 		Ok(PackedVq {
 			descr_ring,

--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -311,7 +311,7 @@ impl SplitVq {
 
 		vq_handler.enable_queue();
 
-		info!("Created SplitVq: idx={}, size={}", index.0, size);
+		info!("virtqueue: Created SplitVq: idx={}, size={}", index.0, size);
 
 		Ok(SplitVq {
 			ring: descr_ring,

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -40,8 +40,7 @@ fn fill_queue(vq: &mut VirtQueue, num_packets: u16, packet_size: u32) {
 		) {
 			Ok(tkn) => tkn,
 			Err(_vq_err) => {
-				error!("Setup of network queue failed, which should not happen!");
-				panic!("setup of network queue failed!");
+				panic!("vsock: Setup of network queue failed, which should not happen!");
 			}
 		};
 
@@ -72,7 +71,7 @@ impl RxQueue {
 	pub fn add(&mut self, mut vq: VirtQueue) {
 		const BUFF_PER_PACKET: u16 = 2;
 		let num_packets: u16 = u16::from(vq.size()) / BUFF_PER_PACKET;
-		info!("num_packets {num_packets}");
+		info!("vsock: num_packets {num_packets}");
 		fill_queue(&mut vq, num_packets, self.packet_size);
 
 		self.vq = Some(vq);
@@ -112,7 +111,7 @@ impl RxQueue {
 
 				fill_queue(vq, 1, self.packet_size);
 			} else {
-				panic!("Invalid length of receive queue");
+				panic!("vsock: Invalid length of receive queue");
 			}
 		}
 	}
@@ -188,7 +187,7 @@ impl TxQueue {
 
 			result
 		} else {
-			panic!("Unable to get send queue");
+			panic!("vsock: Unable to get send queue");
 		}
 	}
 }
@@ -293,13 +292,13 @@ impl VirtioVsockDriver {
 
 		#[cfg(not(feature = "pci"))]
 		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
-			info!("Configuration changes are not possible! Aborting");
+			info!("vsock: Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}
 
 		#[cfg(feature = "pci")]
 		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
-			info!("Configuration changes are not possible! Aborting");
+			info!("vsock: Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}
 
@@ -315,7 +314,7 @@ impl VirtioVsockDriver {
 		let device_features = virtio::vsock::F::from(self.com_cfg.dev_features());
 
 		if device_features.requirements_satisfied() {
-			info!("Feature set wanted by vsock driver are in conformance with specification.");
+			info!("vsock: Feature set requested by driver is spec-conforming.");
 		} else {
 			return Err(VirtioVsockError::FeatureRequirementsNotMet(device_features));
 		}
@@ -357,7 +356,7 @@ impl VirtioVsockDriver {
 		// Checks if the device has accepted final set. This finishes feature negotiation.
 		if self.com_cfg.check_features() {
 			info!(
-				"Features have been negotiated between virtio socket device {:x} and driver.",
+				"vsock: Features negotiated between virtio socket device {:x} and driver.",
 				self.dev_cfg.dev_id
 			);
 			// Set feature set in device config fur future use.

--- a/src/drivers/vsock/pci.rs
+++ b/src/drivers/vsock/pci.rs
@@ -44,7 +44,7 @@ impl VirtioVsockDriver {
 		} = caps_coll;
 
 		let Some(dev_cfg) = dev_cfg_list.iter().find_map(VirtioVsockDriver::map_cfg) else {
-			error!("No dev config. Aborting!");
+			error!("No dev config present. Aborting!");
 			return Err(error::VirtioVsockError::NoDevCfg(device_id));
 		};
 
@@ -70,12 +70,12 @@ impl VirtioVsockDriver {
 			Ok(caps) => match VirtioVsockDriver::new(caps, device) {
 				Ok(driver) => driver,
 				Err(vsock_err) => {
-					error!("Initializing new virtio socket device driver failed. Aborting!");
+					error!("vsock: Driver initialization failed. Aborting!");
 					return Err(VirtioError::VsockDriver(vsock_err));
 				}
 			},
 			Err(err) => {
-				error!("Mapping capabilities failed. Aborting!");
+				error!("vsock: Mapping capabilities failed. Aborting!");
 				return Err(err);
 			}
 		};
@@ -83,7 +83,7 @@ impl VirtioVsockDriver {
 		match drv.init_dev() {
 			Ok(()) => {
 				info!(
-					"Socket device with cid {:x}, has been initialized by driver!",
+					"vsock: Driver initialized socket device with cid {:x}",
 					drv.dev_cfg.raw.guest_cid
 				);
 

--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -58,16 +58,16 @@ impl<'a> NetworkInterface<'a> {
 		#[cfg(feature = "trace")]
 		let mut device = Tracer::new(device, |timestamp, printer| trace!("{timestamp} {printer}"));
 
-		if hermit_var!("HERMIT_IP").is_some() {
+		if let Some(hermit_ip) = hermit_var!("HERMIT_IP") {
 			warn!(
-				"A static IP address is specified with the environment variable HERMIT_IP, but the device is configured to use DHCPv4!"
+				"Device is configured to use DHCPv4, but the environment variable HERMIT_IP has set the following static IP address: {hermit_ip}"
 			);
 		}
 
 		let ethernet_addr = EthernetAddress([mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]]);
 		let hardware_addr = HardwareAddress::Ethernet(ethernet_addr);
 
-		info!("MAC address {hardware_addr}");
+		info!("MAC Address: {hardware_addr}");
 		let capabilities = device.capabilities();
 		info!("{:?}", capabilities.checksum);
 		info!("MTU: {} bytes", capabilities.max_transmission_unit);
@@ -132,9 +132,9 @@ impl<'a> NetworkInterface<'a> {
 		let hardware_addr = HardwareAddress::Ethernet(ethernet_addr);
 		let ip_addr = IpCidr::from(Ipv4Cidr::from_netmask(myip, mymask).unwrap());
 
-		info!("MAC address {hardware_addr}");
-		info!("Configure network interface with address {ip_addr}");
-		info!("Configure gateway with address {mygw}");
+		info!("MAC Address: {hardware_addr}");
+		info!("IPv4: {ip_addr}");
+		info!("Gateway IP: {mygw}");
 		let capabilities = device.capabilities();
 		info!("{:?}", capabilities.checksum);
 		info!("MTU: {} bytes", capabilities.max_transmission_unit);

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -245,7 +245,7 @@ pub(crate) async fn get_query_result(query: QueryHandle) -> io::Result<Vec<IpAdd
 }
 
 pub(crate) fn init() {
-	info!("Try to initialize network!");
+	info!("Network: Initializing...");
 
 	// initialize variable, which contains the next local endpoint
 	LOCAL_ENDPOINT.store(start_endpoint(), Ordering::Relaxed);

--- a/src/executor/vsock.rs
+++ b/src/executor/vsock.rs
@@ -204,7 +204,7 @@ impl VsockMap {
 }
 
 pub(crate) fn init() {
-	info!("Try to initialize vsock interface!");
+	info!("vsock: Initializing...");
 
 	spawn(vsock_run());
 }

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -229,10 +229,10 @@ impl VfsNode for UhyveDirectory {
 }
 
 pub(crate) fn init() {
-	info!("Try to initialize uhyve filesystem");
+	info!("uhyve hostfs: Initializing...");
 	if is_uhyve() {
 		let mount_point = hermit_var_or!("UHYVE_MOUNT", "/root").to_string();
-		info!("Mounting uhyve filesystem at {mount_point}");
+		info!("uhyve hostfs: Mounting uhyve filesystem at {mount_point}");
 		fs::FILESYSTEM
 			.get()
 			.unwrap()

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -343,9 +343,6 @@ pub(crate) fn unmap(virtual_address: VirtAddr, size: usize) {
 			KERNEL_FREE_LIST.lock().deallocate(range).unwrap();
 		}
 	} else {
-		panic!(
-			"No page table entry for virtual address {:p}",
-			virtual_address
-		);
+		panic!("No page table entry for virtual address {virtual_address:p}",);
 	}
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -297,11 +297,11 @@ impl PerCoreScheduler {
 				core_scheduler().ready_queue.push(task);
 				false
 			} else {
-				panic!("Invalid  core_id {}!", core_id)
+				panic!("Invalid core_id {core_id}!")
 			}
 		};
 
-		debug!("Creating task {tid} with priority {prio} on core {core_id}");
+		debug!("CPU {core_id}: Creating task {tid} with priority {prio}.");
 
 		if wakeup {
 			arch::wakeup_core(core_id);
@@ -373,7 +373,7 @@ impl PerCoreScheduler {
 				core_scheduler().ready_queue.push(clone_task);
 				false
 			} else {
-				panic!("Invalid core_id {}!", core_id);
+				panic!("Invalid core_id {core_id}!");
 			}
 		};
 
@@ -634,14 +634,13 @@ impl PerCoreScheduler {
 
 	pub fn set_current_task_priority(&mut self, prio: Priority) {
 		without_interrupts(|| {
-			trace!("Change priority of the current task");
+			trace!("Scheduler: Change priority of current task .");
 			self.current_task.borrow_mut().prio = prio;
 		});
 	}
 
 	pub fn set_priority(&mut self, id: TaskId, prio: Priority) -> Result<(), ()> {
-		trace!("Change priority of task {id} to priority {prio}");
-
+		trace!("Scheduler: Change priority of task {id} to priority {prio}.");
 		without_interrupts(|| {
 			let task = get_task_handle(id).ok_or(())?;
 			#[cfg(feature = "smp")]
@@ -650,13 +649,13 @@ impl PerCoreScheduler {
 			let other_core = false;
 
 			if other_core {
-				warn!("Have to change the priority on another core");
+				warn!("Scheduler: Must change the priority on another core.");
 			} else if self.current_task.borrow().id == task.get_id() {
 				self.current_task.borrow_mut().prio = prio;
 			} else {
 				self.ready_queue
 					.set_priority(task, prio)
-					.expect("Do not find valid task in ready queue");
+					.expect("Scheduler: No valid task found in ready queue.");
 			}
 
 			Ok(())
@@ -680,7 +679,7 @@ impl PerCoreScheduler {
 	pub fn fpu_switch(&mut self) {
 		if !Rc::ptr_eq(&self.current_task, &self.fpu_owner) {
 			debug!(
-				"Switching FPU owner from task {} to {}",
+				"Scheduler: Switching FPU owner from task {} to {}",
 				self.fpu_owner.borrow().id,
 				self.current_task.borrow().id
 			);
@@ -695,7 +694,7 @@ impl PerCoreScheduler {
 	fn cleanup_tasks(&mut self) {
 		// Pop the first finished task and remove it from the TASKS list, which implicitly deallocates all associated memory.
 		while let Some(finished_task) = self.finished_tasks.pop_front() {
-			debug!("Cleaning up task {}", finished_task.borrow().id);
+			debug!("Scheduler: Cleaning up task {}", finished_task.borrow().id);
 		}
 	}
 
@@ -794,11 +793,11 @@ impl PerCoreScheduler {
 			// Check if there is any available task and get the one with the highest priority.
 			if let Some(task) = self.ready_queue.pop() {
 				// This available task becomes the new task.
-				debug!("Task is available.");
+				debug!("Scheduler: Task is available.");
 				new_task = Some(task);
 			} else if status != TaskStatus::Idle {
 				// The Idle task becomes the new task.
-				debug!("Only Idle Task is available.");
+				debug!("Scheduler: Only Idle Task is available.");
 				new_task = Some(self.idle_task.clone());
 			}
 		}
@@ -896,7 +895,7 @@ pub(crate) fn add_current_core() {
 		),
 	);
 	// Initialize a scheduler for this core.
-	debug!("Initializing scheduler for core {core_id} with idle task {tid}");
+	debug!("Initializing scheduler for core {core_id} with IDle task {tid}");
 	let boxed_scheduler = Box::new(PerCoreScheduler {
 		#[cfg(feature = "smp")]
 		core_id,

--- a/src/scheduler/task.rs
+++ b/src/scheduler/task.rs
@@ -421,7 +421,7 @@ impl Task {
 			>,
 		>,
 	) -> Task {
-		debug!("Creating new task {tid} on core {core_id}");
+		debug!("Scheduler: Creating new task {tid} on core {core_id}");
 
 		Task {
 			id: tid,
@@ -441,7 +441,7 @@ impl Task {
 	}
 
 	pub fn new_idle(tid: TaskId, core_id: CoreId) -> Task {
-		debug!("Creating idle task {tid}");
+		debug!("Scheduler: Creating idle task {tid}");
 
 		/// All cores use the same mapping between file descriptor and the referenced object
 		static OBJECT_MAP: OnceCell<
@@ -533,7 +533,7 @@ impl Task {
 
 /*impl Drop for Task {
 	fn drop(&mut self) {
-		debug!("Drop task {}", self.id);
+		debug!("Scheduler: Drop task {}", self.id);
 	}
 }*/
 
@@ -566,7 +566,7 @@ impl BlockedTaskQueue {
 	fn mark_ready(task: &RefCell<Task>) {
 		let mut borrowed = task.borrow_mut();
 		debug!(
-			"Waking up task {} on core {}",
+			"Scheduler: Waking up task {} on core {}",
 			borrowed.id, borrowed.core_id
 		);
 
@@ -605,7 +605,7 @@ impl BlockedTaskQueue {
 		{
 			// Set the task status to Blocked.
 			let mut borrowed = task.borrow_mut();
-			debug!("Blocking task {}", borrowed.id);
+			debug!("Scheduler: Blocking task {}", borrowed.id);
 
 			assert_eq!(
 				borrowed.status,

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -93,7 +93,7 @@ pub(crate) fn init() {
 pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
 	let layout_res = Layout::from_size_align(size, align);
 	if layout_res.is_err() || size == 0 {
-		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		warn!("__sys_alloc: called with size {size:#x}, align {align:#x} is an invalid layout!");
 		return core::ptr::null_mut();
 	}
 	let layout = layout_res.unwrap();
@@ -111,7 +111,7 @@ pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
 	let layout_res = Layout::from_size_align(size, align);
 	if layout_res.is_err() || size == 0 {
 		warn!(
-			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
+			"__sys_alloc_zeroed: called with size {size:#x}, align {align:#x} is an invalid layout!"
 		);
 		return core::ptr::null_mut();
 	}
@@ -129,7 +129,7 @@ pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
 pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 	let layout_res = Layout::from_size_align(size, align);
 	if layout_res.is_err() || size == 0 {
-		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		warn!("__sys_malloc: called with size {size:#x}, align {align:#x} is an invalid layout!");
 		return core::ptr::null_mut();
 	}
 	let layout = layout_res.unwrap();
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn sys_realloc(
 		let layout_res = Layout::from_size_align(size, align);
 		if layout_res.is_err() || size == 0 || new_size == 0 {
 			warn!(
-				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
+				"__sys_realloc: called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
 			);
 			return core::ptr::null_mut();
 		}
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn sys_realloc(
 
 		if new_ptr.is_null() {
 			debug!(
-				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
+				"__sys_realloc: failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
 			);
 		} else {
 			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
 		let layout_res = Layout::from_size_align(size, align);
 		if layout_res.is_err() || size == 0 {
 			warn!(
-				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
+				"__sys_dealloc: called with size {size:#x}, align {align:#x} is an invalid layout!"
 			);
 			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
 			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 	unsafe {
 		let layout_res = Layout::from_size_align(size, align);
 		if layout_res.is_err() || size == 0 {
-			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
+			warn!("__sys_free: called with size {size:#x}, align {align:#x} is an invalid layout!");
 			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
 			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
 		} else {
@@ -438,7 +438,7 @@ pub unsafe extern "C" fn sys_faccessat(
 			fs::read_lstat(name)
 		}
 	} else {
-		warn!("faccessat with directory relative to fd is not implemented!");
+		error!("sys_faccessat: directory relative to fd is not implemented!");
 		return -i32::from(Errno::Nosys);
 	};
 
@@ -790,7 +790,7 @@ pub unsafe extern "C" fn sys_getdents64(
 	dirp: *mut Dirent64,
 	count: usize,
 ) -> i64 {
-	debug!("getdents for fd {fd:?} - count: {count}");
+	debug!("sys_getdents64: for fd {fd:?} - count: {count}");
 	if dirp.is_null() || count == 0 {
 		return (-i32::from(Errno::Inval)).into();
 	}

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -68,7 +68,7 @@ pub extern "C" fn sys_abort() -> ! {
 pub(super) fn usleep(usecs: u64) {
 	if usecs >= 10_000 {
 		// Enough time to set a wakeup timer and block the current task.
-		debug!("sys_usleep blocking the task for {usecs} microseconds");
+		debug!("sys_usleep: task blocked for {usecs} microseconds");
 		let wakeup_time = arch::processor::get_timer_ticks() + usecs;
 		let core_scheduler = core_scheduler();
 		core_scheduler.block_current_task(Some(wakeup_time));
@@ -101,11 +101,11 @@ pub extern "C" fn sys_usleep(usecs: u64) {
 pub unsafe extern "C" fn sys_nanosleep(rqtp: *const timespec, _rmtp: *mut timespec) -> i32 {
 	assert!(
 		!rqtp.is_null(),
-		"sys_nanosleep called with a zero rqtp parameter"
+		"sys_nanosleep: called with a zero rqtp parameter"
 	);
 	let requested_time = unsafe { &*rqtp };
 	if requested_time.tv_sec < 0 || requested_time.tv_nsec > 999_999_999 {
-		debug!("sys_nanosleep called with an invalid requested time, returning -EINVAL");
+		debug!("sys_nanosleep: called with an invalid requested time, returning -EINVAL");
 		return -i32::from(Errno::Inval);
 	}
 
@@ -252,7 +252,7 @@ pub extern "C" fn sys_set_priority(id: Tid, prio: u8) {
 			.set_priority(TaskId::from(id), Priority::from(prio))
 			.expect("Unable to set priority");
 	} else {
-		panic!("Invalid priority {}", prio);
+		panic!("Invalid priority {prio}");
 	}
 }
 
@@ -263,6 +263,6 @@ pub extern "C" fn sys_set_current_task_priority(prio: u8) {
 	if prio > 0 {
 		core_scheduler().set_current_task_priority(Priority::from(prio));
 	} else {
-		panic!("Invalid priority {}", prio);
+		panic!("Invalid priority {prio}");
 	}
 }

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -27,7 +27,7 @@ pub(crate) const TIMER_ABSTIME: i32 = 4;
 pub unsafe extern "C" fn sys_clock_getres(clock_id: clockid_t, res: *mut timespec) -> i32 {
 	assert!(
 		!res.is_null(),
-		"sys_clock_getres called with a zero res parameter"
+		"sys_clock_getres: called with a zero res parameter"
 	);
 	let result = unsafe { &mut *res };
 
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn sys_clock_getres(clock_id: clockid_t, res: *mut timespe
 			0
 		}
 		_ => {
-			debug!("Called sys_clock_getres for unsupported clock {clock_id}");
+			error!("sys_clock_getres: called for unsupported clock {clock_id}");
 			-i32::from(Errno::Inval)
 		}
 	}
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn sys_clock_getres(clock_id: clockid_t, res: *mut timespe
 pub unsafe extern "C" fn sys_clock_gettime(clock_id: clockid_t, tp: *mut timespec) -> i32 {
 	assert!(
 		!tp.is_null(),
-		"sys_clock_gettime called with a zero tp parameter"
+		"sys_clock_gettime: called with a zero tp parameter"
 	);
 	let result = unsafe { &mut *tp };
 
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn sys_clock_gettime(clock_id: clockid_t, tp: *mut timespe
 			0
 		}
 		_ => {
-			debug!("Called sys_clock_gettime for unsupported clock {clock_id}");
+			error!("sys_clock_gettime: called for unsupported clock {clock_id}");
 			-i32::from(Errno::Inval)
 		}
 	}
@@ -96,11 +96,11 @@ pub unsafe extern "C" fn sys_clock_nanosleep(
 ) -> i32 {
 	assert!(
 		!rqtp.is_null(),
-		"sys_clock_nanosleep called with a zero rqtp parameter"
+		"sys_clock_nanosleep: called with a zero rqtp parameter"
 	);
 	let requested_time = unsafe { &*rqtp };
 	if requested_time.tv_sec < 0 || requested_time.tv_nsec > 999_999_999 {
-		debug!("sys_clock_nanosleep called with an invalid requested time, returning -EINVAL");
+		error!("sys_clock_nanosleep: called with an invalid requested time, returning -EINVAL");
 		return -i32::from(Errno::Inval);
 	}
 
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn sys_clock_nanosleep(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_clock_settime(_clock_id: clockid_t, _tp: *const timespec) -> i32 {
 	// We don't support setting any clocks yet.
-	debug!("sys_clock_settime is unimplemented, returning -EINVAL");
+	error!("sys_clock_settime: unimplemented, returning -EINVAL");
 	-i32::from(Errno::Inval)
 }
 
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
 	}
 
 	if tz > 0 {
-		debug!("The tz parameter in sys_gettimeofday is unimplemented, returning -EINVAL");
+		error!("sys_gettimeofday: tz parameter is unimplemented, returning -EINVAL");
 		return -i32::from(Errno::Inval);
 	}
 
@@ -163,6 +163,6 @@ pub unsafe extern "C" fn sys_setitimer(
 	_value: *const itimerval,
 	_ovalue: *mut itimerval,
 ) -> i32 {
-	debug!("Called sys_setitimer, which is unimplemented and always returns 0");
+	error!("sys_setitimer: unimplemented, always returns 0");
 	0
 }


### PR DESCRIPTION
- Move subjects to beginning of each message
- Unify certain messages across architecture-specific implementations
- State the component/task at the beginning of most messages (before verbs) to make log scrolling and pinpointing failures easier
- Grammar-related improvements
- Increase consistency of used wording
- In some cases, display relevant variables
- Replace debug! with error! before errors are returned.
- Replace some debug! instances with trace!
- Decrease the length of some sentences
- Make messages of standard actions (e.g. driver init) consistent (mostly.)
- Correct mentions of RTL8139 in the driver's messages
- Add more variables inside of placeholders

This change is not intended to be perfect and does not improve ALL messages, with many changes being highly subjective.

It has a primary focus on debugging information and drivers. The primary motivation for this change is mostly the high amount of time spent trying to understand sequences of actions (and e.g. where specifically the booting of a kernel may break), while also assisting those that do not have a full picture of the kernel's source code.

Some messages were not modified to include the name of the component, as it may be self-evident depending on the context and the debugging activity (see: src/drivers/gem.rs) and increase the mental noise, rather than decrease it.