### PR TITLE
chore(Cargo.toml): replace list of authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,7 @@
 [package]
 name = "hermit-kernel"
 version = "0.12.0"
-authors = [
-	"Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
-	"Colin Finck <colin.finck@rwth-aachen.de>",
-	"Martin Kröning <mkroening@posteo.net>",
-	"Frederik Schulz",
-	"Thomas Lambertz",
-	"Jonathan Klimt <jonathan.klimt@eonerc.rwth-aachen.de>",
-	"Jonathan Schwender",
-	"Daniel Krebs",
-	"Yu Duan",
-]
+authors = ["The Hermit Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["unikernel", "libos"]


### PR DESCRIPTION
Given so many people have worked on this project, it might make sense to not grow the list of authors in the `Cargo.toml` any further and instead list them somewhere else.

Where, though? In the README? Should we just point to [Contributors](https://github.com/hermit-os/kernel/graphs/contributors), should we curate a list of people, or should we set up a separate page similar to [Rust Contributors](https://thanks.rust-lang.org/)?