### PR TITLE
feat: support regularly printing allocation stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ harness = false
 [features]
 default = ["kernel-stack", "pci", "pci-ids", "acpi", "fsgsbase", "smp", "tcp", "dhcpv4", "fuse", "virtio-net", "vsock"]
 acpi = []
+alloc-stats = ["talc/counters"]
 common-os = []
 console = ["virtio"]
 dhcpv4 = ["net", "smoltcp", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]

--- a/src/executor/alloc_stats.rs
+++ b/src/executor/alloc_stats.rs
@@ -1,0 +1,22 @@
+use core::future;
+use core::task::Poll;
+
+use crate::executor::spawn;
+use crate::mm::ALLOCATOR;
+
+async fn print_alloc_stats() {
+	future::poll_fn(|cx| {
+		let talc = ALLOCATOR.lock();
+
+		debug!("<alloc-stats>\n{}", talc.get_counters());
+
+		cx.waker().wake_by_ref();
+		Poll::<()>::Pending
+	})
+	.await;
+}
+
+pub(crate) fn init() {
+	info!("Spawning allocation stats printing task");
+	spawn(print_alloc_stats());
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "alloc-stats")]
+mod alloc_stats;
 #[cfg(feature = "net")]
 pub(crate) mod device;
 #[cfg(feature = "net")]
@@ -108,7 +110,12 @@ pub(crate) fn run() {
 
 /// Spawns a future on the executor.
 #[cfg_attr(
-	not(any(feature = "shell", feature = "net", feature = "vsock")),
+	not(any(
+		feature = "alloc-stats",
+		feature = "shell",
+		feature = "net",
+		feature = "vsock"
+	)),
 	expect(dead_code)
 )]
 pub(crate) fn spawn<F>(future: F)
@@ -123,6 +130,8 @@ pub fn init() {
 	crate::executor::network::init();
 	#[cfg(feature = "vsock")]
 	crate::executor::vsock::init();
+	#[cfg(feature = "alloc-stats")]
+	crate::executor::alloc_stats::init();
 }
 
 /// Blocks the current thread on `f`, running the executor when idling.


### PR DESCRIPTION
This was proposed by @hcsch in https://github.com/hermit-os/kernel/pull/1995 (https://github.com/hermit-os/kernel/pull/1995/commits/858b1e6550b502bea2b9f1148778e5b45c01f88c).

Is this useful to us without the context of that PR?