### PR TITLE
fix: don't log before core-local storage is initialized

### DIFF
--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -279,7 +279,11 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
-			error!("SMP support deactivated");
+			let style = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Red.into()));
+			let preamble = format_args!("[            ][{cpu_id}][{style}ERROR{style:#}]");
+			println!(
+				"{preamble} Secondary core booted, but Hermit was not built with SMP support!"
+			);
 			loop {
 				crate::arch::processor::halt();
 			}

--- a/src/arch/riscv64/kernel/start.rs
+++ b/src/arch/riscv64/kernel/start.rs
@@ -70,7 +70,11 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
-			error!("SMP support deactivated");
+			let style = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Red.into()));
+			let preamble = format_args!("[            ][{hart_id}][{style}ERROR{style:#}]");
+			println!(
+				"{preamble} Secondary core booted, but Hermit was not built with SMP support!"
+			);
 			loop {
 				processor::halt();
 			}

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -205,7 +205,11 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
-			error!("SMP support deactivated");
+			let style = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Red.into()));
+			let preamble = format_args!("[            ][{cpu_id}][{style}ERROR{style:#}]");
+			println!(
+				"{preamble} Secondary core booted, but Hermit was not built with SMP support!"
+			);
 			loop {
 				processor::halt();
 			}


### PR DESCRIPTION
This crashes since we don't have core-local storage initialized. Core-local storage is used by the logger to print the core ID, which only exists locally here.