### PR TITLE
perf(virtqueue): replace vec-based `MemPools` with bitmap-based `IndexAlloc`

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -512,21 +512,58 @@ pub enum BufferType {
 	Indirect,
 }
 
-/// MemPool allows to easily control, request and provide memory for Virtqueues.
-struct MemPool {
-	pool: Vec<u16>,
-}
+mod index_alloc {
+	use alloc::boxed::Box;
 
-impl MemPool {
-	/// Returns a given id to the id pool
-	fn ret_id(&mut self, id: u16) {
-		self.pool.push(id);
+	/// This type allows allocating indices.
+	///
+	/// The indices can be used as descriptor IDs.
+	pub struct IndexAlloc {
+		/// Zero bits are available.
+		bits: Box<[usize]>,
 	}
 
-	/// Returns a new instance, with a pool of the specified size.
-	fn new(size: u16) -> MemPool {
-		MemPool {
-			pool: (0..size).collect(),
+	const USIZE_BITS: usize = usize::BITS as usize;
+
+	impl IndexAlloc {
+		pub fn new(len: usize) -> Self {
+			let usizes = len.div_ceil(USIZE_BITS);
+			let extra_bits = len % USIZE_BITS;
+
+			let mut bits = vec![0; usizes].into_boxed_slice();
+
+			if extra_bits != 0 {
+				*bits.last_mut().unwrap() = usize::MAX >> extra_bits;
+			}
+
+			Self { bits }
+		}
+
+		#[inline]
+		pub fn allocate(&mut self) -> Option<usize> {
+			for (word_index, word) in self.bits.iter_mut().enumerate() {
+				let trailing_ones = word.trailing_ones();
+				if trailing_ones < usize::BITS {
+					let mask = 1 << trailing_ones;
+					*word |= mask;
+					let index = word_index * USIZE_BITS + usize::try_from(trailing_ones).unwrap();
+					return Some(index);
+				}
+			}
+
+			None
+		}
+
+		#[inline]
+		pub unsafe fn deallocate(&mut self, index: usize) {
+			let word_index = index / USIZE_BITS;
+			let bit = index % USIZE_BITS;
+			let mask = 1 << bit;
+
+			debug_assert!(self.bits[word_index] & mask == mask);
+			unsafe {
+				*self.bits.get_unchecked_mut(word_index) &= !mask;
+			}
 		}
 	}
 }

--- a/src/drivers/virtio/virtqueue/packed.rs
+++ b/src/drivers/virtio/virtqueue/packed.rs
@@ -22,9 +22,8 @@ use super::super::transport::mmio::{ComCfg, NotifCfg, NotifCtrl};
 #[cfg(feature = "pci")]
 use super::super::transport::pci::{ComCfg, NotifCfg, NotifCtrl};
 use super::error::VirtqError;
-use super::{
-	AvailBufferToken, BufferType, MemPool, TransferToken, UsedBufferToken, Virtq, VirtqPrivate,
-};
+use super::index_alloc::IndexAlloc;
+use super::{AvailBufferToken, BufferType, TransferToken, UsedBufferToken, Virtq, VirtqPrivate};
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::mm::device_alloc::DeviceAlloc;
 
@@ -69,9 +68,8 @@ struct DescriptorRing {
 	/// See Virtio specification v1.1. - 2.7.1
 	drv_wc: bool,
 	dev_wc: bool,
-	/// Memory pool controls the amount of "free floating" descriptors
-	/// See [MemPool] docs for detail.
-	mem_pool: MemPool,
+	/// This allocates available descriptors.
+	indexes: IndexAlloc,
 }
 
 impl DescriptorRing {
@@ -92,7 +90,7 @@ impl DescriptorRing {
 			poll_index: 0,
 			drv_wc: true,
 			dev_wc: true,
-			mem_pool: MemPool::new(size),
+			indexes: IndexAlloc::new(size.into()),
 		}
 	}
 
@@ -186,13 +184,13 @@ impl DescriptorRing {
 	/// Returns an initialized write controller in order
 	/// to write the queue correctly.
 	fn get_write_ctrler(&mut self) -> Result<WriteCtrl<'_>, VirtqError> {
-		let desc_id = self.mem_pool.pool.pop().ok_or(VirtqError::NoDescrAvail)?;
+		let desc_id = self.indexes.allocate().ok_or(VirtqError::NoDescrAvail)?;
 		Ok(WriteCtrl {
 			start: self.write_index,
 			position: self.write_index,
 			modulo: u16::try_from(self.ring.len()).unwrap(),
 			first_flags: DescF::empty(),
-			buff_id: desc_id,
+			buff_id: u16::try_from(desc_id).unwrap(),
 
 			desc_ring: self,
 		})
@@ -303,7 +301,9 @@ impl ReadCtrl<'_> {
 			for _ in 0..tkn.num_consuming_descr() {
 				self.incrmt();
 			}
-			self.desc_ring.mem_pool.ret_id(buff_id);
+			unsafe {
+				self.desc_ring.indexes.deallocate(buff_id.into());
+			}
 
 			Some((tkn, write_len))
 		} else {


### PR DESCRIPTION
This replaces the vec-based `MemPool` with a bitmap-based `IndexAlloc`. To track 256 indexes, we now need 32 bytes instead of 512 bytes.

These are measurements from an Apple M2 of creating the allocator, allocating all indices, and then deallocating them again:

| len  | size old | size new | time old  | time new  |
| ----:| --------:| --------:| ---------:| ---------:|
|  256 |      512 |       32 |  1.242 µs |  1.370 µs |
| 1024 |     2048 |       64 |. 5.505 µs |  7.293 µs | 
| 2048 |     4096 |      128 | 10.460 µs | 21.273 µs |

While this is a strict slowdown in this case, I think it is still worth it.