### PR TITLE
docs(virtq): remove outdated safety comment

### DIFF
--- a/src/drivers/virtio/virtqueue/split.rs
+++ b/src/drivers/virtio/virtqueue/split.rs
@@ -29,12 +29,6 @@ struct DescrRing {
 	token_ring: Box<[Option<Box<TransferToken<virtq::Desc>>>]>,
 	mem_pool: MemPool,
 
-	/// Descriptor Tables
-	///
-	/// # Safety
-	///
-	/// These tables may only be accessed via volatile operations.
-	/// See the corresponding method for a safe wrapper.
 	descr_table_cell: Box<UnsafeCell<[MaybeUninit<virtq::Desc>]>, DeviceAlloc>,
 	avail_ring_cell: Box<UnsafeCell<virtq::Avail>, DeviceAlloc>,
 	used_ring_cell: Box<UnsafeCell<virtq::Used>, DeviceAlloc>,


### PR DESCRIPTION
This was forgotten in https://github.com/hermit-os/kernel/commit/830119269c6f7381f3148cf46c11159bc90aaa40.