### PR TITLE
Uhyve mounts in arbitrary paths

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -404,6 +404,19 @@ pub fn create_dir(path: &str, mode: AccessPermission) -> io::Result<()> {
 	})
 }
 
+/// Creates a directory and creates all missing parent directories as well.
+fn create_dir_recursive(path: &str, mode: AccessPermission) -> io::Result<()> {
+	trace!("create_dir_recursive: {path}");
+	create_dir(path, mode).or_else(|errno| {
+		if errno != Errno::Badf {
+			return Err(errno);
+		}
+		let (parent_path, _file_name) = path.rsplit_once('/').unwrap();
+		create_dir_recursive(parent_path, mode)?;
+		create_dir(path, mode)
+	})
+}
+
 /// Returns an vector with all the entries within a directory.
 pub fn readdir(name: &str) -> io::Result<Vec<DirectoryEntry>> {
 	debug!("Read directory {name}");


### PR DESCRIPTION
This allows Uhyve to announce multiple "mounts" via FDT.

Uhyve places the folders to be mounted in the FDT as follows
```
    uhyve,mounts {
        mounts ="/dir1\0/dir2\0/dir3\0"
    };
```

This does not yet allow single file mounts, but should already help in a lot of scenarios.

Fixes #1572