### PR TITLE
refactor(aarch64/start): move SCTLR_EL1 register values

### DIFF
--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -119,38 +119,38 @@ const fn mair(attr: u64, mt: u64) -> u64 {
 #[cfg(feature = "smp")]
 pub(crate) static TTBR0: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
 
-// Prepare system control register (SCTRL)
-//
-// UCI     [26] Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
-//              DC CVAC and IC IVAU instructions
-// EE      [25] Explicit data accesses at EL1 and Stage 1 translation
-//              table walks at EL1 & EL0 are little-endian
-// EOE     [24] Explicit data accesses at EL0 are little-endian
-// WXN     [19] Regions with write permission are not forced to XN
-// nTWE    [18] WFE instructions are executed as normal
-// nTWI    [16] WFI instructions are executed as normal
-// UCT     [15] Enables EL0 access in AArch64 to the CTR_EL0 register
-// DZE     [14] Execution of the DC ZVA instruction is allowed at EL0
-// I       [12] Instruction caches enabled at EL0 and EL1
-// UMA     [9]  Disable access to the interrupt masks from EL0
-// SED     [8]  The SETEND instruction is available
-// ITD     [7]  The IT instruction functionality is available
-// THEE    [6]  ThumbEE is disabled
-// CP15BEN [5]  CP15 barrier operations disabled
-// SA0     [4]  Stack Alignment check for EL0 enabled
-// SA      [3]  Stack Alignment check enabled
-// C       [2]  Data and unified enabled
-// A       [1]  Alignment fault checking disabled
-// M       [0]  MMU enable
-#[cfg(all(feature = "smp", target_endian = "little"))]
-const SCTLR_EL1: u64 = 0b100_0000_0101_1101_0000_0001_1101;
-// The same, but EE and EOE are set to 1 for big endian.
-#[cfg(all(feature = "smp", target_endian = "big"))]
-const SCTLR_EL1: u64 = 0b111_0000_0101_1101_0000_0001_1101;
-
 #[cfg(feature = "smp")]
 #[unsafe(naked)]
 pub(crate) unsafe extern "C" fn smp_start() -> ! {
+	// Prepare system control register (SCTRL)
+	//
+	// UCI     [26] Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
+	//              DC CVAC and IC IVAU instructions
+	// EE      [25] Explicit data accesses at EL1 and Stage 1 translation
+	//              table walks at EL1 & EL0 are little-endian
+	// EOE     [24] Explicit data accesses at EL0 are little-endian
+	// WXN     [19] Regions with write permission are not forced to XN
+	// nTWE    [18] WFE instructions are executed as normal
+	// nTWI    [16] WFI instructions are executed as normal
+	// UCT     [15] Enables EL0 access in AArch64 to the CTR_EL0 register
+	// DZE     [14] Execution of the DC ZVA instruction is allowed at EL0
+	// I       [12] Instruction caches enabled at EL0 and EL1
+	// UMA     [9]  Disable access to the interrupt masks from EL0
+	// SED     [8]  The SETEND instruction is available
+	// ITD     [7]  The IT instruction functionality is available
+	// THEE    [6]  ThumbEE is disabled
+	// CP15BEN [5]  CP15 barrier operations disabled
+	// SA0     [4]  Stack Alignment check for EL0 enabled
+	// SA      [3]  Stack Alignment check enabled
+	// C       [2]  Data and unified enabled
+	// A       [1]  Alignment fault checking disabled
+	// M       [0]  MMU enable
+	#[cfg(target_endian = "little")]
+	const SCTLR_EL1: u64 = 0b100_0000_0101_1101_0000_0001_1101;
+	// The same, but EE and EOE are set to 1 for big endian.
+	#[cfg(target_endian = "big")]
+	const SCTLR_EL1: u64 = 0b111_0000_0101_1101_0000_0001_1101;
+
 	naked_asm!(
 		// disable interrupts
 		"msr daifset, #0b111",


### PR DESCRIPTION
`asm_cfg` is stable as of Rust 1.93.0.

I don't think it makes sense to apply this to `x86_64/kernel/switch.rs`.