### PR TITLE
docs(x86_64): add explantory comment to `qemu_exit`

### DIFF
--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -1088,6 +1088,9 @@ fn triple_fault() -> ! {
 	unreachable!()
 }
 
+/// Writes an exit code into the isa-debug-exit port.
+///
+/// For a value `e` written into the port, QEMU will exit with `(e << 1) | 1`.
 fn qemu_exit(success: bool) {
 	let code = if success { 3 >> 1 } else { 0 };
 	unsafe {


### PR DESCRIPTION
Cherry-picked from https://github.com/hermit-os/kernel/pull/1995.