### PR TITLE
fix(virtq): make IndexAlloc start at low indixes

### DIFF
--- a/src/drivers/virtio/virtqueue/mod.rs
+++ b/src/drivers/virtio/virtqueue/mod.rs
@@ -570,6 +570,62 @@ mod index_alloc {
 			}
 		}
 	}
+
+	#[cfg(all(test, not(target_os = "none")))]
+	mod tests {
+		use std::collections::HashSet;
+
+		use super::*;
+
+		#[test]
+		fn test_index_alloc() {
+			fn test(len: usize) {
+				let mut index_alloc = IndexAlloc::new(len);
+
+				let indexes = (0..len)
+					.map(|_| index_alloc.allocate().unwrap())
+					.collect::<HashSet<_>>();
+
+				assert_eq!(indexes.len(), len);
+				for index in indexes.iter().copied() {
+					assert!(index < len);
+				}
+
+				assert_eq!(index_alloc.allocate(), None);
+				assert_eq!(index_alloc.allocate(), None);
+
+				let mut deallocated_indexes = indexes
+					.iter()
+					.copied()
+					.take(len / 2)
+					.collect::<HashSet<_>>();
+				for index in deallocated_indexes.iter().copied() {
+					unsafe {
+						index_alloc.deallocate(index);
+					}
+				}
+
+				let reallocated_indexes = (0..deallocated_indexes.len())
+					.map(|_| index_alloc.allocate().unwrap())
+					.collect::<HashSet<_>>();
+
+				assert_eq!(reallocated_indexes, deallocated_indexes);
+
+				assert_eq!(index_alloc.allocate(), None);
+				assert_eq!(index_alloc.allocate(), None);
+
+				for index in indexes {
+					unsafe {
+						index_alloc.deallocate(index);
+					}
+				}
+			}
+
+			for len in [0, 1, 2, 7, 8, 9, 63, 64, 65, 255, 256, 257] {
+				test(len);
+			}
+		}
+	}
 }
 
 /// Virtqeueus error module.


### PR DESCRIPTION
This also fixes index allocation for odd lengths.