### PR TITLE
chore(fs/mem): remove copyright header

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -1,10 +1,3 @@
-// Copyright (c) 2019 Stefan Lankes, RWTH Aachen University
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 //! Implements basic functions to realize a simple in-memory file system
 
 #![allow(dead_code)]


### PR DESCRIPTION
This is the only source file left with a copyright header.