### PR TITLE
add instruction synchronization barrier after modifying CPACR_EL1

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -171,14 +171,6 @@ pub(crate) extern "C" fn do_irq(_state: &State) -> *mut usize {
 
 		GicV3::end_interrupt(irqid, InterruptGroup::Group1);
 
-		trace!("Disabling floating point");
-
-		// Trap next FPU instruction so we can lazily restore FPU state
-		CPACR_EL1.modify(CPACR_EL1::FPEN::TrapEl0El1);
-		unsafe {
-			asm!("isb", options(nostack, preserves_flags));
-		}
-
 		return core_scheduler().scheduler().unwrap_or_default();
 	}
 


### PR DESCRIPTION
Without synchronization, the FPU is reused before the modification of CPACR_EL1 is active. In addition, FPU traps are only activated when the context switch occurs.

Close #1870
