### PR TITLE
fix: Proper network wakers

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -25,7 +25,7 @@ use crate::drivers::pci::get_interrupt_handlers;
 use crate::drivers::{InterruptHandlerQueue, InterruptLine};
 use crate::kernel::serial::handle_uart_interrupt;
 use crate::mm::{PageAlloc, PageRangeAllocator};
-use crate::scheduler::{self, CoreId};
+use crate::scheduler::{self, CoreId, timer_interrupts};
 use crate::{core_id, core_scheduler, env};
 
 /// The ID of the first Private Peripheral Interrupt.
@@ -94,10 +94,7 @@ pub(crate) fn install_handlers() {
 
 	fn timer_handler() {
 		debug!("Handle timer interrupt");
-
-		// disable timer
-		CNTP_CVAL_EL0.set(0);
-		CNTP_CTL_EL0.write(CNTP_CTL_EL0::ENABLE::CLEAR);
+		timer_interrupts::clear_active_and_set_next();
 	}
 
 	for (key, value) in get_interrupt_handlers().into_iter() {

--- a/src/arch/riscv64/kernel/scheduler.rs
+++ b/src/arch/riscv64/kernel/scheduler.rs
@@ -5,11 +5,10 @@ use free_list::{PageLayout, PageRange};
 use memory_addresses::{PhysAddr, VirtAddr};
 
 use crate::arch::riscv64::kernel::core_local::core_scheduler;
-use crate::arch::riscv64::kernel::processor::set_oneshot_timer;
 use crate::arch::riscv64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
-use crate::scheduler::PerCoreSchedulerExt;
 use crate::scheduler::task::{Task, TaskFrame};
+use crate::scheduler::{PerCoreSchedulerExt, timer_interrupts};
 use crate::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
 
 /// For details, see [RISC-V Calling Conventions].
@@ -330,9 +329,9 @@ unsafe extern "C" fn task_start(func: extern "C" fn(usize), arg: usize, user_sta
 }
 
 pub fn timer_handler() {
-	//increment_irq_counter(apic::TIMER_INTERRUPT_NUMBER.into());
+	debug!("Handle timer interrupt");
+	timer_interrupts::clear_active_and_set_next();
 	core_scheduler().handle_waiting_tasks();
-	set_oneshot_timer(None);
 	core_scheduler().scheduler();
 }
 

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -16,8 +16,8 @@ use crate::arch::x86_64::mm::paging::{
 use crate::config::*;
 use crate::env;
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
-use crate::scheduler::PerCoreSchedulerExt;
 use crate::scheduler::task::{Task, TaskFrame};
+use crate::scheduler::{PerCoreSchedulerExt, timer_interrupts};
 
 #[repr(C, packed)]
 struct State {
@@ -315,6 +315,10 @@ impl TaskFrame for Task {
 
 extern "x86-interrupt" fn timer_handler(_stack_frame: interrupts::ExceptionStackFrame) {
 	increment_irq_counter(apic::TIMER_INTERRUPT_NUMBER);
+
+	debug!("Handle timer interrupt");
+	timer_interrupts::clear_active_and_set_next();
+
 	core_scheduler().handle_waiting_tasks();
 	apic::eoi();
 	core_scheduler().reschedule();

--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -32,6 +32,7 @@ use crate::drivers::net::{NetworkDriver, mtu};
 #[cfg(feature = "pci")]
 use crate::drivers::pci as hardware;
 use crate::drivers::{Driver, InterruptLine};
+use crate::executor::network::wake_network_waker;
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::{BasePageSize, PageSize};
 
@@ -276,6 +277,8 @@ impl NetworkDriver for GEMDriver {
 
 	fn handle_interrupt(&mut self) {
 		self.tx_fields.handle_interrupt();
+
+		wake_network_waker();
 	}
 }
 

--- a/src/drivers/net/loopback.rs
+++ b/src/drivers/net/loopback.rs
@@ -8,6 +8,7 @@ use smoltcp::time::Instant;
 
 use crate::drivers::net::NetworkDriver;
 use crate::drivers::{Driver, InterruptLine};
+use crate::executor::network::wake_network_waker;
 use crate::mm::device_alloc::DeviceAlloc;
 
 pub(crate) struct LoopbackDriver {
@@ -122,7 +123,7 @@ impl NetworkDriver for LoopbackDriver {
 	}
 
 	fn handle_interrupt(&mut self) {
-		// no-op
+		wake_network_waker();
 	}
 }
 

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -21,6 +21,7 @@ use crate::drivers::Driver;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::{NetworkDriver, mtu};
 use crate::drivers::pci::PciDevice;
+use crate::executor::network::wake_network_waker;
 use crate::mm::device_alloc::DeviceAlloc;
 
 /// Size of the receive buffer
@@ -691,6 +692,8 @@ impl NetworkDriver for RTL8139Driver {
 		self.regs.as_mut_ptr().isr().write(le16::from(
 			isr_contents & (ISR_RXOVW | ISR_TER | ISR_RER | ISR_TOK | ISR_ROK),
 		));
+
+		wake_network_waker();
 	}
 }
 

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -43,6 +43,7 @@ use crate::drivers::virtio::virtqueue::{
 	AvailBufferToken, BufferElem, BufferType, UsedBufferToken, VirtQueue, Virtq,
 };
 use crate::drivers::{Driver, InterruptLine};
+use crate::executor::network::wake_network_waker;
 use crate::mm::device_alloc::DeviceAlloc;
 
 /// A wrapper struct for the raw configuration structure.
@@ -418,6 +419,8 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 			info!("Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}
+
+		wake_network_waker();
 	}
 }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -18,15 +18,11 @@ use core::time::Duration;
 
 use crossbeam_utils::Backoff;
 use hermit_sync::without_interrupts;
-#[cfg(feature = "net")]
-use smoltcp::time::Instant;
 
 use crate::arch::core_local;
 use crate::errno::Errno;
 use crate::executor::task::AsyncTask;
 use crate::io;
-#[cfg(feature = "net")]
-use crate::scheduler::PerCoreSchedulerExt;
 use crate::synch::futex::*;
 
 /// WakerRegistration is derived from smoltcp's
@@ -157,101 +153,26 @@ where
 
 		let now = crate::arch::kernel::systemtime::now_micros();
 		if let Poll::Ready(t) = result {
-			// allow network interrupts
-			#[cfg(feature = "net")]
-			{
-				if let Some(mut guard) = crate::executor::network::NIC.try_lock() {
-					let delay = if let Ok(nic) = guard.as_nic_mut() {
-						nic.set_polling_mode(false);
-
-						nic.poll_delay(Instant::from_micros_const(now.try_into().unwrap()))
-							.map(|d| d.total_micros())
-					} else {
-						None
-					};
-					core_local::core_scheduler().add_network_timer(
-						delay.map(|d| crate::arch::processor::get_timer_ticks() + d),
-					);
-				}
-			}
-
 			return t;
 		}
 
 		if let Some(duration) = timeout
 			&& Duration::from_micros(now - start) >= duration
 		{
-			// allow network interrupts
-			#[cfg(feature = "net")]
-			{
-				if let Some(mut guard) = crate::executor::network::NIC.try_lock() {
-					let delay = if let Ok(nic) = guard.as_nic_mut() {
-						nic.set_polling_mode(false);
-
-						nic.poll_delay(Instant::from_micros_const(now.try_into().unwrap()))
-							.map(|d| d.total_micros())
-					} else {
-						None
-					};
-					core_local::core_scheduler().add_network_timer(
-						delay.map(|d| crate::arch::processor::get_timer_ticks() + d),
-					);
-				}
-			}
-
 			return Err(Errno::Time);
 		}
 
-		#[cfg(feature = "net")]
 		if backoff.is_completed() {
-			let delay = if let Some(mut guard) = crate::executor::network::NIC.try_lock() {
-				if let Ok(nic) = guard.as_nic_mut() {
-					nic.set_polling_mode(false);
+			let wakeup_time =
+				timeout.map(|duration| start + u64::try_from(duration.as_micros()).unwrap());
 
-					nic.poll_delay(Instant::from_micros_const(now.try_into().unwrap()))
-						.map(|d| d.total_micros())
-				} else {
-					None
-				}
-			} else {
-				None
-			};
+			// switch to another task
+			task_notify.wait(wakeup_time);
 
-			if delay.unwrap_or(10_000_000) > 10_000 {
-				core_local::core_scheduler().add_network_timer(
-					delay.map(|d| crate::arch::processor::get_timer_ticks() + d),
-				);
-				let wakeup_time =
-					timeout.map(|duration| start + u64::try_from(duration.as_micros()).unwrap());
-
-				// switch to another task
-				task_notify.wait(wakeup_time);
-
-				// restore default values
-				if let Ok(nic) = crate::executor::network::NIC.lock().as_nic_mut() {
-					nic.set_polling_mode(true);
-				}
-
-				backoff.reset();
-			}
+			// restore default values
+			backoff.reset();
 		} else {
 			backoff.snooze();
-		}
-
-		#[cfg(not(feature = "net"))]
-		{
-			if backoff.is_completed() {
-				let wakeup_time =
-					timeout.map(|duration| start + u64::try_from(duration.as_micros()).unwrap());
-
-				// switch to another task
-				task_notify.wait(wakeup_time);
-
-				// restore default values
-				backoff.reset();
-			} else {
-				backoff.snooze();
-			}
 		}
 	}
 }

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -26,10 +26,10 @@ use crate::arch;
 use crate::drivers::net::{NetworkDevice, NetworkDriver};
 #[cfg(feature = "dns")]
 use crate::errno::Errno;
-use crate::executor::spawn;
+use crate::executor::{WakerRegistration, spawn};
 #[cfg(feature = "dns")]
 use crate::io;
-use crate::scheduler::PerCoreSchedulerExt;
+use crate::scheduler::timer_interrupts::{Source, create_timer};
 
 pub(crate) enum NetworkState<'a> {
 	Missing,
@@ -189,6 +189,24 @@ async fn dhcpv4_run() {
 	.await;
 }
 
+pub(crate) static NETWORK_WAKER: InterruptTicketMutex<WakerRegistration> =
+	InterruptTicketMutex::new(WakerRegistration::new());
+
+#[track_caller]
+pub(crate) fn wake_network_waker() {
+	if log_enabled!(log::Level::Trace) {
+		let module = core::panic::Location::caller()
+			.file()
+			.rsplit('/')
+			.map(|m| m.split_once('.').map_or(m, |i| i.0))
+			.find(|m| *m != "mod")
+			.unwrap();
+		trace!(target: module, "Waking network waker");
+	}
+
+	NETWORK_WAKER.lock().wake();
+}
+
 async fn network_run() {
 	future::poll_fn(|cx| {
 		let Some(mut guard) = NIC.try_lock() else {
@@ -202,9 +220,24 @@ async fn network_run() {
 			return Poll::Ready(());
 		};
 
-		nic.poll_common(now());
-		// FIXME: only wake when progress can be made
-		cx.waker().wake_by_ref();
+		let now = now();
+
+		match nic.poll_common(now) {
+			PollResult::SocketStateChanged => {
+				// Progress was made
+				cx.waker().wake_by_ref();
+			}
+			PollResult::None => {
+				// Very likely no progress can be made, so set up a timer interrupt to wake the waker
+				NETWORK_WAKER.lock().register(cx.waker());
+				nic.set_polling_mode(false);
+				if let Some(wakeup_time) = nic.poll_delay(now).map(|d| d.total_micros()) {
+					create_timer(Source::Network, wakeup_time);
+					trace!("Configured an interrupt for {wakeup_time:?}");
+				}
+			}
+		}
+
 		Poll::Pending
 	})
 	.await;
@@ -253,20 +286,11 @@ pub(crate) fn init() {
 
 	*guard = NetworkInterface::create();
 
-	let NetworkState::Initialized(nic) = &mut *guard else {
-		return;
-	};
-
-	let time = now();
-	nic.poll_common(time);
-	let wakeup_time = nic
-		.poll_delay(time)
-		.map(|d| crate::arch::processor::get_timer_ticks() + d.total_micros());
-	crate::core_scheduler().add_network_timer(wakeup_time);
-
-	spawn(network_run());
-	#[cfg(feature = "dhcpv4")]
-	spawn(dhcpv4_run());
+	if let NetworkState::Initialized(_) = &mut *guard {
+		spawn(network_run());
+		#[cfg(feature = "dhcpv4")]
+		spawn(dhcpv4_run());
+	}
 }
 
 impl<'a> NetworkInterface<'a> {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -18,6 +18,7 @@ use hashbrown::{HashMap, hash_map};
 use hermit_sync::*;
 #[cfg(target_arch = "riscv64")]
 use riscv::register::sstatus;
+use timer_interrupts::TimerList;
 
 use crate::arch::core_local::*;
 #[cfg(target_arch = "riscv64")]
@@ -32,6 +33,7 @@ use crate::scheduler::task::*;
 use crate::{arch, io};
 
 pub mod task;
+pub mod timer_interrupts;
 
 static NO_TASKS: AtomicU32 = AtomicU32::new(0);
 /// Map between Core ID and per-core scheduler
@@ -90,15 +92,14 @@ pub(crate) struct PerCoreScheduler {
 	finished_tasks: VecDeque<Rc<RefCell<Task>>>,
 	/// Queue of blocked tasks, sorted by wakeup time.
 	blocked_tasks: BlockedTaskQueue,
+	/// Queue of timer interrupts.
+	pub timers: TimerList,
 }
 
 pub(crate) trait PerCoreSchedulerExt {
 	/// Triggers the scheduler to reschedule the tasks.
 	/// Interrupt flag will be cleared during the reschedule
 	fn reschedule(self);
-
-	#[cfg(feature = "net")]
-	fn add_network_timer(self, wakeup_time: Option<u64>);
 
 	/// Terminate the current task on the current core.
 	fn exit(self, exit_code: i32) -> !;
@@ -167,13 +168,6 @@ impl PerCoreSchedulerExt for &mut PerCoreScheduler {
 	#[cfg(target_arch = "riscv64")]
 	fn reschedule(self) {
 		without_interrupts(|| self.scheduler());
-	}
-
-	#[cfg(feature = "net")]
-	fn add_network_timer(self, wakeup_time: Option<u64>) {
-		without_interrupts(|| {
-			self.blocked_tasks.add_network_timer(wakeup_time);
-		});
 	}
 
 	fn exit(self, exit_code: i32) -> ! {
@@ -898,6 +892,7 @@ pub(crate) fn add_current_core() {
 		ready_queue: PriorityTaskQueue::new(),
 		finished_tasks: VecDeque::new(),
 		blocked_tasks: BlockedTaskQueue::new(),
+		timers: TimerList::new(),
 	});
 
 	let scheduler = Box::into_raw(boxed_scheduler);

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -18,6 +18,7 @@ use memory_addresses::VirtAddr;
 
 #[cfg(not(feature = "common-os"))]
 use self::tls::Tls;
+use super::timer_interrupts::{Source, create_timer_abs};
 use crate::arch::core_local::*;
 use crate::arch::scheduler::TaskStacks;
 use crate::fd::stdio::*;
@@ -511,16 +512,12 @@ impl BlockedTask {
 
 pub(crate) struct BlockedTaskQueue {
 	list: LinkedList<BlockedTask>,
-	#[cfg(feature = "net")]
-	network_wakeup_time: Option<u64>,
 }
 
 impl BlockedTaskQueue {
 	pub const fn new() -> Self {
 		Self {
 			list: LinkedList::new(),
-			#[cfg(feature = "net")]
-			network_wakeup_time: None,
 		}
 	}
 
@@ -547,20 +544,6 @@ impl BlockedTaskQueue {
 		borrowed.status = TaskStatus::Ready;
 	}
 
-	#[cfg(feature = "net")]
-	pub fn add_network_timer(&mut self, wakeup_time: Option<u64>) {
-		self.network_wakeup_time = wakeup_time;
-
-		let next = self.list.front().and_then(|t| t.wakeup_time);
-
-		let time = match (wakeup_time, next) {
-			(Some(a), Some(b)) => Some(a.min(b)),
-			(a, b) => a.or(b),
-		};
-
-		arch::set_oneshot_timer(time);
-	}
-
 	/// Blocks the given task for `wakeup_time` ticks, or indefinitely if None is given.
 	pub fn add(&mut self, task: Rc<RefCell<Task>>, wakeup_time: Option<u64>) {
 		{
@@ -582,35 +565,20 @@ impl BlockedTaskQueue {
 		// Shall the task automatically be woken up after a certain time?
 		if let Some(wt) = wakeup_time {
 			let mut cursor = self.list.cursor_front_mut();
-			let set_oneshot_timer = || {
-				#[cfg(not(feature = "net"))]
-				arch::set_oneshot_timer(wakeup_time);
-				#[cfg(feature = "net")]
-				match self.network_wakeup_time {
-					Some(time) => {
-						if time > wt {
-							arch::set_oneshot_timer(wakeup_time);
-						} else {
-							arch::set_oneshot_timer(self.network_wakeup_time);
-						}
-					}
-					_ => arch::set_oneshot_timer(wakeup_time),
-				}
-			};
 
 			while let Some(node) = cursor.current() {
 				let node_wakeup_time = node.wakeup_time;
 				if node_wakeup_time.is_none() || wt < node_wakeup_time.unwrap() {
 					cursor.insert_before(new_node);
 
-					set_oneshot_timer();
+					create_timer_abs(Source::Scheduler, wt);
 					return;
 				}
 
 				cursor.move_next();
 			}
 
-			set_oneshot_timer();
+			create_timer_abs(Source::Scheduler, wt);
 		}
 
 		self.list.push_back(new_node);
@@ -621,13 +589,6 @@ impl BlockedTaskQueue {
 		let mut first_task = true;
 		let mut cursor = self.list.cursor_front_mut();
 
-		#[cfg(feature = "net")]
-		if let Some(wakeup_time) = self.network_wakeup_time
-			&& wakeup_time <= arch::processor::get_timer_ticks()
-		{
-			self.network_wakeup_time = None;
-		}
-
 		// Loop through all blocked tasks to find it.
 		while let Some(node) = cursor.current() {
 			if node.task.borrow().id == task.get_id() {
@@ -637,29 +598,12 @@ impl BlockedTaskQueue {
 
 				// If this is the first task, adjust the One-Shot Timer to fire at the
 				// next task's wakeup time (if any).
-				#[cfg(feature = "net")]
-				if first_task {
-					arch::set_oneshot_timer(cursor.current().map_or_else(
-						|| self.network_wakeup_time,
-						|node| match node.wakeup_time {
-							Some(wt) => {
-								if let Some(timer) = self.network_wakeup_time {
-									if wt < timer { Some(wt) } else { Some(timer) }
-								} else {
-									Some(wt)
-								}
-							}
-							None => self.network_wakeup_time,
-						},
-					));
-				}
-				#[cfg(not(feature = "net"))]
-				if first_task {
-					arch::set_oneshot_timer(
-						cursor
-							.current()
-							.map_or_else(|| None, |node| node.wakeup_time),
-					);
+				if first_task
+					&& let Some(wakeup) = cursor
+						.current()
+						.map_or_else(|| None, |node| node.wakeup_time)
+				{
+					create_timer_abs(Source::Scheduler, wakeup);
 				}
 
 				// Wake it up.
@@ -683,15 +627,6 @@ impl BlockedTaskQueue {
 		// Get the current time.
 		let time = arch::processor::get_timer_ticks();
 
-		#[cfg(feature = "net")]
-		if let Some(mut guard) = crate::executor::network::NIC.try_lock()
-			&& let crate::executor::network::NetworkState::Initialized(nic) = &mut *guard
-		{
-			let now = crate::executor::network::now();
-			nic.poll_common(now);
-			self.network_wakeup_time = nic.poll_delay(now).map(|d| d.total_micros() + time);
-		}
-
 		// Get the wakeup time of this task and check if we have reached the first task
 		// that hasn't elapsed yet or waits indefinitely.
 		// This iterator has to be consumed to actually remove the elements.
@@ -707,20 +642,9 @@ impl BlockedTaskQueue {
 		}
 
 		let new_task_wakeup_time = self.list.front().and_then(|task| task.wakeup_time);
-		cfg_if::cfg_if! {
-			if #[cfg(feature = "net")] {
-				let network_wakeup_time = self.network_wakeup_time;
-			} else {
-				let network_wakeup_time = None;
-			}
-		};
-		let timer_wakeup_time = match (new_task_wakeup_time, network_wakeup_time) {
-			(None, None) => None,
-			(None, Some(network_wt)) => Some(network_wt),
-			(Some(task_wt), None) => Some(task_wt),
-			(Some(task_wt), Some(network_wt)) => Some(u64::min(task_wt, network_wt)),
-		};
 
-		arch::set_oneshot_timer(timer_wakeup_time);
+		if let Some(wakeup) = new_task_wakeup_time {
+			create_timer_abs(Source::Scheduler, wakeup);
+		}
 	}
 }

--- a/src/scheduler/timer_interrupts.rs
+++ b/src/scheduler/timer_interrupts.rs
@@ -1,0 +1,153 @@
+use core::mem;
+
+use crate::core_local::core_scheduler;
+#[cfg(feature = "net")]
+use crate::executor::network::wake_network_waker;
+use crate::set_oneshot_timer;
+
+/// A possible timer interrupt source (i.e. reason the timer interrupt was set
+/// up).
+#[derive(Debug, PartialEq, Eq)]
+pub enum Source {
+	Network,
+	Scheduler,
+}
+
+/// A slot in the timer list. Each source is represented once. This is so that
+/// we can have multiple timers at the same time with only one hardware timer.
+#[derive(Debug)]
+pub struct Slot {
+	/// Timer source.
+	source: Source,
+	/// Point in time at which to wake up (in microsecond precision).
+	/// A value of [`u64::MAX`] means the timer is not set.
+	/// This is done to
+	wakeup_time: u64,
+}
+
+// List of timers with one entry for every possible source.
+#[derive(Debug)]
+pub struct TimerList([Slot; 2]);
+
+impl TimerList {
+	pub fn new() -> Self {
+		Self([
+			Slot {
+				source: Source::Network,
+				wakeup_time: u64::MAX,
+			},
+			Slot {
+				source: Source::Scheduler,
+				wakeup_time: u64::MAX,
+			},
+		])
+	}
+
+	/// Mutably get the slot for a source.
+	pub fn slot_by_source_mut(&mut self, source: Source) -> &mut Slot {
+		// Cannot panic: There's more than one slot
+		self.0
+			.iter_mut()
+			.find(|slot| slot.source == source)
+			.unwrap()
+	}
+
+	// Find and get the next timer to fire (may return one that is not currently set if none are set).
+	pub fn next_timer(&self) -> &Slot {
+		// Cannot panic: There's more than 1 slot
+		self.0
+			.iter()
+			.min_by(|a, b| a.wakeup_time.cmp(&b.wakeup_time))
+			.unwrap()
+	}
+
+	/// Find and mutably get the next timer to fire (may return one that is not currently set if none are set).
+	pub fn next_timer_mut(&mut self) -> &mut Slot {
+		// Cannot panic: There's more than 1 slot
+		self.0
+			.iter_mut()
+			.min_by(|a, b| a.wakeup_time.cmp(&b.wakeup_time))
+			.unwrap()
+	}
+
+	/// Adjust all wakeup times by a specific offset.
+	pub fn adjust_by(&mut self, offset: u64) {
+		for timer in self.0.iter_mut() {
+			if timer.wakeup_time != u64::MAX {
+				timer.wakeup_time -= offset;
+			}
+		}
+	}
+}
+
+impl Default for TimerList {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+/// Create a new timer, overriding any previous timer for the source.
+#[cfg(feature = "net")]
+#[inline]
+pub fn create_timer(source: Source, wakeup_micros: u64) {
+	create_timer_abs(
+		source,
+		// get_timer_ticks should always return a nonzero value
+		crate::arch::processor::get_timer_ticks() + wakeup_micros,
+	);
+}
+
+/// Crete a new timer, but with an absolute wakeup time.
+pub fn create_timer_abs(source: Source, wakeup_time: u64) {
+	let timers = &mut core_scheduler().timers;
+
+	// Cannot panic: Our timer list has an entry for every possible source
+	let previous_entry = timers.slot_by_source_mut(source);
+
+	// Overwrite the wakeup time
+	previous_entry.wakeup_time = previous_entry.wakeup_time.min(wakeup_time);
+
+	// If this timer is the one closest in the future, set the real timer to it
+	if timers.next_timer().wakeup_time == wakeup_time {
+		set_oneshot_timer(Some(wakeup_time));
+	}
+}
+
+/// Clears the timer slot for the currently active timer and sets the next timer or disables it if no timer is pending.
+pub fn clear_active_and_set_next() {
+	let timers = &mut core_scheduler().timers;
+
+	let lowest_timer = timers.next_timer_mut();
+	assert!(lowest_timer.wakeup_time != u64::MAX);
+
+	// Handle the timer interrupt
+	match lowest_timer.source {
+		#[cfg(feature = "net")]
+		Source::Network => wake_network_waker(),
+		_ => {} // no-op, we always poll after a timer interrupt
+	}
+
+	trace!("Cleared active timer {lowest_timer:?}");
+
+	let prev_wakeup_time = mem::replace(&mut lowest_timer.wakeup_time, u64::MAX);
+
+	// We may receive a timer interrupt earlier than expected
+	// This appears to only be the case in QEMU, it seems like timer ticks
+	// do not advance linearly there?
+	// Either way, this means that QEMU *thinks* the time has passed, so it
+	// probably has and knows better than we do.
+	// We can cheat a bit and adjust all timers slightly based on this
+	let timer_ticks = crate::arch::processor::get_timer_ticks();
+	if prev_wakeup_time > timer_ticks {
+		let offset = prev_wakeup_time - timer_ticks;
+		timers.adjust_by(offset);
+	}
+
+	let new_lowest_timer = timers.next_timer().wakeup_time;
+
+	if new_lowest_timer == u64::MAX {
+		set_oneshot_timer(None);
+	} else {
+		set_oneshot_timer(Some(new_lowest_timer));
+	}
+}


### PR DESCRIPTION
This refactors our timer interrupt handling into a separate module that all timer interrupts are configured through and handled by. It allows us to track why a timer interrupt was fired.

We make use of this to now only conditionally wake the network task's waker when necessary. This is either because we sent some network packets, a network device driver received an interrupt, or because a timer interrupt that we configured so we can poll smoltcp in the future was handled.

Closes https://github.com/hermit-os/kernel/pull/1933.
Closes https://github.com/hermit-os/kernel/issues/2126.