### PR TITLE
fix(x86_64): correctly report CPUID source for CPU frequency

### DIFF
--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -345,7 +345,8 @@ impl CpuFrequency {
 					ten_char.to_digit(10),
 				) {
 					let mhz = (thousand * 1000 + hundred * 100 + ten * 10) as u16;
-					return self.set_detected_cpu_frequency(mhz, CpuFrequencySources::CpuIdTscInfo);
+					return self
+						.set_detected_cpu_frequency(mhz, CpuFrequencySources::CpuIdBrandString);
 				}
 			}
 		}


### PR DESCRIPTION
This also would have been detected by https://github.com/hermit-os/kernel/pull/2053, eventually.

Closes https://github.com/hermit-os/kernel/issues/2140.