### PR TITLE
build(deps): don't use git source for x86_64 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,8 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.15.2"
-source = "git+https://github.com/rust-osdev/x86_64.git#fd55fa6d508ab0cd0fb269baab98219b80ffdbae"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,6 @@ exclude = [
 ]
 
 [patch.crates-io]
-x86_64 = { git = "https://github.com/rust-osdev/x86_64.git" }
 # FIXME: remove once merged: https://github.com/rcore-os/trapframe-rs/pull/16
 trapframe = { git = "https://github.com/hermit-os/trapframe-rs", branch = "global_asm" }
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "be" }


### PR DESCRIPTION
This was done in https://github.com/hermit-os/kernel/commit/12f3c0edd5385a043b041d21580ad076e03df1f7, since it needed https://github.com/rust-osdev/x86_64/pull/556.

Those changes should now be released.