### PR TITLE
fix(x86_64/apic): Corrected IOAPIC default address

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -502,17 +502,13 @@ fn detect_from_mp() -> Result<PhysAddr, ()> {
 	Ok(PhysAddr::new(mp_config.lapic.into()))
 }
 
+/// Returns the default local APIC address, and initializes the IOAPIC address to their default
 fn default_apic() -> PhysAddr {
-	let default_address = PhysAddr::new(0xfee0_0000);
-
-	warn!("Using default APIC address: {default_address:p}");
-
-	// currently, uhyve doesn't support an IO-APIC
-	if !env::is_uhyve() {
-		init_ioapic_address(default_address);
-	}
-
-	default_address
+	let default_local = PhysAddr::new(0xfee0_0000);
+	let default_ioapic = PhysAddr::new(0xfec0_0000);
+	warn!("Using default APIC addresses: local: {default_local:p}, I/O: {default_ioapic:p}");
+	init_ioapic_address(default_ioapic);
+	default_local
 }
 
 pub fn eoi() {


### PR DESCRIPTION
The default IOAPIC address is actually `0xfec0_0000`

Sources:
- https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf - Sec. 3.0 - Table 1
- https://wiki.osdev.org/APIC _the I/O APIC's two-register memory space is relocatable, but defaults to 0xFEC00000._