### PR TITLE
refactor: use uhyve version define macro from hermit_entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,14 +812,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-entry"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8646a7eb3029cb587f5d1d8742dd4790d4cb128c78817be42b7b375e7c36f366"
+checksum = "920f9bfe21a23408aade84f1cd2f550c0490be1ec90ae5151b919614808e2e85"
 dependencies = [
  "align-address",
  "const_parse",
  "time",
- "uhyve-interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ free-list = "0.3"
 fuse-abi = { version = "0.2", features = ["linux"], optional = true }
 hashbrown = { version = "0.16", default-features = false }
 heapless = "0.9"
-hermit-entry = { version = "0.10", features = ["kernel"] }
+hermit-entry = { version = "0.10.6", features = ["kernel"] }
 hermit-sync = "0.1"
 lock_api = "0.4"
 log = { version = "0.4", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ hermit_entry::define_abi_tag!();
 hermit_entry::define_entry_version!();
 
 #[cfg(target_os = "none")]
-uhyve_interface::define_uhyve_interface_version!();
+hermit_entry::define_uhyve_interface_version!(uhyve_interface::UHYVE_INTERFACE_VERSION);
 
 #[cfg(test)]
 #[cfg(target_os = "none")]


### PR DESCRIPTION
Depends on https://github.com/hermit-os/hermit-entry/pull/64, and subsequent new `hermit-entry` release.