### PR TITLE
build: allow specification of custom cargo config for kernel compilation

### DIFF
--- a/xtask/src/ci/rs.rs
+++ b/xtask/src/ci/rs.rs
@@ -64,8 +64,14 @@ impl Rs {
 			);
 		};
 
+		let cargo_config = match std::env::var_os("HERMIT_KERNEL_CARGO_CONFIG") {
+			Some(val) if !val.is_empty() => &[std::ffi::OsString::from("--config"), val][..],
+			_ => &[],
+		};
+
 		cargo
 			.current_dir(super::parent_root())
+			.args(cargo_config)
 			.arg("build")
 			.args(self.cargo_build.artifact.arch.ci_cargo_args())
 			.args(self.cargo_build.cargo_build_args())


### PR DESCRIPTION
Of course, this will subsequently require a patch of the cargo build script of the `hermit` crate, in order to report the env var and the file it points to as a rebuild dependency.