### PR TITLE
feat(uhyve): link uhyve interface versions to images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ hermit_entry::define_abi_tag!();
 #[cfg(target_os = "none")]
 hermit_entry::define_entry_version!();
 
+#[cfg(target_os = "none")]
+uhyve_interface::define_uhyve_interface_version!();
+
 #[cfg(test)]
 #[cfg(target_os = "none")]
 #[unsafe(no_mangle)]


### PR DESCRIPTION
This seems to work and is relevant for https://github.com/hermit-os/hermit-entry/pull/58

---

Relevant note in `uhyve-interface`:

https://github.com/hermit-os/uhyve/blob/924ed3c6be61256d167dfe5be42f7d8297170710/uhyve-interface/src/elf.rs#L5-L8

... which mentions the issue https://github.com/rust-lang/rust/issues/99721

(which also caused me to head into the wrong initial rabbit hole, although I should've looked at the [`hermit_entry::define_entry_version` macro](https://github.com/hermit-os/hermit-entry/blob/38a9073fd3756cbc1b9d606875582e8afde1d03a/src/note.rs#L5-L16) first, whoops: https://github.com/hermit-os/uhyve/pull/1144)