### PR TITLE
feat: always log targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ fuse = ["virtio", "pci", "dep:fuse-abi", "fuse-abi/num_enum"]
 gem-net = ["net", "dep:tock-registers"]
 idle-poll = []
 kernel-stack = []
-log-target = []
 net = []
 mman = []
 mmap = ["mman"] # Deprecated in favor of mman

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -51,7 +51,7 @@ impl log::Log for KernelLogger {
 		};
 		let core_id = crate::arch::core_local::core_id();
 		let level = ColorLevel(record.level());
-		// FIXME: Use `super let` once stable
+
 		let target = record.target();
 		let (crate_, modules) = target.split_once("::").unwrap_or((target, ""));
 		let (_modules, module) = modules.rsplit_once("::").unwrap_or(("", modules));
@@ -60,11 +60,8 @@ impl log::Log for KernelLogger {
 		} else {
 			crate_
 		};
-		let format_target = if cfg!(feature = "log-target") {
-			format_args!(" {target:<10}")
-		} else {
-			format_args!("")
-		};
+		let format_target = format_args!(" {target:<10}");
+
 		let args = record.args();
 		println!("{format_time}[{core_id}][{level}{format_target}] {args}");
 	}


### PR DESCRIPTION
This PR builds on https://github.com/hermit-os/kernel/pull/2021 to make target logging unconditional and removes the corresponding feature.

<details>
<summary>Before</summary>

```
[            ][0][INFO ] Welcome to Hermit 0.11.0
[            ][0][INFO ] Git version: v0.11.0-762-gb9e34fd (opt-level=0)
[            ][0][INFO ] Enabled features: acpi, pci
[            ][0][INFO ] Built on Wed, 29 Oct 2025 09:03:28 +0000
[            ][0][INFO ] Kernel starts at 0x1600000
[            ][0][INFO ] FDT:
 / {
    compatible = "hermit,multiboot"
    #address-cells = <0x2>
    #size-cells = <0x2>

    memory@0 {
        device_type = "memory"
        reg = <0x0 0x9fc00>
    };

    memory@100000 {
        device_type = "memory"
        reg = <0x100000 0x3fee0000>
    };

    chosen {
        bootargs = [104, 101, 114, 109, 105, 116, 45, 108, 111, 97, 100, 101, 114, 45, 120, 56, 54, 95, 54, 52, 32, 0]
    };
};

[            ][0][INFO ] BSS starts at 0x1839900
[            ][0][INFO ] tls_info = Some(
    TlsInfo {
        start: 0x180fe30,
        filesz: 0x20,
        memsz: 0x70,
        align: 0x8,
    },
)
[            ][0][INFO ] Total memory size: 997 MiB
[            ][0][INFO ] Kernel region: 0x1600000..0x1a00000
[            ][0][INFO ] Minimum memory size: 31 MiB
[            ][0][INFO ] Heap: size 866 MB, start address 0x400000000000
[            ][0][INFO ] Heap is located at 0x400000000000..0x400036200000 (0 Bytes unmapped)
[            ][0][INFO ] FrameAlloc free list:
         0x1c02000..         0x1e00000 (len =           0x1fe000, pages =              510)
        0x37e00000..        0x3ffe0000 (len =          0x81e0000, pages =            33248)
[            ][0][INFO ] PageAlloc free list:
    0x400036200000..    0x800000000000 (len =     0x3fffc9e00000, pages =      17179647488)
[            ][0][INFO ] bootargs = hermit-loader-x86_64 
[    0.340100][0][INFO ] 
[    0.345990][0][INFO ] ========================== CPU INFORMATION ===========================
[    0.350009][0][INFO ] Model:                   Intel Core Processor (Skylake)
[    0.350403][0][INFO ] Frequency:               1004 MHz (from Measurement)
[    0.350896][0][INFO ] SpeedStep Technology:    Not Available
[    0.351311][0][INFO ] Features:                MMX SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AESNI RDRAND FMA MOVBE MCE FXSR XSAVE RDTSCP CLFLUSH X2APIC HYPERVISOR AVX2 BMI1 BMI2 FSGSBASE RDSEED 
[    0.353128][0][INFO ] Physical Address Width:  40 bits
[    0.353464][0][INFO ] Linear Address Width:    48 bits
[    0.353725][0][INFO ] Supports 1GiB Pages:     No
[    0.353946][0][INFO ] ======================================================================
[    0.354363][0][INFO ] 
[    0.371288][0][INFO ] Hermit booted on 2025-10-29 9:03:34.630983 +00:00:00
[    0.382246][0][INFO ] Found an ACPI revision 0 table at 0xF52E0 with OEM ID "BOCHS "
[    0.400690][0][INFO ] Initialized PCI
[    0.433515][0][INFO ] IOAPIC v32 has 24 entries
[    0.440934][0][INFO ] 
[    0.441222][0][INFO ] ===================== MULTIPROCESSOR INFORMATION =====================
[    0.441567][0][INFO ] APIC in use:             x2APIC
[    0.441806][0][INFO ] Initialized CPUs:        1
[    0.442052][0][INFO ] ======================================================================
[    0.442450][0][INFO ] 
[    0.442630][0][INFO ] Compiled with PCI support
[    0.442897][0][INFO ] Compiled with ACPI support
[    0.443173][0][INFO ] 
[    0.443374][0][INFO ] ======================== PCI BUS INFORMATION =========================
[    0.444278][0][INFO ] 00:00 Unknown Class [0600]: Unknown Vendor Unknown Device [8086:1237]
[    0.445356][0][INFO ] 00:01 Unknown Class [0601]: Unknown Vendor Unknown Device [8086:7000]
[    0.445735][0][INFO ] 00:02 Unknown Class [0300]: Unknown Vendor Unknown Device [1234:1111], BAR0 Memory32 { address: 0xFD000000, size: 0x1000000, prefetchable: true }, BAR2 Memory32 { address: 0xFEBF0000, size: 0x1000, prefetchable: false }
[    0.447154][0][INFO ] 00:03 Unknown Class [0200]: Unknown Vendor Unknown Device [8086:100E], IRQ 11, BAR0 Memory32 { address: 0xFEBC0000, size: 0x20000, prefetchable: false }, BAR1 IO { port: 0xC000 }
[    0.448322][0][INFO ] ======================================================================
[    0.448687][0][INFO ] 
[    0.459678][0][INFO ] Hermit is running on common system!
[    0.502206][0][INFO ] Jumping into application
Hello, world!
Number of interrupts
exit status 0
```

</details>

<details>
<summary>After</summary>

```
[            ][0][INFO  hermit    ] Welcome to Hermit 0.11.0
[            ][0][INFO  hermit    ] Git version: v0.11.0-763-ga6ee871 (opt-level=0)
[            ][0][INFO  hermit    ] Enabled features: acpi, pci
[            ][0][INFO  hermit    ] Built on Wed, 29 Oct 2025 09:03:59 +0000
[            ][0][INFO  hermit    ] Kernel starts at 0x1600000
[            ][0][INFO  hermit    ] FDT:
 / {
    compatible = "hermit,multiboot"
    #address-cells = <0x2>
    #size-cells = <0x2>

    memory@0 {
        device_type = "memory"
        reg = <0x0 0x9fc00>
    };

    memory@100000 {
        device_type = "memory"
        reg = <0x100000 0x3fee0000>
    };

    chosen {
        bootargs = [104, 101, 114, 109, 105, 116, 45, 108, 111, 97, 100, 101, 114, 45, 120, 56, 54, 95, 54, 52, 32, 0]
    };
};

[            ][0][INFO  hermit    ] BSS starts at 0x1839a00
[            ][0][INFO  hermit    ] tls_info = Some(
    TlsInfo {
        start: 0x180fee0,
        filesz: 0x20,
        memsz: 0x70,
        align: 0x8,
    },
)
[            ][0][INFO  mm        ] Total memory size: 997 MiB
[            ][0][INFO  mm        ] Kernel region: 0x1600000..0x1a00000
[            ][0][INFO  mm        ] Minimum memory size: 31 MiB
[            ][0][INFO  mm        ] Heap: size 866 MB, start address 0x400000000000
[            ][0][INFO  mm        ] Heap is located at 0x400000000000..0x400036200000 (0 Bytes unmapped)
[            ][0][INFO  mm        ] FrameAlloc free list:
         0x1c02000..         0x1e00000 (len =           0x1fe000, pages =              510)
        0x37e00000..        0x3ffe0000 (len =          0x81e0000, pages =            33248)
[            ][0][INFO  mm        ] PageAlloc free list:
    0x400036200000..    0x800000000000 (len =     0x3fffc9e00000, pages =      17179647488)
[            ][0][INFO  env       ] bootargs = hermit-loader-x86_64 
[    0.233697][0][INFO  processor ] 
[    0.239635][0][INFO  processor ] ========================== CPU INFORMATION ===========================
[    0.245024][0][INFO  processor ] Model:                   Intel Core Processor (Skylake)
[    0.247615][0][INFO  processor ] Frequency:               964 MHz (from Measurement)
[    0.248832][0][INFO  processor ] SpeedStep Technology:    Not Available
[    0.249261][0][INFO  processor ] Features:                MMX SSE SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AESNI RDRAND FMA MOVBE MCE FXSR XSAVE RDTSCP CLFLUSH X2APIC HYPERVISOR AVX2 BMI1 BMI2 FSGSBASE RDSEED 
[    0.252127][0][INFO  processor ] Physical Address Width:  40 bits
[    0.252684][0][INFO  processor ] Linear Address Width:    48 bits
[    0.253211][0][INFO  processor ] Supports 1GiB Pages:     No
[    0.253554][0][INFO  processor ] ======================================================================
[    0.254273][0][INFO  processor ] 
[    0.276679][0][INFO  systemtime] Hermit booted on 2025-10-29 9:04:04.725816 +00:00:00
[    0.290731][0][INFO  acpi      ] Found an ACPI revision 0 table at 0xF52E0 with OEM ID "BOCHS "
[    0.316697][0][INFO  pci       ] Initialized PCI
[    0.426881][0][INFO  apic      ] IOAPIC v32 has 24 entries
[    0.451521][0][INFO  apic      ] 
[    0.454100][0][INFO  apic      ] ===================== MULTIPROCESSOR INFORMATION =====================
[    0.454567][0][INFO  apic      ] APIC in use:             x2APIC
[    0.458581][0][INFO  apic      ] Initialized CPUs:        1
[    0.459022][0][INFO  apic      ] ======================================================================
[    0.459576][0][INFO  apic      ] 
[    0.459829][0][INFO  hermit    ] Compiled with PCI support
[    0.460142][0][INFO  hermit    ] Compiled with ACPI support
[    0.460406][0][INFO  pci       ] 
[    0.460619][0][INFO  pci       ] ======================== PCI BUS INFORMATION =========================
[    0.461551][0][INFO  pci       ] 00:00 Unknown Class [0600]: Unknown Vendor Unknown Device [8086:1237]
[    0.462998][0][INFO  pci       ] 00:01 Unknown Class [0601]: Unknown Vendor Unknown Device [8086:7000]
[    0.463482][0][INFO  pci       ] 00:02 Unknown Class [0300]: Unknown Vendor Unknown Device [1234:1111], BAR0 Memory32 { address: 0xFD000000, size: 0x1000000, prefetchable: true }, BAR2 Memory32 { address: 0xFEBF0000, size: 0x1000, prefetchable: false }
[    0.465064][0][INFO  pci       ] 00:03 Unknown Class [0200]: Unknown Vendor Unknown Device [8086:100E], IRQ 11, BAR0 Memory32 { address: 0xFEBC0000, size: 0x20000, prefetchable: false }, BAR1 IO { port: 0xC000 }
[    0.466006][0][INFO  pci       ] ======================================================================
[    0.466469][0][INFO  pci       ] 
[    0.479977][0][INFO  hermit    ] Hermit is running on common system!
[    0.526124][0][INFO  hermit    ] Jumping into application
Hello, world!
Number of interrupts
exit status 0
```

</details>