### PR TITLE
fix(xtask): print firecracker logs before erroring

### DIFF
--- a/xtask/src/ci/firecracker.rs
+++ b/xtask/src/ci/firecracker.rs
@@ -38,11 +38,13 @@ impl Firecracker {
 
 		let log_path = Path::new("firecracker.log");
 		sh.write_file(log_path, "")?;
-		cmd!(sh, "{program} {arg...} --no-api --config-file {config_path} --log-path {log_path} --level Info --show-level --show-log-origin").run()?;
+		let res = cmd!(sh, "{program} {arg...} --no-api --config-file {config_path} --log-path {log_path} --level Info --show-level --show-log-origin").run();
 		let log = sh.read_file(log_path)?;
 
 		eprintln!("firecracker log");
 		eprintln!("{log}");
+
+		res?;
 
 		Ok(())
 	}


### PR DESCRIPTION
Cherry-picked from https://github.com/hermit-os/kernel/pull/2018.