### PR TITLE
refactor(fd): replace `dyn ObjectInterface` with `enum Fd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,17 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +471,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -823,12 +823,12 @@ dependencies = [
  "arm-pl011-uart",
  "async-executor",
  "async-lock",
- "async-trait",
  "bit_field",
  "bitflags 2.11.0",
  "build-time",
  "built",
  "crossbeam-utils",
+ "delegate",
  "document-features",
  "embedded-io",
  "endian-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,11 +315,11 @@ align-address = "0.4"
 anstyle = { version = "1", default-features = false }
 async-executor = { git = "https://github.com/hermit-os/async-executor.git", branch = "no_std", default-features = false, features = ["static"] }
 async-lock = { version = "3.4.2", default-features = false }
-async-trait = "0.1.89"
 bit_field = "0.10"
 bitflags = "2"
 build-time = "0.1.3"
 crossbeam-utils = { version = "0.8", default-features = false }
+delegate = "0.13"
 document-features = { version = "0.2", optional = true }
 embedded-io = { version = "0.7", features = ["alloc"] }
 endian-num = { version = "0.2", optional = true, features = ["linux-types"] }

--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -1,0 +1,163 @@
+#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+use alloc::sync::Arc;
+use core::mem::MaybeUninit;
+
+use delegate::delegate;
+
+use crate::fd::eventfd::EventFd;
+#[cfg(feature = "tcp")]
+use crate::fd::socket::tcp;
+#[cfg(feature = "udp")]
+use crate::fd::socket::udp;
+#[cfg(feature = "virtio-vsock")]
+use crate::fd::socket::vsock;
+use crate::fd::stdio::{
+	GenericStderr, GenericStdin, GenericStdout, UhyveStderr, UhyveStdin, UhyveStdout,
+};
+use crate::fd::{AccessPermission, ObjectInterface, PollEvent, StatusFlags};
+#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+use crate::fd::{Endpoint, ListenEndpoint, SocketOption};
+use crate::fs::mem::{MemDirectoryInterface, RamFileInterface, RomFileInterface};
+use crate::fs::uhyve::UhyveFileHandle;
+#[cfg(feature = "virtio-fs")]
+use crate::fs::virtio_fs::{VirtioFsDirectoryHandle, VirtioFsFileHandle};
+use crate::fs::{DirectoryReader, FileAttr, SeekWhence};
+use crate::io;
+
+pub(crate) enum Fd {
+	GenericStdin(GenericStdin),
+	GenericStdout(GenericStdout),
+	GenericStderr(GenericStderr),
+	UhyveStdin(UhyveStdin),
+	UhyveStdout(UhyveStdout),
+	UhyveStderr(UhyveStderr),
+	EventFd(EventFd),
+	#[cfg(feature = "tcp")]
+	TcpSocket(tcp::Socket),
+	#[cfg(feature = "udp")]
+	UdpSocket(udp::Socket),
+	#[cfg(feature = "virtio-vsock")]
+	VsockNullSocket(vsock::NullSocket),
+	#[cfg(feature = "virtio-vsock")]
+	VsockSocket(vsock::Socket),
+	#[cfg(feature = "virtio-fs")]
+	VirtioFsFileHandle(VirtioFsFileHandle),
+	#[cfg(feature = "virtio-fs")]
+	VirtioFsDirectoryHandle(VirtioFsDirectoryHandle),
+	RomFileInterface(RomFileInterface),
+	RamFileInterface(RamFileInterface),
+	MemDirectoryInterface(MemDirectoryInterface),
+	DirectoryReader(DirectoryReader),
+	UhyveFileHandle(UhyveFileHandle),
+}
+
+macro_rules! fd_from {
+	() => {};
+	(
+		$(#[$meta:meta])*
+		$ident:ident($ty:ty),
+		$($rest:tt)*
+	) => {
+		$(#[$meta])*
+		impl From<$ty> for Fd {
+			fn from(value: $ty) -> Self {
+				Self::$ident(value)
+			}
+		}
+
+		fd_from!($($rest)*);
+	};
+}
+
+fd_from! {
+	GenericStdin(GenericStdin),
+	GenericStdout(GenericStdout),
+	GenericStderr(GenericStderr),
+	UhyveStdin(UhyveStdin),
+	UhyveStdout(UhyveStdout),
+	UhyveStderr(UhyveStderr),
+	EventFd(EventFd),
+	#[cfg(feature = "tcp")]
+	TcpSocket(tcp::Socket),
+	#[cfg(feature = "udp")]
+	UdpSocket(udp::Socket),
+	#[cfg(feature = "virtio-vsock")]
+	VsockNullSocket(vsock::NullSocket),
+	#[cfg(feature = "virtio-vsock")]
+	VsockSocket(vsock::Socket),
+	#[cfg(feature = "virtio-fs")]
+	VirtioFsFileHandle(VirtioFsFileHandle),
+	#[cfg(feature = "virtio-fs")]
+	VirtioFsDirectoryHandle(VirtioFsDirectoryHandle),
+	RomFileInterface(RomFileInterface),
+	RamFileInterface(RamFileInterface),
+	MemDirectoryInterface(MemDirectoryInterface),
+	DirectoryReader(DirectoryReader),
+	UhyveFileHandle(UhyveFileHandle),
+}
+
+impl ObjectInterface for Fd {
+	delegate! {
+		to match self {
+			Self::GenericStdin(fd) => fd,
+			Self::GenericStdout(fd) => fd,
+			Self::GenericStderr(fd) => fd,
+			Self::UhyveStdin(fd) => fd,
+			Self::UhyveStdout(fd) => fd,
+			Self::UhyveStderr(fd) => fd,
+			Self::EventFd(fd) => fd,
+			#[cfg(feature = "tcp")]
+			Self::TcpSocket(fd) => fd,
+			#[cfg(feature = "udp")]
+			Self::UdpSocket(fd) => fd,
+			#[cfg(feature = "virtio-vsock")]
+			Self::VsockNullSocket(fd) => fd,
+			#[cfg(feature = "virtio-vsock")]
+			Self::VsockSocket(fd) => fd,
+			#[cfg(feature = "virtio-fs")]
+			Self::VirtioFsFileHandle(fd) => fd,
+			#[cfg(feature = "virtio-fs")]
+			Self::VirtioFsDirectoryHandle(fd) => fd,
+			Self::RomFileInterface(fd) => fd,
+			Self::RamFileInterface(fd) => fd,
+			Self::MemDirectoryInterface(fd) => fd,
+			Self::DirectoryReader(fd) => fd,
+			Self::UhyveFileHandle(fd) => fd,
+		} {
+			async fn poll(&self, event: PollEvent) -> io::Result<PollEvent>;
+			async fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
+			async fn write(&self, buf: &[u8]) -> io::Result<usize>;
+			async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize>;
+			async fn fstat(&self) -> io::Result<FileAttr>;
+			async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn accept(&mut self) -> io::Result<(Arc<async_lock::RwLock<Fd>>, Endpoint)>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn connect(&mut self, endpoint: Endpoint) -> io::Result<()>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn bind(&mut self, _name: ListenEndpoint) -> io::Result<()>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn listen(&mut self, _backlog: i32) -> io::Result<()>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn setsockopt(&self, _opt: SocketOption, _optval: bool) -> io::Result<()>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn getsockopt(&self, _opt: SocketOption) -> io::Result<bool>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn getsockname(&self) -> io::Result<Option<Endpoint>>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			#[allow(dead_code)]
+			async fn getpeername(&self) -> io::Result<Option<Endpoint>>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn recvfrom(&self, _buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize>;
+			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
+			async fn shutdown(&self, _how: i32) -> io::Result<()>;
+			async fn status_flags(&self) -> io::Result<StatusFlags>;
+			async fn set_status_flags(&mut self, _status_flags: StatusFlags) -> io::Result<()>;
+			async fn truncate(&self, _size: usize) -> io::Result<()>;
+			async fn chmod(&self, _access_permission: AccessPermission) -> io::Result<()>;
+			async fn isatty(&self) -> io::Result<bool>;
+		}
+	}
+}

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use alloc::collections::vec_deque::VecDeque;
 use core::future::{self, Future};
 use core::mem;
@@ -6,7 +5,6 @@ use core::pin::pin;
 use core::task::{Poll, Waker, ready};
 
 use async_lock::Mutex;
-use async_trait::async_trait;
 
 use crate::errno::Errno;
 use crate::fd::{EventFlags, ObjectInterface, PollEvent};
@@ -44,7 +42,6 @@ impl EventFd {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for EventFd {
 	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		let len = mem::size_of::<u64>();

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -1,11 +1,9 @@
-use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use core::future;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::Poll;
 
-use async_trait::async_trait;
 use smoltcp::iface;
 use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
@@ -14,7 +12,7 @@ use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
 use crate::errno::Errno;
 use crate::executor::block_on;
 use crate::executor::network::{Handle, NIC, wake_network_waker};
-use crate::fd::{self, Endpoint, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
+use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
 use crate::syscalls::socket::Af;
 use crate::{DEFAULT_KEEP_ALIVE_INTERVAL, io};
 
@@ -115,7 +113,6 @@ impl Socket {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for Socket {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		future::poll_fn(|cx| {
@@ -308,9 +305,7 @@ impl ObjectInterface for Socket {
 		.await
 	}
 
-	async fn accept(
-		&mut self,
-	) -> io::Result<(Arc<async_lock::RwLock<dyn ObjectInterface>>, Endpoint)> {
+	async fn accept(&mut self) -> io::Result<(Arc<async_lock::RwLock<Fd>>, Endpoint)> {
 		if !self.is_listen {
 			self.listen(DEFAULT_BACKLOG).await?;
 		}
@@ -369,7 +364,7 @@ impl ObjectInterface for Socket {
 			is_listen: false,
 		};
 
-		Ok((Arc::new(async_lock::RwLock::new(socket)), endpoint))
+		Ok((Arc::new(async_lock::RwLock::new(socket.into())), endpoint))
 	}
 
 	async fn getpeername(&self) -> io::Result<Option<Endpoint>> {

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,9 +1,7 @@
-use alloc::boxed::Box;
 use core::future;
 use core::mem::MaybeUninit;
 use core::task::Poll;
 
-use async_trait::async_trait;
 use smoltcp::socket::udp;
 use smoltcp::socket::udp::UdpMetadata;
 use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
@@ -77,7 +75,6 @@ impl Socket {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for Socket {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		future::poll_fn(|cx| {

--- a/src/fd/stdio.rs
+++ b/src/fd/stdio.rs
@@ -1,8 +1,6 @@
-use alloc::boxed::Box;
 use core::future;
 use core::task::Poll;
 
-use async_trait::async_trait;
 use embedded_io::{Read, ReadReady, Write};
 use uhyve_interface::parameters::WriteParams;
 use uhyve_interface::{GuestVirtAddr, Hypercall};
@@ -16,7 +14,6 @@ use crate::syscalls::interfaces::uhyve_hypercall;
 
 pub struct GenericStdin;
 
-#[async_trait]
 impl ObjectInterface for GenericStdin {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let available = if CONSOLE.lock().read_ready()? {
@@ -64,7 +61,6 @@ impl GenericStdin {
 
 pub struct GenericStdout;
 
-#[async_trait]
 impl ObjectInterface for GenericStdout {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let available = PollEvent::POLLOUT | PollEvent::POLLWRNORM | PollEvent::POLLWRBAND;
@@ -96,7 +92,6 @@ impl GenericStdout {
 
 pub struct GenericStderr;
 
-#[async_trait]
 impl ObjectInterface for GenericStderr {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let available = PollEvent::POLLOUT | PollEvent::POLLWRNORM | PollEvent::POLLWRBAND;
@@ -128,7 +123,6 @@ impl GenericStderr {
 
 pub struct UhyveStdin;
 
-#[async_trait]
 impl ObjectInterface for UhyveStdin {
 	async fn isatty(&self) -> io::Result<bool> {
 		Ok(true)
@@ -151,7 +145,6 @@ impl UhyveStdin {
 
 pub struct UhyveStdout;
 
-#[async_trait]
 impl ObjectInterface for UhyveStdout {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let available = PollEvent::POLLOUT | PollEvent::POLLWRNORM | PollEvent::POLLWRBAND;
@@ -190,7 +183,6 @@ impl UhyveStdout {
 
 pub struct UhyveStderr;
 
-#[async_trait]
 impl ObjectInterface for UhyveStderr {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let available = PollEvent::POLLOUT | PollEvent::POLLWRNORM | PollEvent::POLLWRBAND;

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -12,11 +12,10 @@ use core::{mem, ptr};
 
 use align_address::Align;
 use async_lock::{Mutex, RwLock};
-use async_trait::async_trait;
 
 use crate::errno::Errno;
 use crate::executor::block_on;
-use crate::fd::{AccessPermission, ObjectInterface, OpenOption, PollEvent};
+use crate::fd::{AccessPermission, Fd, ObjectInterface, OpenOption, PollEvent};
 use crate::fs::{DirectoryEntry, FileAttr, FileType, NodeKind, SeekWhence, VfsNode};
 use crate::syscalls::Dirent64;
 use crate::time::timespec;
@@ -44,7 +43,6 @@ pub struct RomFileInterface {
 	inner: Arc<RomFileInner>,
 }
 
-#[async_trait]
 impl ObjectInterface for RomFileInterface {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let len = self.inner.data.len();
@@ -140,7 +138,6 @@ pub struct RamFileInterface {
 	inner: Arc<RwLock<RamFileInner>>,
 }
 
-#[async_trait]
 impl ObjectInterface for RamFileInterface {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		let len = self.inner.read().await.data.len();
@@ -272,10 +269,10 @@ impl VfsNode for RomFile {
 		NodeKind::File
 	}
 
-	fn get_object(&self) -> io::Result<Arc<RwLock<dyn ObjectInterface>>> {
-		Ok(Arc::new(RwLock::new(RomFileInterface::new(
-			self.data.clone(),
-		))))
+	fn get_object(&self) -> io::Result<Arc<RwLock<Fd>>> {
+		Ok(Arc::new(RwLock::new(
+			RomFileInterface::new(self.data.clone()).into(),
+		)))
 	}
 
 	fn get_file_attributes(&self) -> io::Result<FileAttr> {
@@ -328,10 +325,10 @@ impl VfsNode for RamFile {
 		NodeKind::File
 	}
 
-	fn get_object(&self) -> io::Result<Arc<RwLock<dyn ObjectInterface>>> {
-		Ok(Arc::new(RwLock::new(RamFileInterface::new(
-			self.data.clone(),
-		))))
+	fn get_object(&self) -> io::Result<Arc<RwLock<Fd>>> {
+		Ok(Arc::new(RwLock::new(
+			RamFileInterface::new(self.data.clone()).into(),
+		)))
 	}
 
 	fn get_file_attributes(&self) -> io::Result<FileAttr> {
@@ -388,7 +385,6 @@ impl MemDirectoryInterface {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for MemDirectoryInterface {
 	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		let mut buf_offset: usize = 0;
@@ -473,7 +469,7 @@ impl MemDirectory {
 		components: &mut Vec<&str>,
 		opt: OpenOption,
 		mode: AccessPermission,
-	) -> io::Result<Arc<RwLock<dyn ObjectInterface>>> {
+	) -> io::Result<Arc<RwLock<Fd>>> {
 		let component = components.pop().ok_or(Errno::Noent)?;
 
 		if !components.is_empty() {
@@ -487,7 +483,7 @@ impl MemDirectory {
 			if opt.contains(OpenOption::O_CREAT) {
 				let file = Box::new(RamFile::new(mode));
 				inner.insert(component.to_owned(), file.clone());
-				let file = Arc::new(RwLock::new(RamFileInterface::new(file.data.clone())));
+				let file = Arc::new(RwLock::new(RamFileInterface::new(file.data.clone()).into()));
 				return Ok(file);
 			}
 
@@ -511,10 +507,10 @@ impl VfsNode for MemDirectory {
 		NodeKind::Directory
 	}
 
-	fn get_object(&self) -> io::Result<Arc<RwLock<dyn ObjectInterface>>> {
-		Ok(Arc::new(RwLock::new(MemDirectoryInterface::new(
-			self.inner.clone(),
-		))))
+	fn get_object(&self) -> io::Result<Arc<RwLock<Fd>>> {
+		Ok(Arc::new(RwLock::new(
+			MemDirectoryInterface::new(self.inner.clone()).into(),
+		)))
 	}
 
 	fn get_file_attributes(&self) -> io::Result<FileAttr> {
@@ -677,7 +673,7 @@ impl VfsNode for MemDirectory {
 		components: &mut Vec<&str>,
 		opt: OpenOption,
 		mode: AccessPermission,
-	) -> io::Result<Arc<RwLock<dyn ObjectInterface>>> {
+	) -> io::Result<Arc<RwLock<Fd>>> {
 		block_on(self.async_traverse_open(components, opt, mode), None)
 	}
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -12,7 +12,6 @@ use core::mem::MaybeUninit;
 use core::ops::BitAnd;
 use core::{fmt, slice};
 
-use async_trait::async_trait;
 use embedded_io::{Read, Write};
 use hermit_sync::{InterruptSpinMutex, OnceCell};
 use mem::MemDirectory;
@@ -20,7 +19,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::errno::Errno;
 use crate::executor::block_on;
-use crate::fd::{AccessPermission, ObjectInterface, OpenOption, insert_object, remove_object};
+use crate::fd::{AccessPermission, Fd, ObjectInterface, OpenOption, insert_object, remove_object};
 use crate::io;
 use crate::time::{SystemTime, timespec};
 
@@ -62,7 +61,7 @@ pub(crate) trait VfsNode: Send + Sync + fmt::Debug {
 	}
 
 	/// Determines the syscall interface
-	fn get_object(&self) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	fn get_object(&self) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		Err(Errno::Nosys)
 	}
 
@@ -115,7 +114,7 @@ pub(crate) trait VfsNode: Send + Sync + fmt::Debug {
 		_components: &mut Vec<&str>,
 		_option: OpenOption,
 		_mode: AccessPermission,
-	) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		Err(Errno::Nosys)
 	}
 
@@ -139,7 +138,6 @@ impl DirectoryReader {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for DirectoryReader {
 	async fn getdents(&self, _buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		let _ = &self.0; // Dummy statement to avoid warning for the moment
@@ -165,7 +163,7 @@ impl Filesystem {
 		path: &str,
 		opt: OpenOption,
 		mode: AccessPermission,
-	) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		debug!("Open file {path} with {opt:?}");
 		let mut components: Vec<&str> = path.split('/').collect();
 
@@ -208,11 +206,11 @@ impl Filesystem {
 		self.root.traverse_mkdir(&mut components, mode)
 	}
 
-	pub fn opendir(&self, path: &str) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	pub fn opendir(&self, path: &str) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		debug!("Open directory {path}");
-		Ok(Arc::new(async_lock::RwLock::new(DirectoryReader::new(
-			self.readdir(path)?,
-		))))
+		Ok(Arc::new(async_lock::RwLock::new(
+			DirectoryReader::new(self.readdir(path)?).into(),
+		)))
 	}
 
 	/// List given directory

--- a/src/fs/virtio_fs.rs
+++ b/src/fs/virtio_fs.rs
@@ -12,7 +12,6 @@ use core::{future, mem, ptr, slice};
 
 use align_address::Align;
 use async_lock::Mutex;
-use async_trait::async_trait;
 use embedded_io::{ErrorType, Read, Write};
 use fuse_abi::linux::*;
 
@@ -23,7 +22,7 @@ use crate::drivers::pci::get_filesystem_driver;
 use crate::drivers::virtio::virtqueue::error::VirtqError;
 use crate::errno::Errno;
 use crate::executor::block_on;
-use crate::fd::PollEvent;
+use crate::fd::{Fd, PollEvent};
 use crate::fs::virtio_fs::ops::SetAttrValidFields;
 use crate::fs::{
 	self, AccessPermission, DirectoryEntry, FileAttr, NodeKind, ObjectInterface, OpenOption,
@@ -909,7 +908,6 @@ impl VirtioFsFileHandle {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for VirtioFsFileHandle {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		self.0.lock().await.poll(event).await
@@ -979,7 +977,6 @@ impl VirtioFsDirectoryHandle {
 	}
 }
 
-#[async_trait]
 impl ObjectInterface for VirtioFsDirectoryHandle {
 	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
 		let path: CString = if let Some(name) = &self.name {
@@ -1145,9 +1142,9 @@ impl VfsNode for VirtioFsDirectory {
 		Ok(self.attr)
 	}
 
-	fn get_object(&self) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	fn get_object(&self) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		Ok(Arc::new(async_lock::RwLock::new(
-			VirtioFsDirectoryHandle::new(self.prefix.clone()),
+			VirtioFsDirectoryHandle::new(self.prefix.clone()).into(),
 		)))
 	}
 
@@ -1277,7 +1274,7 @@ impl VfsNode for VirtioFsDirectory {
 		components: &mut Vec<&str>,
 		opt: OpenOption,
 		mode: AccessPermission,
-	) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		let path = self.traversal_path(components);
 
 		debug!("virtio-fs open: {path:#?}, {opt:?} {mode:?}");
@@ -1303,7 +1300,7 @@ impl VfsNode for VirtioFsDirectory {
 			let mut path = path.into_string().unwrap();
 			path.remove(0);
 			return Ok(Arc::new(async_lock::RwLock::new(
-				VirtioFsDirectoryHandle::new(Some(path)),
+				VirtioFsDirectoryHandle::new(Some(path)).into(),
 			)));
 		}
 
@@ -1347,7 +1344,7 @@ impl VfsNode for VirtioFsDirectory {
 
 		drop(file_guard);
 
-		Ok(Arc::new(async_lock::RwLock::new(file)))
+		Ok(Arc::new(async_lock::RwLock::new(file.into())))
 	}
 
 	fn traverse_unlink(&self, components: &mut Vec<&str>) -> io::Result<()> {

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -27,7 +27,7 @@ use crate::arch::switch::switch_to_task;
 use crate::arch::switch::{switch_to_fpu_owner, switch_to_task};
 use crate::arch::{get_processor_count, interrupts};
 use crate::errno::Errno;
-use crate::fd::{ObjectInterface, RawFd};
+use crate::fd::{Fd, RawFd};
 use crate::kernel::scheduler::TaskStacks;
 use crate::scheduler::task::*;
 use crate::{arch, io};
@@ -211,8 +211,7 @@ struct NewTask {
 	prio: Priority,
 	core_id: CoreId,
 	stacks: TaskStacks,
-	object_map:
-		Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<dyn ObjectInterface>>, RandomState>>>,
+	object_map: Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>>>,
 }
 
 impl From<NewTask> for Task {
@@ -449,18 +448,14 @@ impl PerCoreScheduler {
 	#[inline]
 	pub fn get_current_task_object_map(
 		&self,
-	) -> Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<dyn ObjectInterface>>, RandomState>>>
-	{
+	) -> Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>>> {
 		without_interrupts(|| self.current_task.borrow().object_map.clone())
 	}
 
 	/// Map a file descriptor to their IO interface and returns
 	/// the shared reference
 	#[inline]
-	pub fn get_object(
-		&self,
-		fd: RawFd,
-	) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	pub fn get_object(&self, fd: RawFd) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		without_interrupts(|| {
 			let current_task = self.current_task.borrow();
 			let object_map = current_task.object_map.read();
@@ -473,11 +468,9 @@ impl PerCoreScheduler {
 	#[cfg(feature = "common-os")]
 	#[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
 	pub fn recreate_objmap(&self) -> io::Result<()> {
-		let mut map = HashMap::<
-			RawFd,
-			Arc<async_lock::RwLock<dyn ObjectInterface>>,
-			RandomState,
-		>::with_hasher(RandomState::with_seeds(0, 0, 0, 0));
+		let mut map = HashMap::<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>::with_hasher(
+			RandomState::with_seeds(0, 0, 0, 0),
+		);
 
 		without_interrupts(|| {
 			let mut current_task = self.current_task.borrow_mut();
@@ -499,10 +492,7 @@ impl PerCoreScheduler {
 
 	/// Insert a new IO interface and returns a file descriptor as
 	/// identifier to this object
-	pub fn insert_object(
-		&self,
-		obj: Arc<async_lock::RwLock<dyn ObjectInterface>>,
-	) -> io::Result<RawFd> {
+	pub fn insert_object(&self, obj: Arc<async_lock::RwLock<Fd>>) -> io::Result<RawFd> {
 		without_interrupts(|| {
 			let current_task = self.current_task.borrow();
 			let mut object_map = current_task.object_map.write();
@@ -577,10 +567,7 @@ impl PerCoreScheduler {
 	}
 
 	/// Remove a IO interface, which is named by the file descriptor
-	pub fn remove_object(
-		&self,
-		fd: RawFd,
-	) -> io::Result<Arc<async_lock::RwLock<dyn ObjectInterface>>> {
+	pub fn remove_object(&self, fd: RawFd) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
 		without_interrupts(|| {
 			let current_task = self.current_task.borrow();
 			let mut object_map = current_task.object_map.write();

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -22,7 +22,7 @@ use super::timer_interrupts::{Source, create_timer_abs};
 use crate::arch::core_local::*;
 use crate::arch::scheduler::TaskStacks;
 use crate::fd::stdio::*;
-use crate::fd::{ObjectInterface, RawFd, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
+use crate::fd::{Fd, RawFd, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use crate::scheduler::CoreId;
 use crate::{arch, env};
 
@@ -380,8 +380,7 @@ pub(crate) struct Task {
 	/// Stack of the task
 	pub stacks: TaskStacks,
 	/// Mapping between file descriptor and the referenced IO interface
-	pub object_map:
-		Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<dyn ObjectInterface>>, RandomState>>>,
+	pub object_map: Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>>>,
 	/// Task Thread-Local-Storage (TLS)
 	#[cfg(not(feature = "common-os"))]
 	pub tls: Option<Tls>,
@@ -402,9 +401,7 @@ impl Task {
 		task_status: TaskStatus,
 		task_prio: Priority,
 		stacks: TaskStacks,
-		object_map: Arc<
-			RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<dyn ObjectInterface>>, RandomState>>,
-		>,
+		object_map: Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>>>,
 	) -> Task {
 		debug!("Creating new task {tid} on core {core_id}");
 
@@ -430,18 +427,14 @@ impl Task {
 
 		/// All cores use the same mapping between file descriptor and the referenced object
 		static OBJECT_MAP: OnceCell<
-			Arc<
-				RwSpinLock<
-					HashMap<RawFd, Arc<async_lock::RwLock<dyn ObjectInterface>>, RandomState>,
-				>,
-			>,
+			Arc<RwSpinLock<HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>>>,
 		> = OnceCell::new();
 
 		if core_id == 0 {
 			OBJECT_MAP
 				.set(Arc::new(RwSpinLock::new(HashMap::<
 					RawFd,
-					Arc<async_lock::RwLock<dyn ObjectInterface>>,
+					Arc<async_lock::RwLock<Fd>>,
 					RandomState,
 				>::with_hasher(
 					RandomState::with_seeds(0, 0, 0, 0),
@@ -452,16 +445,16 @@ impl Task {
 			let objmap = OBJECT_MAP.get().unwrap().clone();
 			let mut guard = objmap.write();
 			if env::is_uhyve() {
-				let stdin = Arc::new(async_lock::RwLock::new(UhyveStdin::new()));
-				let stdout = Arc::new(async_lock::RwLock::new(UhyveStdout::new()));
-				let stderr = Arc::new(async_lock::RwLock::new(UhyveStderr::new()));
+				let stdin = Arc::new(async_lock::RwLock::new(UhyveStdin::new().into()));
+				let stdout = Arc::new(async_lock::RwLock::new(UhyveStdout::new().into()));
+				let stderr = Arc::new(async_lock::RwLock::new(UhyveStderr::new().into()));
 				guard.insert(STDIN_FILENO, stdin);
 				guard.insert(STDOUT_FILENO, stdout);
 				guard.insert(STDERR_FILENO, stderr);
 			} else {
-				let stdin = Arc::new(async_lock::RwLock::new(GenericStdin::new()));
-				let stdout = Arc::new(async_lock::RwLock::new(GenericStdout::new()));
-				let stderr = Arc::new(async_lock::RwLock::new(GenericStderr::new()));
+				let stdin = Arc::new(async_lock::RwLock::new(GenericStdin::new().into()));
+				let stdout = Arc::new(async_lock::RwLock::new(GenericStdout::new().into()));
+				let stderr = Arc::new(async_lock::RwLock::new(GenericStderr::new().into()));
 				guard.insert(STDIN_FILENO, stdin);
 				guard.insert(STDOUT_FILENO, stdout);
 				guard.insert(STDERR_FILENO, stderr);

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -25,8 +25,8 @@ use crate::env;
 use crate::errno::{Errno, ToErrno};
 use crate::executor::block_on;
 use crate::fd::{
-	self, AccessOption, AccessPermission, EventFlags, OpenOption, PollFd, RawFd, dup_object,
-	dup_object2, get_object, isatty, remove_object,
+	self, AccessOption, AccessPermission, EventFlags, ObjectInterface, OpenOption, PollFd, RawFd,
+	dup_object, dup_object2, get_object, isatty, remove_object,
 };
 use crate::fs::{self, FileAttr, SeekWhence};
 #[cfg(all(target_os = "none", not(feature = "common-os")))]

--- a/src/syscalls/socket/mod.rs
+++ b/src/syscalls/socket/mod.rs
@@ -618,7 +618,7 @@ pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 			block_on(socket.set_status_flags(fd::StatusFlags::O_NONBLOCK), None).unwrap();
 		}
 
-		let socket = Arc::new(async_lock::RwLock::new(socket));
+		let socket = Arc::new(async_lock::RwLock::new(socket.into()));
 		let fd = insert_object(socket).expect("FD is already used");
 
 		return fd;
@@ -643,7 +643,7 @@ pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 				block_on(socket.set_status_flags(fd::StatusFlags::O_NONBLOCK), None).unwrap();
 			}
 
-			let socket = Arc::new(async_lock::RwLock::new(socket));
+			let socket = Arc::new(async_lock::RwLock::new(socket.into()));
 			let fd = insert_object(socket).expect("FD is already used");
 
 			return fd;
@@ -659,7 +659,7 @@ pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
 				block_on(socket.set_status_flags(fd::StatusFlags::O_NONBLOCK), None).unwrap();
 			}
 
-			let socket = Arc::new(async_lock::RwLock::new(socket));
+			let socket = Arc::new(async_lock::RwLock::new(socket.into()));
 			let fd = insert_object(socket).expect("FD is already used");
 
 			return fd;


### PR DESCRIPTION
We currently define `ObjectInterface::read` and `ObjectInterface::write` ourselves:

https://github.com/hermit-os/kernel/blob/4712cd2b0d2502ffcc94f241b61d0afce92c70b0/src/fd/mod.rs#L205-L215

It would be useful to migrate to [`embedded_io_async::Read`](https://docs.rs/embedded-io-async/latest/embedded_io_async/trait.Read.html) and [`embedded_io_async::Write`](https://docs.rs/embedded-io-async/latest/embedded_io_async/trait.Write.html) instead: `ObjectInterface: Read + Write`.

https://github.com/hermit-os/kernel/pull/1891 has already migrated non-`async` I/O to `embedded-io`.

https://github.com/hermit-os/kernel/pull/1900 has prepared migrating to `ObjectInterface` to `Read` and `Write` traits by moving socket-internal synchronization to the outside.
This was required since `Read` and `Write` take `self` mutably, while our methods take `self` sharedly.
Additionally, moving the synchronization to the outside allowed us to get rid of a lot of boilerplate code and enabled performing multiple operations while avoiding frequent relocking.

This PR further prepares migrating `ObjectInterface` to `Read` and `Write`.
This is done by replacing `dyn ObjectInterface` via [`async-trait`](https://docs.rs/async-trait) with an `enum Fd`, enumerating all possible file descriptors.

Continuing to use `dyn ObjectInterface` would require the respective macros ([`dynosaur`](https://docs.rs/dynosaur) or [`async-trait`](https://docs.rs/async-trait)) to also be applied to the respective traits, since dyn async traits in Rust are not there yet ([Dyn Async Traits · baby steps](https://smallcultfollowing.com/babysteps/series/dyn-async-traits/), [In-place initialization - Rust Project Goals](https://rust-lang.github.io/rust-project-goals/2025h2/in-place-initialization.html)).
I am not sure if `embedded-io-async` would be open to this optional additional dependency.
This would also require us to do the same thing with every new async trait that we would want to depend on in the future.

Using [`enum_dispatch`](https://docs.rs/enum_dispatch) or [`static-dispatch`](https://docs.rs/static-dispatch) to avoid writing macros ourselves for forwarding is also not possible, because the respective trait needs to be registered with the macro too.

While using [`enum_delegate`](https://docs.rs/enum_delegate) would be possible, I chose [`delegate`](https://docs.rs/delegate) to implement this.

I did a rough benchmark of this with AArch64 on AArch64 with TCG:

```rust
use std::fs::File;
use std::io::{Read, Write};
use std::time::Instant;

#[cfg(target_os = "hermit")]
use hermit as _;

const BUF_SIZE: usize = 8 * 1024;

fn main() {
	let mut file = File::create("/tmp/hello.txt").unwrap();
	let mut buf = vec![0; BUF_SIZE];

	let now = Instant::now();
	for _ in 0..100_000 {
		file.write(b"Hello, world!\n").unwrap();
		file.read(&mut buf).unwrap();
	}
	println!("{:?}", now.elapsed());
}
```

- Before this PR: 750ms
- After this PR: 635ms