### PR TITLE
refactor(fd): remove `Debug` bound from `ObjectInterface`

### DIFF
--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -28,7 +28,6 @@ impl EventState {
 	}
 }
 
-#[derive(Debug)]
 pub(crate) struct EventFd {
 	state: Mutex<EventState>,
 	flags: EventFlags,

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -196,7 +196,7 @@ impl Default for AccessPermission {
 }
 
 #[async_trait]
-pub(crate) trait ObjectInterface: Sync + Send + core::fmt::Debug {
+pub(crate) trait ObjectInterface: Sync + Send {
 	/// check if an IO event is possible
 	async fn poll(&self, _event: PollEvent) -> io::Result<PollEvent> {
 		Ok(PollEvent::empty())

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -33,7 +33,6 @@ fn get_ephemeral_port() -> u16 {
 	LOCAL_ENDPOINT.fetch_add(1, Ordering::SeqCst)
 }
 
-#[derive(Debug)]
 pub struct Socket {
 	handle: BTreeSet<Handle>,
 	endpoint: IpEndpoint,

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -15,7 +15,6 @@ use crate::fd::{self, Endpoint, ListenEndpoint, ObjectInterface, PollEvent};
 use crate::io;
 use crate::syscalls::socket::Af;
 
-#[derive(Debug)]
 pub struct Socket {
 	handle: Handle,
 	nonblocking: bool,

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -41,7 +41,6 @@ impl VsockEndpoint {
 	}
 }
 
-#[derive(Debug)]
 pub struct NullSocket;
 
 impl NullSocket {
@@ -53,7 +52,6 @@ impl NullSocket {
 #[async_trait]
 impl ObjectInterface for NullSocket {}
 
-#[derive(Debug)]
 pub struct Socket {
 	port: u32,
 	cid: u32,

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -14,7 +14,6 @@ use crate::fd::{
 use crate::io;
 use crate::syscalls::interfaces::uhyve_hypercall;
 
-#[derive(Debug)]
 pub struct GenericStdin;
 
 #[async_trait]
@@ -63,7 +62,6 @@ impl GenericStdin {
 	}
 }
 
-#[derive(Debug)]
 pub struct GenericStdout;
 
 #[async_trait]
@@ -96,7 +94,6 @@ impl GenericStdout {
 	}
 }
 
-#[derive(Debug)]
 pub struct GenericStderr;
 
 #[async_trait]
@@ -129,7 +126,6 @@ impl GenericStderr {
 	}
 }
 
-#[derive(Debug)]
 pub struct UhyveStdin;
 
 #[async_trait]
@@ -153,7 +149,6 @@ impl UhyveStdin {
 	}
 }
 
-#[derive(Debug)]
 pub struct UhyveStdout;
 
 #[async_trait]
@@ -193,7 +188,6 @@ impl UhyveStdout {
 	}
 }
 
-#[derive(Debug)]
 pub struct UhyveStderr;
 
 #[async_trait]

--- a/src/fs/fuse.rs
+++ b/src/fs/fuse.rs
@@ -896,7 +896,6 @@ impl Drop for FuseFileHandleInner {
 	}
 }
 
-#[derive(Debug)]
 struct FuseFileHandle(pub Arc<Mutex<FuseFileHandleInner>>);
 
 impl FuseFileHandle {
@@ -961,7 +960,6 @@ impl Clone for FuseFileHandle {
 	}
 }
 
-#[derive(Debug)]
 pub struct FuseDirectoryHandle {
 	name: Option<String>,
 	read_position: Mutex<usize>,

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -41,7 +41,6 @@ impl RomFileInner {
 	}
 }
 
-#[derive(Debug)]
 struct RomFileInterface {
 	/// Position within the file
 	pos: Mutex<usize>,
@@ -152,7 +151,6 @@ impl RamFileInner {
 	}
 }
 
-#[derive(Debug)]
 pub struct RamFileInterface {
 	/// Position within the file
 	pos: Mutex<usize>,
@@ -395,7 +393,6 @@ impl RamFile {
 	}
 }
 
-#[derive(Debug)]
 pub struct MemDirectoryInterface {
 	/// Directory entries
 	inner:

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -127,7 +127,7 @@ pub(crate) trait VfsNode: core::fmt::Debug {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct DirectoryReader(Vec<DirectoryEntry>);
 
 impl DirectoryReader {

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -98,7 +98,6 @@ impl Drop for UhyveFileHandleInner {
 	}
 }
 
-#[derive(Debug)]
 struct UhyveFileHandle(pub Arc<Mutex<UhyveFileHandleInner>>);
 
 impl UhyveFileHandle {

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -464,7 +464,9 @@ impl Task {
 				>::with_hasher(
 					RandomState::with_seeds(0, 0, 0, 0),
 				))))
-				.unwrap();
+				// This function is called once per core and thus only once on core 0.
+				// Thus, this is the only place where we set OBJECT_MAP.
+				.unwrap_or_else(|_| unreachable!());
 			let objmap = OBJECT_MAP.get().unwrap().clone();
 			let mut guard = objmap.write();
 			if env::is_uhyve() {


### PR DESCRIPTION
Extracted and extended from https://github.com/hermit-os/kernel/pull/2078.