### PR TITLE
ci(bench): enable QEMU's isa-debug-exit device

### DIFF
--- a/.github/benchmarks/general.yaml
+++ b/.github/benchmarks/general.yaml
@@ -11,6 +11,7 @@
       -m 128M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/startup_benchmark
   iterations: 25
@@ -29,6 +30,7 @@
       -m 128M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/startup_benchmark
   iterations: 25
@@ -47,6 +49,7 @@
       -m 128M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/startup_benchmark
   iterations: 25
@@ -65,6 +68,7 @@
       -m 512M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/multithreaded_benchmark
   iterations: 25

--- a/.github/benchmarks/misc.yaml
+++ b/.github/benchmarks/misc.yaml
@@ -10,6 +10,7 @@
       -m 512M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/micro_benchmarks
   iterations: 25
@@ -26,6 +27,7 @@
       -m 6G \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/alloc_benchmarks
   iterations: 50
@@ -42,6 +44,7 @@
       -m 512M \
       -display none \
       -serial stdio \
+      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
       -kernel hermit-loader-x86_64 \
       -initrd target/x86_64-unknown-hermit/release/mutex_benchmark
   iterations: 50


### PR DESCRIPTION
This allows failing the benchmarks fast.

Depends on https://github.com/hermit-os/hermit-bench/pull/12.