### PR TITLE
fix(pcie): include the end bus number in scan

### DIFF
--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -1,4 +1,5 @@
-use core::ops::Range;
+use alloc::fmt::Debug;
+use core::iter::IntoIterator;
 
 use pci_types::{ConfigRegionAccess, PciAddress, PciHeader};
 use x86_64::instructions::port::Port;
@@ -100,7 +101,7 @@ pub(crate) fn init() {
 	info!("Initialized PCI");
 }
 
-fn scan_bus(bus_range: Range<u8>, pci_config: PciConfigRegion) {
+fn scan_bus(bus_range: impl IntoIterator<Item = u8> + Debug, pci_config: PciConfigRegion) {
 	debug!("Scanning PCI buses {bus_range:?}");
 
 	// Hermit only uses PCI for network devices.
@@ -224,13 +225,13 @@ mod pcie {
 			paging::map::<LargePageSize>(
 				virt_addr,
 				phys_addr,
-				bus_entry.bus_number_end.into(),
+				usize::from(bus_entry.bus_number_end) + 1,
 				flags,
 			);
 		}
 
 		super::scan_bus(
-			bus_entry.bus_number_start..bus_entry.bus_number_end,
+			bus_entry.bus_number_start..=bus_entry.bus_number_end,
 			PciConfigRegion::PciE(*bus_entry),
 		);
 	}


### PR DESCRIPTION
According to the sections 4.1.1 and 4.1.2 of the PCI firmware specification v3.0, PCI segments support up to 256 buses, which would mean that the value in the 8-bit end bus number field is included in the range of valid bus numbers. Previous behavious caused no busses to be scanned when only one was available.