### PR TITLE
fix(x86_64/smp): SMP boot code size assertion

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -758,7 +758,7 @@ pub fn boot_application_processors() {
 
 	// We shouldn't have any problems fitting the boot code into a single page, but let's better be sure.
 	assert!(
-		smp_boot_code.len() < BasePageSize::SIZE as usize,
+		smp_boot_code.len() <= BasePageSize::SIZE as usize,
 		"SMP Boot Code is larger than a page"
 	);
 	debug!("SMP boot code is {} bytes long", smp_boot_code.len());


### PR DESCRIPTION
In kernel/src/arch/x86_64/kernel/apic.rs, this assertion's message indicates it will be failed when smp_boot_code.len() >= BasePageSize::SIZE while the predicate is `smp_boot_code.len() < BasePageSize::SIZE as usize`. I think it should be changed into `smp_boot_code.len() <= BasePageSize::SIZE as usize` as the code can still fit into a single page when its size is equal to the page size.

```rust
assert!(
		smp_boot_code.len() < BasePageSize::SIZE as usize,
		"SMP Boot Code is larger than a page"
	);
```