### PR TITLE
MSI-X support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ net = []
 ## Enables the virtio driver backend.
 ##
 ## This is automatically enabled by any virtio driver.
-virtio = ["dep:virtio", "dep:mem-barrier"]
+virtio = ["dep:virtio", "dep:mem-barrier", "volatile/derive"]
 
 ## Enables a warning that this libhermit.a was prebuilt.
 warn-prebuilt = []

--- a/src/drivers/console/mmio.rs
+++ b/src/drivers/console/mmio.rs
@@ -4,6 +4,7 @@ use volatile::VolatileRef;
 
 use crate::drivers::console::{ConsoleDevCfg, RxQueue, TxQueue, VirtioConsoleDriver};
 use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::InterruptCapability;
 use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
 use crate::drivers::{InterruptHandlerMap, InterruptLine};
 
@@ -28,7 +29,7 @@ impl VirtioConsoleDriver {
 			dev_id,
 			features: virtio::console::F::empty(),
 		};
-		let isr_stat = IsrStatus::new(registers.borrow_mut());
+		let isr_stat = InterruptCapability::IsrStatus(IsrStatus::new(registers.borrow_mut()));
 		let notif_cfg = NotifCfg::new(registers.borrow_mut());
 
 		Ok(VirtioConsoleDriver {

--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -32,10 +32,11 @@ use crate::drivers::mmio::get_console_driver;
 use crate::drivers::pci::get_console_driver;
 use crate::drivers::virtio::ControlRegisters;
 use crate::drivers::virtio::error::VirtioConsoleError;
+use crate::drivers::virtio::transport::InterruptCapability;
 #[cfg(not(feature = "pci"))]
-use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::mmio::{ComCfg, NotifCfg};
 #[cfg(feature = "pci")]
-use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::pci::{ComCfg, NotifCfg};
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::drivers::virtio::virtqueue::{
 	AvailBufferToken, BufferElem, BufferType, UsedBufferToken, VirtQueue, Virtq,
@@ -260,7 +261,7 @@ pub(crate) struct ConsoleDevCfg {
 pub(crate) struct VirtioConsoleDriver {
 	pub(super) dev_cfg: ConsoleDevCfg,
 	pub(super) com_cfg: ComCfg,
-	pub(super) isr_stat: IsrStatus,
+	pub(super) isr_stat: InterruptCapability,
 	pub(super) notif_cfg: NotifCfg,
 
 	pub(super) recv_vq: RxQueue,
@@ -280,17 +281,35 @@ impl VirtioConsoleDriver {
 
 	/// Handle interrupt and acknowledge interrupt
 	pub fn handle_interrupt(&mut self) {
-		let status = self.isr_stat.acknowledge();
+		#[cfg_attr(
+			not(all(feature = "pci", target_arch = "x86_64")),
+			expect(irrefutable_let_patterns)
+		)]
+		let InterruptCapability::IsrStatus(ref mut isr_stat) = self.isr_stat else {
+			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
+		};
+
+		let status = isr_stat.acknowledge();
 
 		let config_change = cfg_select! {
 			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
-			todo!("Device configuration change notification cannot be handled yet");
+		if status.contains(config_change) {
+			self.handle_device_configuration_interrupt();
 		}
 
+		Self::handle_queue_interrupt();
+	}
+
+	fn handle_device_configuration_interrupt(&self) {
+		if self.com_cfg.does_device_need_reset() {
+			todo!("Device configuration change notification cannot be handled yet");
+		}
+	}
+
+	fn handle_queue_interrupt() {
 		crate::console::CONSOLE_WAKER.lock().wake();
 	}
 
@@ -368,11 +387,30 @@ impl VirtioConsoleDriver {
 		// Interrupt for communicating that a sent packet left, is not needed
 		self.send_vq.disable_notifs();
 
-		handlers.entry(irq.unwrap()).or_default().push_back(|| {
-			if let Some(driver) = get_console_driver() {
-				driver.lock().handle_interrupt();
-			};
-		});
+		match &mut self.isr_stat {
+			InterruptCapability::IsrStatus(_) => {
+				let irq = irq.unwrap();
+				handlers.entry(irq).or_default().push_back(|| {
+					if let Some(driver) = get_console_driver() {
+						driver.lock().handle_interrupt();
+					};
+				});
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
+				info!("Virtio interrupt handler at line {irq}");
+			}
+			#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+			InterruptCapability::Msix(msix_table) => self.com_cfg.register_msix_vectors(
+				msix_table,
+				handlers,
+				|| {
+					if let Some(driver) = get_console_driver() {
+						driver.lock().handle_device_configuration_interrupt();
+					};
+				},
+				[(0..2u16, Self::handle_queue_interrupt as fn())].into_iter(),
+				[],
+			),
+		}
 
 		// At this point the device is "live"
 		self.com_cfg.drv_ok();

--- a/src/drivers/fs/mmio.rs
+++ b/src/drivers/fs/mmio.rs
@@ -6,6 +6,7 @@ use volatile::VolatileRef;
 
 use crate::drivers::fs::{FsDevCfg, VirtioFsDriver};
 use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::InterruptCapability;
 use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
 use crate::drivers::{InterruptHandlerMap, InterruptLine};
 
@@ -30,7 +31,7 @@ impl VirtioFsDriver {
 			dev_id,
 			features: virtio::fs::F::empty(),
 		};
-		let isr_stat = IsrStatus::new(registers.borrow_mut());
+		let isr_stat = InterruptCapability::IsrStatus(IsrStatus::new(registers.borrow_mut()));
 		let notif_cfg = NotifCfg::new(registers.borrow_mut());
 
 		Ok(VirtioFsDriver {

--- a/src/drivers/fs/mod.rs
+++ b/src/drivers/fs/mod.rs
@@ -36,10 +36,11 @@ use crate::drivers::mmio::get_filesystem_driver;
 use crate::drivers::pci::get_filesystem_driver;
 use crate::drivers::virtio::ControlRegisters;
 use crate::drivers::virtio::error::VirtioFsInitError;
+use crate::drivers::virtio::transport::InterruptCapability;
 #[cfg(not(feature = "pci"))]
-use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::mmio::{ComCfg, NotifCfg};
 #[cfg(feature = "pci")]
-use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::pci::{ComCfg, NotifCfg};
 use crate::drivers::virtio::virtqueue::error::VirtqError;
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::drivers::virtio::virtqueue::{
@@ -67,7 +68,7 @@ pub(crate) struct FsDevCfg {
 pub(crate) struct VirtioFsDriver {
 	pub(super) dev_cfg: FsDevCfg,
 	pub(super) com_cfg: ComCfg,
-	pub(super) isr_stat: IsrStatus,
+	pub(super) isr_stat: InterruptCapability,
 	pub(super) notif_cfg: NotifCfg,
 	pub(super) vqueues: Vec<VirtQueue>,
 }
@@ -159,11 +160,34 @@ impl VirtioFsDriver {
 			self.vqueues.push(vq);
 		}
 
-		handlers.entry(irq.unwrap()).or_default().push_back(|| {
-			if let Some(driver) = get_filesystem_driver() {
-				driver.lock().handle_interrupt();
-			};
-		});
+		match &mut self.isr_stat {
+			InterruptCapability::IsrStatus(_) => {
+				let irq = irq.unwrap();
+				handlers.entry(irq).or_default().push_back(|| {
+					if let Some(driver) = get_filesystem_driver() {
+						driver.lock().handle_interrupt();
+					};
+				});
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
+				info!("Virtio interrupt handler at line {irq}");
+			}
+			#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+			InterruptCapability::Msix(msix_table) => {
+				use core::iter;
+
+				self.com_cfg.register_msix_vectors(
+					msix_table,
+					handlers,
+					|| {
+						if let Some(driver) = get_filesystem_driver() {
+							driver.lock().handle_device_configuration_interrupt();
+						};
+					},
+					iter::empty::<(iter::Empty<_>, _)>(),
+					0..vqnum as u16,
+				);
+			}
+		}
 
 		// At this point the device is "live"
 		self.com_cfg.drv_ok();
@@ -172,14 +196,27 @@ impl VirtioFsDriver {
 	}
 
 	pub fn handle_interrupt(&mut self) {
-		let status = self.isr_stat.acknowledge();
+		#[cfg_attr(
+			not(all(feature = "pci", target_arch = "x86_64")),
+			expect(irrefutable_let_patterns)
+		)]
+		let InterruptCapability::IsrStatus(ref mut isr_stat) = self.isr_stat else {
+			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
+		};
+
+		let status = isr_stat.acknowledge();
 
 		let config_change = cfg_select! {
 			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
+		if status.contains(config_change) {
+			self.handle_device_configuration_interrupt();
+		}
+	}
 
-		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
+	fn handle_device_configuration_interrupt(&mut self) {
+		if self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}

--- a/src/drivers/net/virtio/mmio.rs
+++ b/src/drivers/net/virtio/mmio.rs
@@ -4,6 +4,7 @@ use volatile::VolatileRef;
 
 use crate::drivers::net::virtio::{Init, NetDevCfg, Uninit, VirtioNetDriver};
 use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::InterruptCapability;
 use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
 use crate::drivers::{InterruptHandlerMap, InterruptLine};
 
@@ -28,7 +29,7 @@ impl VirtioNetDriver<Uninit> {
 			dev_id,
 			features: virtio::net::F::empty(),
 		};
-		let isr_stat = IsrStatus::new(registers.borrow_mut());
+		let isr_stat = InterruptCapability::IsrStatus(IsrStatus::new(registers.borrow_mut()));
 		let notif_cfg = NotifCfg::new(registers.borrow_mut());
 
 		Ok(VirtioNetDriver {

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -37,10 +37,11 @@ use crate::config::VIRTIO_MAX_QUEUE_SIZE;
 use crate::drivers::net::virtio::constants::BUFF_PER_PACKET;
 use crate::drivers::net::{NetworkDriver, mtu};
 use crate::drivers::virtio::ControlRegisters;
+use crate::drivers::virtio::transport::InterruptCapability;
 #[cfg(not(feature = "pci"))]
-use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::mmio::{ComCfg, NotifCfg};
 #[cfg(feature = "pci")]
-use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::pci::{ComCfg, NotifCfg};
 use crate::drivers::virtio::virtqueue::packed::PackedVq;
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::drivers::virtio::virtqueue::{
@@ -242,7 +243,7 @@ pub(crate) struct Init {
 pub(crate) struct VirtioNetDriver<T = Init> {
 	pub(super) dev_cfg: NetDevCfg,
 	pub(super) com_cfg: ComCfg,
-	pub(super) isr_stat: IsrStatus,
+	pub(super) isr_stat: InterruptCapability,
 	pub(super) notif_cfg: NotifCfg,
 
 	pub(super) inner: T,
@@ -519,15 +520,22 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 	}
 
 	fn handle_interrupt(&mut self) {
-		let status = self.isr_stat.acknowledge();
+		#[cfg_attr(
+			not(all(feature = "pci", target_arch = "x86_64")),
+			expect(irrefutable_let_patterns)
+		)]
+		let InterruptCapability::IsrStatus(ref mut isr_stat) = self.isr_stat else {
+			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
+		};
+
+		let status = isr_stat.acknowledge();
 
 		let config_change = cfg_select! {
 			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
-
-		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
-			todo!("Device configuration change notification cannot be handled yet");
+		if status.contains(config_change) {
+			self.handle_device_configuration_interrupt();
 		}
 
 		wake_network_waker();
@@ -740,6 +748,12 @@ impl VirtioNetDriver<Init> {
 		// We need to poll to get the queue to remove elements from the table and open up capacity if possible.
 		self.inner.send_capacity += self.inner.send_vqs.poll() * u32::from(BUFF_PER_PACKET);
 	}
+
+	pub(crate) fn handle_device_configuration_interrupt(&self) {
+		if self.com_cfg.does_device_need_reset() {
+			todo!("Device configuration change notification cannot be handled yet");
+		}
+	}
 }
 
 impl VirtioNetDriver<Uninit> {
@@ -835,10 +849,34 @@ impl VirtioNetDriver<Uninit> {
 			self.dev_cfg.dev_id
 		);
 
-		handlers
-			.entry(irq.unwrap())
-			.or_default()
-			.push_back(crate::executor::network::network_handler);
+		match &mut self.isr_stat {
+			InterruptCapability::IsrStatus(_) => {
+				let irq = irq.unwrap();
+				handlers
+					.entry(irq)
+					.or_default()
+					.push_back(crate::executor::network::network_handler);
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
+				info!("Virtio interrupt handler at line {irq}");
+			}
+			#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+			InterruptCapability::Msix(msix_table) => {
+				let recv_vqs = (0..self.num_vqs).step_by(2);
+				let send_vqs = (1..self.num_vqs).step_by(2);
+				let ctrl_vq = self
+					.dev_cfg
+					.features
+					.contains(virtio::net::F::CTRL_VQ)
+					.then_some(self.num_vqs);
+				self.com_cfg.register_msix_vectors(
+					msix_table,
+					handlers,
+					crate::executor::network::network_device_configuration_handler,
+					[(recv_vqs, wake_network_waker as fn())].into_iter(),
+					send_vqs.chain(ctrl_vq),
+				);
+			}
+		}
 
 		// At this point the device is "live"
 		self.com_cfg.drv_ok();

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -463,6 +463,70 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 	});
 }
 
+#[cfg(feature = "virtio")]
+pub(crate) mod msix {
+	// Intel 64 and IA-32 Architectures Software Developer’s Manual volume 2 section 12.11.2.1.
+	pub const VECTOR_MAX: u8 = 0xfe;
+
+	/// MSI-X Table entry.
+	#[repr(C)]
+	#[derive(volatile::VolatileFieldAccess)]
+	pub struct TableEntry {
+		/// Message Address
+		pub(crate) message_address: u32,
+
+		/// Message Upper Address
+		pub(crate) message_upper_address: u32,
+
+		/// Message Data
+		pub(crate) message_data: u32,
+
+		/// Vector Control
+		pub(crate) vector_control: u32,
+	}
+
+	pub trait MsixTableVolatileElementAccess {
+		fn configure(&mut self, index: u16, vector: u8);
+	}
+
+	#[cfg(target_arch = "x86_64")]
+	impl MsixTableVolatileElementAccess for volatile::VolatileRef<'_, [TableEntry]> {
+		/// Configures the [TableEntry] at the given index of the MSI-X table to trigger the vector provided.
+		///
+		/// Note that unlike the IRQ numbering scheme, the first user defined vector is 32, not 0. More advanced
+		/// interrupt configurations such as destination ID, redirection hint indication, etc. (see Intel 64 and IA-32
+		/// Architectures Software Developer’s Manual volume 3 section 12.11.2 for more details) are not modified.
+		fn configure(&mut self, index: u16, vector: u8) {
+			use bit_field::BitField;
+
+			// Intel 64 and IA-32 Architectures Software Developer’s Manual volume 3 section 12.11.2.1.
+			core::assert_matches!(vector, 0x10..=VECTOR_MAX);
+
+			let msix_entry = unsafe {
+				self.as_mut_ptr()
+					.map(|table| table.cast().offset(index.try_into().unwrap()))
+			};
+
+			// Mask the entry because "[s]oftware must not modify the Address, Data, or Steering Tag fields
+			// of an entry while it is unmasked." (PCIe spec. 6.1.4.2)
+			msix_entry
+				.vector_control()
+				.update(|mut control| *control.set_bit(0, true));
+
+			// Format described in Intel 64 and IA-32 Architectures Software Developer’s Manual volume 3 section 12.11.2.
+			msix_entry
+				.message_address()
+				.update(|mut addr_low| *addr_low.set_bits(20..32, 0xfee));
+			msix_entry
+				.message_data()
+				.update(|mut data| *data.set_bits(0..8, u32::from(vector)));
+			msix_entry
+				.vector_control()
+				.update(|mut control| *control.set_bit(0, false));
+		}
+	}
+}
+
 /// A module containing PCI specific errors
 ///
 /// Errors include...

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -352,10 +352,6 @@ pub(crate) fn init_device(
 		virtio::Id::Console => match VirtioConsoleDriver::init(dev_id, registers, irq_no, handlers) {
 			Ok(virt_console_drv) => {
 				info!("Virtio console driver initialized.");
-
-				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {irq_no}");
-
 				Ok(VirtioDriver::Console(alloc::boxed::Box::new(
 					virt_console_drv,
 				)))
@@ -372,7 +368,6 @@ pub(crate) fn init_device(
 			match VirtioFsDriver::init(dev_id, registers, irq_no, handlers) {
 				Ok(virt_fs_drv) => {
 					info!("Virtio filesystem driver initialized.");
-					crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
 					Ok(VirtioDriver::Fs(alloc::boxed::Box::new(virt_fs_drv)))
 				}
 				Err(virtio_error) => {
@@ -385,10 +380,6 @@ pub(crate) fn init_device(
 		virtio::Id::Net => match VirtioNetDriver::init(dev_id, registers, irq_no, handlers) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");
-
-				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {irq_no}");
-
 				Ok(VirtioDriver::Net(alloc::boxed::Box::new(virt_net_drv)))
 			}
 			Err(virtio_error) => {
@@ -400,10 +391,6 @@ pub(crate) fn init_device(
 		virtio::Id::Vsock => match VirtioVsockDriver::init(dev_id, registers, irq_no, handlers) {
 			Ok(virt_vsock_drv) => {
 				info!("Virtio sock driver initialized.");
-
-				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
-				info!("Virtio interrupt handler at line {irq_no}");
-
 				Ok(VirtioDriver::Vsock(alloc::boxed::Box::new(virt_vsock_drv)))
 			}
 			Err(virtio_error) => {

--- a/src/drivers/virtio/transport/mod.rs
+++ b/src/drivers/virtio/transport/mod.rs
@@ -1,4 +1,15 @@
 #[cfg(not(feature = "pci"))]
+use mmio::IsrStatus;
+#[cfg(feature = "pci")]
+use pci::IsrStatus;
+
+#[cfg(not(feature = "pci"))]
 pub mod mmio;
 #[cfg(feature = "pci")]
 pub mod pci;
+
+pub(crate) enum InterruptCapability {
+	IsrStatus(IsrStatus),
+	#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+	Msix(volatile::VolatileRef<'static, [crate::drivers::pci::msix::TableEntry]>),
+}

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -33,7 +33,12 @@ use crate::drivers::fs::VirtioFsDriver;
 use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::error::PciError;
+#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+use crate::drivers::pci::msix;
+#[cfg(target_arch = "x86_64")]
+use crate::drivers::pci::msix::MsixTableVolatileElementAccess;
 use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::InterruptCapability;
 use crate::drivers::virtio::transport::pci::PciBar as VirtioPciBar;
 use crate::drivers::virtio::{ControlRegisters, VirtioIdExt};
 #[cfg(feature = "virtio-vsock")]
@@ -179,7 +184,7 @@ impl PciCap {
 pub struct UniCapsColl {
 	pub(crate) com_cfg: ComCfg,
 	pub(crate) notif_cfg: NotifCfg,
-	pub(crate) isr_cfg: IsrStatus,
+	pub(crate) isr_cfg: InterruptCapability,
 	pub(crate) dev_cfg_list: Vec<PciCap>,
 }
 /// Wraps a [`CommonCfg`] in order to preserve
@@ -204,6 +209,9 @@ pub struct VqCfgHandler<'a> {
 	vq_index: u16,
 	raw: VolatileRef<'a, CommonCfg>,
 }
+
+#[cfg_attr(not(target_arch = "x86_64"), expect(unused))]
+pub(crate) const NO_VECTOR: u16 = 0xffff;
 
 impl VqCfgHandler<'_> {
 	// TODO: Create type for queue selected invariant to get rid of `self.select_queue()` everywhere.
@@ -254,6 +262,21 @@ impl VqCfgHandler<'_> {
 			.as_mut_ptr()
 			.queue_device()
 			.write(addr.as_u64().into());
+	}
+
+	#[cfg(target_arch = "x86_64")]
+	fn set_queue_msix_vector(&mut self, index: u16) -> Result<(), ()> {
+		self.select_queue();
+		let queue_msix_vector = self.raw.as_mut_ptr().queue_msix_vector();
+		queue_msix_vector.write(index.into());
+		let index_read = u16::from(queue_msix_vector.read());
+		if index_read == index {
+			Ok(())
+		} else if index_read == NO_VECTOR {
+			Err(())
+		} else {
+			unreachable!()
+		}
 	}
 
 	pub fn notif_off(&mut self) -> u16 {
@@ -366,6 +389,76 @@ impl ComCfg {
 	pub fn does_device_need_reset(&self) -> bool {
 		let status = self.com_cfg.as_ptr().device_status().read();
 		status.contains(DeviceStatus::DEVICE_NEEDS_RESET)
+	}
+}
+
+#[cfg(target_arch = "x86_64")]
+impl ComCfg {
+	fn set_config_msix_vector(&mut self, index: u16) -> Result<(), ()> {
+		let config_msix_vector = self.com_cfg.as_mut_ptr().config_msix_vector();
+		config_msix_vector.write(index.into());
+		let index_read = u16::from(config_msix_vector.read());
+		if index_read == index {
+			Ok(())
+		} else if index_read == NO_VECTOR {
+			Err(())
+		} else {
+			unreachable!()
+		}
+	}
+
+	pub(crate) fn register_msix_vectors(
+		&mut self,
+		msix_table: &mut VolatileRef<'_, [msix::TableEntry]>,
+		handlers: &mut InterruptHandlerMap,
+		config_handler: fn(),
+		queue_handlers: impl ExactSizeIterator<Item = (impl IntoIterator<Item = u16>, fn())>,
+		handlerless_queues: impl IntoIterator<Item = u16>,
+	) {
+		// One for the device config irq.
+		let needed_irqs = 1 + queue_handlers.len();
+		// We will need to map the IRQ number to the vector number by adding 32.
+		const IRQ_RANGE: core::ops::RangeInclusive<u8> = 0..=(msix::VECTOR_MAX - 32);
+		let mut free_irqs = IRQ_RANGE
+			.filter(|v| !handlers.contains_key(v))
+			// If we do not have enough free IRQs, fall back to using any
+			// IRQ in the valid range.
+			.chain(IRQ_RANGE)
+			.take(needed_irqs)
+			.collect::<Vec<_>>()
+			.into_iter();
+
+		const TABLE_CONFIG_INDEX: u16 = 0;
+		let config_irq = free_irqs.next().unwrap();
+		handlers
+			.entry(config_irq)
+			.or_default()
+			.push_back(config_handler);
+		msix_table.configure(TABLE_CONFIG_INDEX, config_irq + 32);
+		self.set_config_msix_vector(TABLE_CONFIG_INDEX).unwrap();
+		crate::arch::kernel::interrupts::add_irq_name(config_irq, "virtio config");
+		info!("Virtio config interrupt handler at line {config_irq}");
+
+		for (((queues, handler), irq), table_queue_index) in queue_handlers.zip(free_irqs).zip(1..)
+		{
+			handlers.entry(irq).or_default().push_back(handler);
+			msix_table.configure(table_queue_index, irq + 32);
+			for i in queues {
+				self.select_vq(i)
+					.unwrap()
+					.set_queue_msix_vector(table_queue_index)
+					.unwrap();
+			}
+			crate::arch::kernel::interrupts::add_irq_name(irq, "virtio queue");
+			info!("Virtio queue interrupt handler at line {irq}");
+		}
+
+		for i in handlerless_queues {
+			self.select_vq(i)
+				.unwrap()
+				.set_queue_msix_vector(NO_VECTOR)
+				.unwrap();
+		}
 	}
 }
 
@@ -516,43 +609,6 @@ impl PciBar {
 	}
 }
 
-/// Reads all PCI capabilities, starting at the capabilities list pointer from the
-/// PCI device.
-///
-/// Returns ONLY Virtio specific capabilities, which allow to locate the actual capability
-/// structures inside the memory areas, indicated by the BaseAddressRegisters (BAR's).
-fn read_caps(device: &PciDevice<PciConfigRegion>) -> Result<Vec<PciCap>, PciError> {
-	let device_id = device.device_id();
-
-	let capabilities = device
-		.capabilities()
-		.unwrap()
-		.filter_map(|capability| match capability {
-			PciCapability::Vendor(capability) => Some(capability),
-			_ => None,
-		})
-		.map(|addr| CapData::read(addr, device.access()).unwrap())
-		.filter(|cap| cap.cfg_type != CapCfgType::Pci)
-		.flat_map(|cap| {
-			let slot = cap.bar;
-			device
-				.memory_map_bar(slot, true)
-				.map(|(addr, size)| PciCap {
-					bar: VirtioPciBar::new(slot, addr.as_u64(), size.try_into().unwrap()),
-					dev_id: device_id,
-					cap,
-				})
-		})
-		.collect::<Vec<_>>();
-
-	if capabilities.is_empty() {
-		error!("No virtio capability found for device {device_id:x}");
-		return Err(PciError::NoVirtioCaps(device_id));
-	}
-
-	Ok(capabilities)
-}
-
 pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsColl, VirtioError> {
 	let device_id = device.device_id();
 
@@ -562,61 +618,119 @@ pub(crate) fn map_caps(device: &PciDevice<PciConfigRegion>) -> Result<UniCapsCol
 		return Err(VirtioError::FromPci(PciError::NoCapPtr(device_id)));
 	}
 
-	// Get list of PciCaps pointing to capabilities
-	let cap_list = match read_caps(device) {
-		Ok(list) => list,
-		Err(pci_error) => return Err(VirtioError::FromPci(pci_error)),
-	};
-
 	let mut com_cfg = None;
 	let mut notif_cfg = None;
 	let mut isr_cfg = None;
 	let mut dev_cfg_list = Vec::new();
-	// Map Caps in virtual memory
-	for pci_cap in cap_list {
-		match pci_cap.cap.cfg_type {
-			CapCfgType::Common => {
-				if com_cfg.is_none() {
-					match pci_cap.map_common_cfg() {
-						Some(cap) => com_cfg = Some(ComCfg::new(cap)),
-						None => error!(
-							"Common config capability of device {device_id:x} could not be mapped!"
-						),
-					}
-				}
-			}
-			CapCfgType::Notify => {
-				if notif_cfg.is_none() {
-					match NotifCfg::new(&pci_cap) {
-						Some(notif) => notif_cfg = Some(notif),
-						None => error!(
-							"Notification config capability of device {device_id:x} could not be used!"
-						),
-					}
-				}
-			}
-			CapCfgType::Isr => {
-				if isr_cfg.is_none() {
-					match pci_cap.map_isr_status() {
-						Some(isr_stat) => isr_cfg = Some(IsrStatus::new(isr_stat)),
-						None => error!(
-							"ISR status config capability of device {device_id:x} could not be used!"
-						),
-					}
-				}
-			}
-			CapCfgType::SharedMemory => {
-				let cap_id = pci_cap.cap.id;
-				error!(
-					"Shared Memory config capability with id {cap_id} of device {device_id:x} could not be used!"
-				);
-			}
-			CapCfgType::Device => dev_cfg_list.push(pci_cap),
+	#[cfg(target_arch = "x86_64")]
+	let mut msix_table = None;
 
-			// PCI's configuration space is allowed to hold other structures, which are not virtio specific and are therefore ignored
+	// Reads all PCI capabilities, starting at the capabilities list pointer from the
+	// PCI device.
+	//
+	// Maps ONLY Virtio specific capabilities and the MSI-X capability , which allow to locate the actual capability
+	// structures inside the memory areas, indicated by the BaseAddressRegisters (BAR's).
+	for capability in device.capabilities().unwrap() {
+		match capability {
+			PciCapability::Vendor(addr) => {
+				let cap = CapData::read(addr, device.access()).unwrap();
+				if cap.cfg_type == CapCfgType::Pci {
+					continue;
+				}
+				let slot = cap.bar;
+				let Some((addr, size)) = device.memory_map_bar(slot, true) else {
+					continue;
+				};
+				let pci_cap = PciCap {
+					bar: VirtioPciBar::new(slot, addr.as_u64(), size.try_into().unwrap()),
+					dev_id: device_id,
+					cap,
+				};
+				match pci_cap.cap.cfg_type {
+					CapCfgType::Common => {
+						if com_cfg.is_none() {
+							match pci_cap.map_common_cfg() {
+								Some(cap) => com_cfg = Some(ComCfg::new(cap)),
+								None => error!(
+									"Common config capability of device {device_id:x} could not be mapped!"
+								),
+							}
+						}
+					}
+					CapCfgType::Notify => {
+						if notif_cfg.is_none() {
+							match NotifCfg::new(&pci_cap) {
+								Some(notif) => notif_cfg = Some(notif),
+								None => error!(
+									"Notification config capability of device {device_id:x} could not be used!"
+								),
+							}
+						}
+					}
+					CapCfgType::Isr => {
+						let cond = isr_cfg.is_none();
+						// We prefer MSI-X over ISR Status.
+						#[cfg(target_arch = "x86_64")]
+						let cond = cond && msix_table.is_none();
+						if cond {
+							match pci_cap.map_isr_status() {
+								Some(isr_stat) => isr_cfg = Some(IsrStatus::new(isr_stat)),
+								None => error!(
+									"ISR status config capability of device {device_id:x} could not be used!"
+								),
+							}
+						}
+					}
+					CapCfgType::SharedMemory => {
+						let cap_id = pci_cap.cap.id;
+						error!(
+							"Shared Memory config capability with id {cap_id} of device {device_id:x} could not be used!"
+						);
+					}
+					CapCfgType::Device => dev_cfg_list.push(pci_cap),
+					_ => continue,
+				}
+			}
+			// We can currently only make use of MSI-X on x86_64.
+			#[cfg(target_arch = "x86_64")]
+			PciCapability::MsiX(mut msix_capability) => {
+				msix_capability.set_enabled(true, device.access());
+				let (base_addr, _) = device
+					.memory_map_bar(msix_capability.table_bar(), true)
+					.unwrap();
+				let table_ptr = NonNull::slice_from_raw_parts(
+					NonNull::with_exposed_provenance(
+						core::num::NonZero::new(
+							base_addr.as_usize()
+								+ usize::try_from(msix_capability.table_offset()).unwrap(),
+						)
+						.unwrap(),
+					),
+					msix_capability.table_size().into(),
+				);
+				msix_table = Some(unsafe { VolatileRef::new(table_ptr) });
+			}
+			// PCI's configuration space is allowed to hold other structures, which are not useful for us and are therefore ignored
 			// in the following
 			_ => continue,
 		}
+	}
+
+	let isr_cfg = cfg_select! {
+		target_arch = "x86_64" => msix_table.map(InterruptCapability::Msix),
+		_ => None,
+	}
+	.or(isr_cfg.map(InterruptCapability::IsrStatus));
+
+	match isr_cfg {
+		Some(InterruptCapability::IsrStatus(_)) => {
+			info!("The device will use legacy interrupts.");
+		}
+		#[cfg(target_arch = "x86_64")]
+		Some(InterruptCapability::Msix(_)) => {
+			info!("Found MSI-X capability. The device will use message signaled interrupts.");
+		}
+		_ => (),
 	}
 
 	Ok(UniCapsColl {
@@ -667,11 +781,6 @@ pub(crate) fn init_device(
 		virtio::Id::Console => match VirtioConsoleDriver::init(device, handlers) {
 			Ok(virt_console_drv) => {
 				info!("Virtio console driver initialized.");
-
-				let irq = device.get_irq().unwrap();
-				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
-
 				Ok(VirtioDriver::Console(alloc::boxed::Box::new(
 					virt_console_drv,
 				)))
@@ -688,8 +797,6 @@ pub(crate) fn init_device(
 			match VirtioFsDriver::init(device, handlers) {
 				Ok(virt_fs_drv) => {
 					info!("Virtio filesystem driver initialized.");
-					let irq = device.get_irq().unwrap();
-					crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 					Ok(VirtioDriver::Fs(alloc::boxed::Box::new(virt_fs_drv)))
 				}
 				Err(virtio_error) => {
@@ -708,11 +815,6 @@ pub(crate) fn init_device(
 		virtio::Id::Net => match VirtioNetDriver::init(device, handlers) {
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");
-
-				let irq = device.get_irq().unwrap();
-				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
-
 				Ok(VirtioDriver::Net(alloc::boxed::Box::new(virt_net_drv)))
 			}
 			Err(virtio_error) => {
@@ -726,11 +828,6 @@ pub(crate) fn init_device(
 		virtio::Id::Vsock => match VirtioVsockDriver::init(device, handlers) {
 			Ok(virt_sock_drv) => {
 				info!("Virtio sock driver initialized.");
-
-				let irq = device.get_irq().unwrap();
-				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
-				info!("Virtio interrupt handler at line {irq}");
-
 				Ok(VirtioDriver::Vsock(alloc::boxed::Box::new(virt_sock_drv)))
 			}
 			Err(virtio_error) => {

--- a/src/drivers/vsock/mmio.rs
+++ b/src/drivers/vsock/mmio.rs
@@ -3,6 +3,7 @@ use virtio::vsock::Config;
 use volatile::VolatileRef;
 
 use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::InterruptCapability;
 use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
 use crate::drivers::vsock::{EventQueue, RxQueue, TxQueue, VirtioVsockDriver, VsockDevCfg};
 use crate::drivers::{InterruptHandlerMap, InterruptLine};
@@ -28,7 +29,7 @@ impl VirtioVsockDriver {
 			dev_id,
 			features: virtio::vsock::F::empty(),
 		};
-		let isr_stat = IsrStatus::new(registers.borrow_mut());
+		let isr_stat = InterruptCapability::IsrStatus(IsrStatus::new(registers.borrow_mut()));
 		let notif_cfg = NotifCfg::new(registers.borrow_mut());
 
 		Ok(VirtioVsockDriver {

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -26,10 +26,11 @@ use crate::drivers::mmio::get_vsock_driver;
 use crate::drivers::pci::get_vsock_driver;
 use crate::drivers::virtio::ControlRegisters;
 use crate::drivers::virtio::error::VirtioVsockError;
+use crate::drivers::virtio::transport::InterruptCapability;
 #[cfg(not(feature = "pci"))]
-use crate::drivers::virtio::transport::mmio::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::mmio::{ComCfg, NotifCfg};
 #[cfg(feature = "pci")]
-use crate::drivers::virtio::transport::pci::{ComCfg, IsrStatus, NotifCfg};
+use crate::drivers::virtio::transport::pci::{ComCfg, NotifCfg};
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::drivers::virtio::virtqueue::{
 	AvailBufferToken, BufferElem, BufferType, UsedBufferToken, Virtq,
@@ -262,7 +263,7 @@ pub(crate) struct VsockDevCfg {
 pub(crate) struct VirtioVsockDriver {
 	pub(super) dev_cfg: VsockDevCfg,
 	pub(super) com_cfg: ComCfg,
-	pub(super) isr_stat: IsrStatus,
+	pub(super) isr_stat: InterruptCapability,
 	pub(super) notif_cfg: NotifCfg,
 
 	pub(super) event_vq: EventQueue,
@@ -305,14 +306,28 @@ impl VirtioVsockDriver {
 	}
 
 	pub fn handle_interrupt(&mut self) {
-		let status = self.isr_stat.acknowledge();
+		#[cfg_attr(
+			not(all(feature = "pci", target_arch = "x86_64")),
+			expect(irrefutable_let_patterns)
+		)]
+		let InterruptCapability::IsrStatus(ref mut isr_stat) = self.isr_stat else {
+			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
+		};
+
+		let status = isr_stat.acknowledge();
 
 		let config_change = cfg_select! {
 			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
+		if status.contains(config_change) {
+			self.handle_device_configuration_interrupt();
+		}
+	}
+
+	fn handle_device_configuration_interrupt(&mut self) {
+		if self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}
@@ -403,11 +418,34 @@ impl VirtioVsockDriver {
 			.unwrap(),
 		));
 
-		handlers.entry(irq.unwrap()).or_default().push_back(|| {
-			if let Some(driver) = get_vsock_driver() {
-				driver.lock().handle_interrupt();
-			};
-		});
+		match &mut self.isr_stat {
+			InterruptCapability::IsrStatus(_) => {
+				let irq = irq.unwrap();
+				handlers.entry(irq).or_default().push_back(|| {
+					if let Some(driver) = get_vsock_driver() {
+						driver.lock().handle_interrupt();
+					};
+				});
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
+				info!("Virtio interrupt handler at line {irq}");
+			}
+			#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+			InterruptCapability::Msix(msix_table) => {
+				self.com_cfg.register_msix_vectors(
+					msix_table,
+					handlers,
+					|| {
+						if let Some(driver) = get_vsock_driver() {
+							driver.lock().handle_device_configuration_interrupt();
+						};
+					},
+					// The no-op handler allows the processor to receive an interrupt and reschedule.
+					// FIXME: replace with a function to wake the vsock task waker once it is not woken unconditionally.
+					[([0], (|| {}) as fn())].into_iter(),
+					1..3,
+				);
+			}
+		}
 
 		// Interrupt for event packets is wanted
 		self.event_vq.enable_notifs();

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -52,6 +52,18 @@ pub(crate) fn network_handler() {
 	}
 }
 
+#[cfg(all(
+	feature = "virtio-net",
+	not(feature = "rtl8139"),
+	feature = "pci",
+	target_arch = "x86_64"
+))]
+pub(crate) fn network_device_configuration_handler() {
+	if let Ok(nic) = NIC.lock().as_nic_mut() {
+		nic.handle_device_configuration_interrupt();
+	}
+}
+
 impl<'a> NetworkState<'a> {
 	pub fn as_nic_mut(&mut self) -> Result<&mut NetworkInterface<'a>, &'static str> {
 		match self {
@@ -392,12 +404,23 @@ impl<'a> NetworkInterface<'a> {
 		self.get_inner_device().handle_interrupt();
 	}
 
+	#[cfg(all(
+		feature = "virtio-net",
+		not(feature = "rtl8139"),
+		feature = "pci",
+		target_arch = "x86_64"
+	))]
+	fn handle_device_configuration_interrupt(&mut self) {
+		self.get_inner_device()
+			.handle_device_configuration_interrupt();
+	}
+
 	pub(crate) fn set_polling_mode(&mut self, value: bool) {
 		self.get_inner_device().set_polling_mode(value);
 	}
 
 	/// Gets the device inside the [smoltcp::phy::Tracer] and [smoltcp::phy::PcapWriter] layers.
-	fn get_inner_device(&mut self) -> &mut impl NetworkDriver {
+	fn get_inner_device(&mut self) -> &mut NetworkDevice {
 		let device = &mut self.device;
 		#[cfg(feature = "net-trace")]
 		let device = device.get_mut();


### PR DESCRIPTION
cloud-hypervisor only supports MSI-X interrupts for PCI devices, so support for MSI-X is needed to support running on it. Additionally, MSI-X  allows us to set separate interrupt handlers for the configuration change interrupts and queue updates (even per-queue handlers once we have multiple queues in the future).

~The implementation does not work on QEMU with the TAP network device (tested with `cargo xtask ci rs --arch x86_64 --profile dev  --package httpd --features ci,hermit/virtio-net,hermit/msix qemu --accel --sudo --devices virtio-net-pci --tap`) and possibly other platforms as well. It works with QEMU user network device in addition to cloud-hypervisor, by adding the `hermit/msix` feature to the regular run command.~