### PR TITLE
fix: don't log complete module path

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -53,8 +53,15 @@ impl log::Log for KernelLogger {
 		let level = ColorLevel(record.level());
 		// FIXME: Use `super let` once stable
 		let target = record.target();
+		let (crate_, modules) = target.split_once("::").unwrap_or((target, ""));
+		let (_modules, module) = modules.rsplit_once("::").unwrap_or(("", modules));
+		let target = if !module.is_empty() && crate_ == "hermit" {
+			module
+		} else {
+			crate_
+		};
 		let format_target = if cfg!(feature = "log-target") {
-			format_args!(" {target}")
+			format_args!(" {target:<10}")
 		} else {
 			format_args!("")
 		};


### PR DESCRIPTION
<details>
<summary>Default (without `feature = "log-target"`)</summary>

```
[            ][0][INFO]  Welcome to Hermit 0.11.0
[            ][0][INFO]  Git version: v0.11.0-740-g177c47d (dirty) (opt-level=0)
[            ][0][INFO]  Enabled features: acpi, pci
[            ][0][INFO]  Built on Mon, 27 Oct 2025 16:34:17 +0000
[            ][0][INFO]  Kernel starts at 0x1600000
[            ][0][INFO]  FDT:
 / {
    compatible = "hermit,multiboot"
    #address-cells = <0x2>
    #size-cells = <0x2>

    memory@0 {
        device_type = "memory"
        reg = <0x0 0x9fc00>
    };

    memory@100000 {
        device_type = "memory"
        reg = <0x100000 0x3fee0000>
    };

    chosen {
        bootargs = [104, 101, 114, 109, 105, 116, 45, 108, 111, 97, 100, 101, 114, 45, 120, 56, 54, 95, 54, 52, 32, 0]
    };
};

[            ][0][INFO]  BSS starts at 0x1839880
[            ][0][INFO]  tls_info = Some(
    TlsInfo {
        start: 0x180fdd0,
        filesz: 0x20,
        memsz: 0x70,
        align: 0x8,
    },
)
[            ][0][INFO]  Total memory size: 997 MiB
[            ][0][INFO]  Kernel region: 0x1600000..0x1a00000
[            ][0][INFO]  Minimum memory size: 31 MiB
[            ][0][INFO]  Heap: size 866 MB, start address 0x400000000000
[            ][0][INFO]  Heap is located at 0x400000000000..0x400036200000 (0 Bytes unmapped)
[            ][0][INFO]  FrameAlloc free list:
         0x1c02000..         0x1e00000 (len =           0x1fe000, pages =              510)
        0x37e00000..        0x3ffe0000 (len =          0x81e0000, pages =            33248)
[            ][0][INFO]  PageAlloc free list:
    0x400036200000..    0x800000000000 (len =     0x3fffc9e00000, pages =      17179647488)
[            ][0][INFO]  bootargs = hermit-loader-x86_64 
[    0.192108][0][INFO]  
[    0.196738][0][INFO]  ========================== CPU INFORMATION ===========================
[    0.200551][0][INFO]  Model:                   Intel Core Processor (Skylake)
[    0.201002][0][INFO]  Frequency:               997 MHz (from Measurement)
[    0.201540][0][INFO]  SpeedStep Technology:    Not Available
[    0.201888][0][INFO]  Features:                MMX SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AESNI RDRAND FMA MOVBE MCE FXSR XSAVE RDTSCP CLFLUSH X2APIC HYPERVISOR AVX2 BMI1 BMI2 FSGSBASE RDSEED 
[    0.203856][0][INFO]  Physical Address Width:  40 bits
[    0.204347][0][INFO]  Linear Address Width:    48 bits
[    0.204684][0][INFO]  Supports 1GiB Pages:     No
[    0.204948][0][INFO]  ======================================================================
[    0.205372][0][INFO]  
[    0.219316][0][INFO]  Hermit booted on 2025-10-27 16:34:28.782381 +00:00:00
[    0.228089][0][INFO]  Found an ACPI revision 0 table at 0xF52E0 with OEM ID "BOCHS "
[    0.242472][0][INFO]  Initialized PCI
[    0.274663][0][INFO]  IOAPIC v32 has 24 entries
[    0.280707][0][INFO]  
[    0.280935][0][INFO]  ===================== MULTIPROCESSOR INFORMATION =====================
[    0.281317][0][INFO]  APIC in use:             x2APIC
[    0.281582][0][INFO]  Initialized CPUs:        1
[    0.281824][0][INFO]  ======================================================================
[    0.282197][0][INFO]  
[    0.282370][0][INFO]  Compiled with PCI support
[    0.282644][0][INFO]  Compiled with ACPI support
[    0.282918][0][INFO]  
[    0.283099][0][INFO]  ======================== PCI BUS INFORMATION =========================
[    0.283873][0][INFO]  00:00 Unknown Class [0600]: Unknown Vendor Unknown Device [8086:1237]
[    0.285042][0][INFO]  00:01 Unknown Class [0601]: Unknown Vendor Unknown Device [8086:7000]
[    0.285385][0][INFO]  00:02 Unknown Class [0300]: Unknown Vendor Unknown Device [1234:1111], BAR0 Memory32 { address: 0xFD000000, size: 0x1000000, prefetchable: true }, BAR2 Memory32 { address: 0xFEBF0000, size: 0x1000, prefetchable: false }
[    0.286593][0][INFO]  00:03 Unknown Class [0200]: Unknown Vendor Unknown Device [8086:100E], IRQ 11, BAR0 Memory32 { address: 0xFEBC0000, size: 0x20000, prefetchable: false }, BAR1 IO { port: 0xC000 }
[    0.287492][0][INFO]  ======================================================================
[    0.287951][0][INFO]  
[    0.298523][0][INFO]  Hermit is running on common system!
[    0.337744][0][INFO]  Jumping into application
Hello, world!
Number of interrupts
exit status 0
```

</details>


<details>
<summary>Before (with `feature = "log-target"`)</summary>

```
[            ][0][INFO hermit] Welcome to Hermit 0.11.0
[            ][0][INFO hermit] Git version: v0.11.0-739-g987c04f (opt-level=0)
[            ][0][INFO hermit] Enabled features: acpi, log_target, pci
[            ][0][INFO hermit] Built on Mon, 27 Oct 2025 16:37:21 +0000
[            ][0][INFO hermit] Kernel starts at 0x1600000
[            ][0][INFO hermit] FDT:
 / {
    compatible = "hermit,multiboot"
    #address-cells = <0x2>
    #size-cells = <0x2>

    memory@0 {
        device_type = "memory"
        reg = <0x0 0x9fc00>
    };

    memory@100000 {
        device_type = "memory"
        reg = <0x100000 0x3fee0000>
    };

    chosen {
        bootargs = [104, 101, 114, 109, 105, 116, 45, 108, 111, 97, 100, 101, 114, 45, 120, 56, 54, 95, 54, 52, 32, 0]
    };
};

[            ][0][INFO hermit] BSS starts at 0x1837400
[            ][0][INFO hermit] tls_info = Some(
    TlsInfo {
        start: 0x180da30,
        filesz: 0x20,
        memsz: 0x70,
        align: 0x8,
    },
)
[            ][0][INFO hermit::mm] Total memory size: 997 MiB
[            ][0][INFO hermit::mm] Kernel region: 0x1600000..0x1a00000
[            ][0][INFO hermit::mm] Minimum memory size: 31 MiB
[            ][0][INFO hermit::mm] Heap: size 866 MB, start address 0x400000000000
[            ][0][INFO hermit::mm] Heap is located at 0x400000000000..0x400036200000 (0 Bytes unmapped)
[            ][0][INFO hermit::mm] FrameAlloc free list:
         0x1c02000..         0x1e00000 (len =           0x1fe000, pages =              510)
        0x37e00000..        0x3ffe0000 (len =          0x81e0000, pages =            33248)
[            ][0][INFO hermit::mm] PageAlloc free list:
    0x400036200000..    0x800000000000 (len =     0x3fffc9e00000, pages =      17179647488)
[            ][0][INFO hermit::env] bootargs = hermit-loader-x86_64 
[    0.193854][0][INFO hermit::arch::x86_64::kernel::processor] 
[    0.197737][0][INFO hermit::arch::x86_64::kernel::processor] ========================== CPU INFORMATION ===========================
[    0.201324][0][INFO hermit::arch::x86_64::kernel::processor] Model:                   Intel Core Processor (Skylake)
[    0.201781][0][INFO hermit::arch::x86_64::kernel::processor] Frequency:               984 MHz (from Measurement)
[    0.202331][0][INFO hermit::arch::x86_64::kernel::processor] SpeedStep Technology:    Not Available
[    0.202737][0][INFO hermit::arch::x86_64::kernel::processor] Features:                MMX SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AESNI RDRAND FMA MOVBE MCE FXSR XSAVE RDTSCP CLFLUSH X2APIC HYPERVISOR AVX2 BMI1 BMI2 FSGSBASE RDSEED 
[    0.204577][0][INFO hermit::arch::x86_64::kernel::processor] Physical Address Width:  40 bits
[    0.204961][0][INFO hermit::arch::x86_64::kernel::processor] Linear Address Width:    48 bits
[    0.205511][0][INFO hermit::arch::x86_64::kernel::processor] Supports 1GiB Pages:     No
[    0.205822][0][INFO hermit::arch::x86_64::kernel::processor] ======================================================================
[    0.206276][0][INFO hermit::arch::x86_64::kernel::processor] 
[    0.219948][0][INFO hermit::arch::x86_64::kernel::systemtime] Hermit booted on 2025-10-27 16:37:22.781653 +00:00:00
[    0.229248][0][INFO hermit::arch::x86_64::kernel::acpi] Found an ACPI revision 0 table at 0xF52E0 with OEM ID "BOCHS "
[    0.243423][0][INFO hermit::arch::x86_64::kernel::pci] Initialized PCI
[    0.275553][0][INFO hermit::arch::x86_64::kernel::apic] IOAPIC v32 has 24 entries
[    0.281738][0][INFO hermit::arch::x86_64::kernel::apic] 
[    0.282367][0][INFO hermit::arch::x86_64::kernel::apic] ===================== MULTIPROCESSOR INFORMATION =====================
[    0.282841][0][INFO hermit::arch::x86_64::kernel::apic] APIC in use:             x2APIC
[    0.283290][0][INFO hermit::arch::x86_64::kernel::apic] Initialized CPUs:        1
[    0.283606][0][INFO hermit::arch::x86_64::kernel::apic] ======================================================================
[    0.284433][0][INFO hermit::arch::x86_64::kernel::apic] 
[    0.284667][0][INFO hermit] Compiled with PCI support
[    0.284870][0][INFO hermit] Compiled with ACPI support
[    0.285092][0][INFO hermit::drivers::pci] 
[    0.285288][0][INFO hermit::drivers::pci] ======================== PCI BUS INFORMATION =========================
[    0.286234][0][INFO hermit::drivers::pci] 00:00 Unknown Class [0600]: Unknown Vendor Unknown Device [8086:1237]
[    0.287383][0][INFO hermit::drivers::pci] 00:01 Unknown Class [0601]: Unknown Vendor Unknown Device [8086:7000]
[    0.287724][0][INFO hermit::drivers::pci] 00:02 Unknown Class [0300]: Unknown Vendor Unknown Device [1234:1111], BAR0 Memory32 { address: 0xFD000000, size: 0x1000000, prefetchable: true }, BAR2 Memory32 { address: 0xFEBF0000, size: 0x1000, prefetchable: false }
[    0.289606][0][INFO hermit::drivers::pci] 00:03 Unknown Class [0200]: Unknown Vendor Unknown Device [8086:100E], IRQ 11, BAR0 Memory32 { address: 0xFEBC0000, size: 0x20000, prefetchable: false }, BAR1 IO { port: 0xC000 }
[    0.290469][0][INFO hermit::drivers::pci] ======================================================================
[    0.291054][0][INFO hermit::drivers::pci] 
[    0.301667][0][INFO hermit] Hermit is running on common system!
[    0.340783][0][INFO hermit] Jumping into application
Hello, world!
Number of interrupts
exit status 0
```

</details>

<details>
<summary>After (with `feature = "log-target"`)</summary>

```
[            ][0][INFO  hermit    ] Welcome to Hermit 0.11.0
[            ][0][INFO  hermit    ] Git version: v0.11.0-741-g6e5ee28 (opt-level=0)
[            ][0][INFO  hermit    ] Enabled features: acpi, log_target, pci
[            ][0][INFO  hermit    ] Built on Tue, 28 Oct 2025 09:59:06 +0000
[            ][0][INFO  hermit    ] Kernel starts at 0x1600000
[            ][0][INFO  hermit    ] FDT:
 / {
    compatible = "hermit,multiboot"
    #address-cells = <0x2>
    #size-cells = <0x2>

    memory@0 {
        device_type = "memory"
        reg = <0x0 0x9fc00>
    };

    memory@100000 {
        device_type = "memory"
        reg = <0x100000 0x3fee0000>
    };

    chosen {
        bootargs = [104, 101, 114, 109, 105, 116, 45, 108, 111, 97, 100, 101, 114, 45, 120, 56, 54, 95, 54, 52, 32, 0]
    };
};

[            ][0][INFO  hermit    ] BSS starts at 0x18399f0
[            ][0][INFO  hermit    ] tls_info = Some(
    TlsInfo {
        start: 0x180fed0,
        filesz: 0x20,
        memsz: 0x70,
        align: 0x8,
    },
)
[            ][0][INFO  mm        ] Total memory size: 997 MiB
[            ][0][INFO  mm        ] Kernel region: 0x1600000..0x1a00000
[            ][0][INFO  mm        ] Minimum memory size: 31 MiB
[            ][0][INFO  mm        ] Heap: size 866 MB, start address 0x400000000000
[            ][0][INFO  mm        ] Heap is located at 0x400000000000..0x400036200000 (0 Bytes unmapped)
[            ][0][INFO  mm        ] FrameAlloc free list:
         0x1c02000..         0x1e00000 (len =           0x1fe000, pages =              510)
        0x37e00000..        0x3ffe0000 (len =          0x81e0000, pages =            33248)
[            ][0][INFO  mm        ] PageAlloc free list:
    0x400036200000..    0x800000000000 (len =     0x3fffc9e00000, pages =      17179647488)
[            ][0][INFO  env       ] bootargs = hermit-loader-x86_64 
[    0.184683][0][INFO  processor ] 
[    0.189432][0][INFO  processor ] ========================== CPU INFORMATION ===========================
[    0.193044][0][INFO  processor ] Model:                   Intel Core Processor (Skylake)
[    0.193479][0][INFO  processor ] Frequency:               999 MHz (from Measurement)
[    0.194020][0][INFO  processor ] SpeedStep Technology:    Not Available
[    0.194352][0][INFO  processor ] Features:                MMX SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AESNI RDRAND FMA MOVBE MCE FXSR XSAVE RDTSCP CLFLUSH X2APIC HYPERVISOR AVX2 BMI1 BMI2 FSGSBASE RDSEED 
[    0.196058][0][INFO  processor ] Physical Address Width:  40 bits
[    0.196386][0][INFO  processor ] Linear Address Width:    48 bits
[    0.196698][0][INFO  processor ] Supports 1GiB Pages:     No
[    0.196966][0][INFO  processor ] ======================================================================
[    0.197351][0][INFO  processor ] 
[    0.210924][0][INFO  systemtime] Hermit booted on 2025-10-28 9:59:07.79084 +00:00:00
[    0.219699][0][INFO  acpi      ] Found an ACPI revision 0 table at 0xF52E0 with OEM ID "BOCHS "
[    0.234051][0][INFO  pci       ] Initialized PCI
[    0.266300][0][INFO  apic      ] IOAPIC v32 has 24 entries
[    0.272304][0][INFO  apic      ] 
[    0.272557][0][INFO  apic      ] ===================== MULTIPROCESSOR INFORMATION =====================
[    0.272952][0][INFO  apic      ] APIC in use:             x2APIC
[    0.273251][0][INFO  apic      ] Initialized CPUs:        1
[    0.273502][0][INFO  apic      ] ======================================================================
[    0.273877][0][INFO  apic      ] 
[    0.274069][0][INFO  hermit    ] Compiled with PCI support
[    0.274345][0][INFO  hermit    ] Compiled with ACPI support
[    0.274604][0][INFO  pci       ] 
[    0.274802][0][INFO  pci       ] ======================== PCI BUS INFORMATION =========================
[    0.275578][0][INFO  pci       ] 00:00 Unknown Class [0600]: Unknown Vendor Unknown Device [8086:1237]
[    0.276561][0][INFO  pci       ] 00:01 Unknown Class [0601]: Unknown Vendor Unknown Device [8086:7000]
[    0.276861][0][INFO  pci       ] 00:02 Unknown Class [0300]: Unknown Vendor Unknown Device [1234:1111], BAR0 Memory32 { address: 0xFD000000, size: 0x1000000, prefetchable: true }, BAR2 Memory32 { address: 0xFEBF0000, size: 0x1000, prefetchable: false }
[    0.278221][0][INFO  pci       ] 00:03 Unknown Class [0200]: Unknown Vendor Unknown Device [8086:100E], IRQ 11, BAR0 Memory32 { address: 0xFEBC0000, size: 0x20000, prefetchable: false }, BAR1 IO { port: 0xC000 }
[    0.279183][0][INFO  pci       ] ======================================================================
[    0.279629][0][INFO  pci       ] 
[    0.290250][0][INFO  hermit    ] Hermit is running on common system!
[    0.329476][0][INFO  hermit    ] Jumping into application
Hello, world!
Number of interrupts
exit status 0
```

</details>

This should address a large part of https://github.com/hermit-os/kernel/pull/1974.