### PR TITLE
fix(fs/mem): don't implement min manually

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -80,12 +80,7 @@ impl ObjectInterface for RomFileInterface {
 			return Ok(0);
 		}
 
-		let len = if vec.len() - pos < buf.len() {
-			vec.len() - pos
-		} else {
-			buf.len()
-		};
-
+		let len = (vec.len() - pos).min(buf.len());
 		buf[..len].copy_from_slice(&vec[pos..pos + len]);
 		*pos_guard = pos + len;
 


### PR DESCRIPTION
Extracted from https://github.com/hermit-os/kernel/pull/2078.

There does not seem to be a `clippy::manual_min` or similar. 🤔 