### PR TITLE
fix(virtq/split): don't box `TransferToken`s

### DIFF
--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -30,7 +30,7 @@ use crate::mm::device_alloc::DeviceAlloc;
 
 struct DescrRing {
 	read_idx: u16,
-	token_ring: Box<[Option<Box<TransferToken<virtq::Desc>>>]>,
+	token_ring: Box<[Option<TransferToken<virtq::Desc>>]>,
 	indexes: IndexAlloc,
 
 	descr_table_cell: Box<UnsafeCell<[MaybeUninit<virtq::Desc>]>, DeviceAlloc>,
@@ -81,7 +81,7 @@ impl DescrRing {
 			// thus the head of the descriptor chain.
 		}
 
-		self.token_ring[index] = Some(Box::new(tkn));
+		self.token_ring[index] = Some(tkn);
 
 		let len = self.token_ring.len();
 		let idx = self.avail_ring_mut().idx.to_ne();


### PR DESCRIPTION
This was proposed by @hcsch in https://github.com/hermit-os/kernel/pull/1995 (https://github.com/hermit-os/kernel/pull/1995/commits/2efa9ca69c61b75e66e14bc393a1fefd1b94bf0d).

This was already done for packed virtqueues in https://github.com/hermit-os/kernel/pull/1734.