### PR TITLE
build(deps): update to trapframe 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,8 +1960,9 @@ checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "trapframe"
-version = "0.10.0"
-source = "git+https://github.com/hermit-os/trapframe-rs?branch=global_asm#45d62be444cbf86df8f15dee1e5ed4e63bcd2046"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1699c0079cb7ff77b57fd429bcfa87b1220898bb303e0e45f75789778a376d"
 dependencies = [
  "raw-cpuid 11.6.0",
  "x86_64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,8 +210,6 @@ exclude = [
 ]
 
 [patch.crates-io]
-# FIXME: remove once merged: https://github.com/rcore-os/trapframe-rs/pull/16
-trapframe = { git = "https://github.com/hermit-os/trapframe-rs", branch = "global_asm" }
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "be" }
 
 [profile.profiling]


### PR DESCRIPTION
https://github.com/rcore-os/trapframe-rs/pull/16 has been published.