### PR TITLE
ci: patch Uhyve's KVM exits disabling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
 
           $HOME/.local/bin/firecracker --version
         if: matrix.arch == 'x86_64'
-      - run: cargo +stable install --locked uhyve
+      - run: cargo +stable install --locked uhyve --git https://github.com/hermit-os/uhyve.git --rev 357a022f4f381b1ac80b064f88caae1a657b3687
         if: matrix.arch == 'x86_64'
       - run: cargo +stable install --locked virtiofsd
         if: matrix.arch == 'x86_64'


### PR DESCRIPTION
This PR makes the CI use a backported version of https://github.com/hermit-os/uhyve/pull/1130 (https://github.com/hermit-os/uhyve/commit/357a022f4f381b1ac80b064f88caae1a657b3687) to fix https://github.com/hermit-os/uhyve/issues/1129.