### PR TITLE
refactor(arch/*/kernel): factor out duplicated code

### DIFF
--- a/src/arch/aarch64/kernel/core_local.rs
+++ b/src/arch/aarch64/kernel/core_local.rs
@@ -79,28 +79,10 @@ impl CoreLocal {
 	}
 }
 
-#[inline]
-pub(crate) fn core_id() -> CoreId {
-	if cfg!(target_os = "none") {
-		CoreLocal::get().core_id
-	} else {
-		0
-	}
-}
-
-#[inline]
-pub(crate) fn core_scheduler() -> &'static mut PerCoreScheduler {
-	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
-}
-
-pub(crate) fn ex() -> &'static StaticExecutor<RawSpinMutex, RawRwSpinLock> {
-	&CoreLocal::get().ex
-}
-
-pub(crate) fn set_core_scheduler(scheduler: *mut PerCoreScheduler) {
-	CoreLocal::get().scheduler.set(scheduler);
-}
-
 pub(crate) fn increment_irq_counter(irq_no: u8) {
 	CoreLocal::get().irq_statistics.inc(irq_no);
 }
+
+#[path = "../../../kernel/core_local.rs"]
+mod core_local_common;
+pub use core_local_common::*;

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -10,7 +10,7 @@ use arm_gic::{IntId, Trigger};
 use fdt::standard_nodes::Compatible;
 use free_list::PageLayout;
 use hashbrown::HashMap;
-use hermit_sync::{InterruptSpinMutex, InterruptTicketMutex, OnceCell, SpinMutex};
+use hermit_sync::{InterruptSpinMutex, OnceCell, SpinMutex};
 use memory_addresses::VirtAddr;
 use memory_addresses::arch::aarch64::PhysAddr;
 
@@ -482,19 +482,6 @@ pub fn init_cpu() {
 	}
 }
 
-static IRQ_NAMES: InterruptTicketMutex<HashMap<u8, &'static str, RandomState>> =
-	InterruptTicketMutex::new(HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0)));
-
-#[allow(dead_code)]
-pub(crate) fn add_irq_name(irq_number: u8, name: &'static str) {
-	debug!("Register name \"{name}\" for interrupt {irq_number}");
-	IRQ_NAMES.lock().insert(SPI_START + irq_number, name);
-}
-
-fn get_irq_name(irq_number: u8) -> Option<&'static str> {
-	IRQ_NAMES.lock().get(&irq_number).copied()
-}
-
 pub(crate) static IRQ_COUNTERS: InterruptSpinMutex<BTreeMap<CoreId, &IrqStatistics>> =
 	InterruptSpinMutex::new(BTreeMap::new());
 
@@ -534,3 +521,7 @@ pub(crate) fn print_statistics() {
 		}
 	}
 }
+
+#[path = "../../../kernel/interrupts.rs"]
+mod interrupts_common;
+pub(crate) use interrupts_common::*;

--- a/src/arch/riscv64/kernel/core_local.rs
+++ b/src/arch/riscv64/kernel/core_local.rs
@@ -69,21 +69,6 @@ impl CoreLocal {
 	}
 }
 
-#[inline]
-pub fn core_id() -> CoreId {
-	CoreLocal::get().core_id
-}
-
-#[inline]
-pub fn core_scheduler() -> &'static mut PerCoreScheduler {
-	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
-}
-
-#[inline]
-pub fn set_core_scheduler(scheduler: *mut PerCoreScheduler) {
-	CoreLocal::get().scheduler.set(scheduler);
-}
-
-pub(crate) fn ex() -> &'static StaticExecutor<RawSpinMutex, RawRwSpinLock> {
-	&CoreLocal::get().ex
-}
+#[path = "../../../kernel/core_local.rs"]
+mod core_local_common;
+pub use core_local_common::*;

--- a/src/arch/x86_64/kernel/core_local.rs
+++ b/src/arch/x86_64/kernel/core_local.rs
@@ -98,26 +98,10 @@ impl CoreLocal {
 	}
 }
 
-pub(crate) fn core_id() -> CoreId {
-	if cfg!(target_os = "none") {
-		CoreLocal::get().core_id
-	} else {
-		0
-	}
-}
-
-pub(crate) fn core_scheduler() -> &'static mut PerCoreScheduler {
-	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
-}
-
-pub(crate) fn ex() -> &'static StaticExecutor<RawSpinMutex, RawRwSpinLock> {
-	&CoreLocal::get().ex
-}
-
-pub(crate) fn set_core_scheduler(scheduler: *mut PerCoreScheduler) {
-	CoreLocal::get().scheduler.set(scheduler);
-}
-
 pub(crate) fn increment_irq_counter(irq_no: u8) {
 	CoreLocal::get().irq_statistics.inc(irq_no);
 }
+
+#[path = "../../../kernel/core_local.rs"]
+mod core_local_common;
+pub use core_local_common::*;

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -1,0 +1,3 @@
+# kernel
+
+This directory is used to collect architecture-unspecific code used in `src/arch/*/kernel`.

--- a/src/kernel/core_local.rs
+++ b/src/kernel/core_local.rs
@@ -1,0 +1,29 @@
+use async_executor::StaticExecutor;
+use hermit_sync::{RawRwSpinLock, RawSpinMutex};
+
+use super::CoreLocal;
+use crate::scheduler::{CoreId, PerCoreScheduler};
+
+#[inline]
+pub(crate) fn core_id() -> CoreId {
+	if cfg!(target_os = "none") {
+		CoreLocal::get().core_id
+	} else {
+		0
+	}
+}
+
+#[inline]
+pub(crate) fn core_scheduler() -> &'static mut PerCoreScheduler {
+	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
+}
+
+#[inline]
+pub fn set_core_scheduler(scheduler: *mut PerCoreScheduler) {
+	CoreLocal::get().scheduler.set(scheduler);
+}
+
+#[inline]
+pub(crate) fn ex() -> &'static StaticExecutor<RawSpinMutex, RawRwSpinLock> {
+	&CoreLocal::get().ex
+}

--- a/src/kernel/interrupts.rs
+++ b/src/kernel/interrupts.rs
@@ -1,0 +1,19 @@
+use ahash::RandomState;
+use hashbrown::HashMap;
+use hermit_sync::InterruptTicketMutex;
+
+use super::SPI_START;
+
+pub(super) static IRQ_NAMES: InterruptTicketMutex<HashMap<u8, &'static str, RandomState>> =
+	InterruptTicketMutex::new(HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0)));
+
+#[allow(dead_code)]
+pub(crate) fn add_irq_name(irq_number: u8, name: &'static str) {
+	debug!("Register name \"{name}\" for interrupt {irq_number}");
+	IRQ_NAMES.lock().insert(SPI_START + irq_number, name);
+}
+
+#[allow(dead_code)]
+pub(super) fn get_irq_name(irq_number: u8) -> Option<&'static str> {
+	IRQ_NAMES.lock().get(&irq_number).copied()
+}


### PR DESCRIPTION
This is just a suggestion, but I found it way easier to understand code when the parts that are actually 100% identical aren't duplicated in per-architecture code.