### PR TITLE
feat(uhyve): use v2 interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,6 @@ checksum = "01af0509edc73791972185a4ed1e3e8b2d0f21c3c527f96078586446b61750c4"
 dependencies = [
  "align-address 0.3.0",
  "cfg-if",
- "x86_64",
 ]
 
 [[package]]
@@ -2091,13 +2090,13 @@ dependencies = [
 
 [[package]]
 name = "uhyve-interface"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4f1b21b9d7368474a8cebf8e34348ea1eff1c44201a0ee54b129fbe5b8f9d1"
+checksum = "4f9fe9717fe011743d97a5dc1f552656ff2dc934af940261c22fe353c55acd42"
 dependencies = [
  "aarch64",
  "hermit-abi",
- "memory_addresses 0.2.3",
+ "memory_addresses 0.3.0",
  "num_enum",
  "x86_64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ talc = { version = "5" }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
 volatile = "0.6"
-uhyve-interface = "0.1.4"
+uhyve-interface = "0.2"
 
 [dependencies.smoltcp]
 version = "0.13"

--- a/src/fd/stdio/uhyve.rs
+++ b/src/fd/stdio/uhyve.rs
@@ -1,6 +1,9 @@
-use uhyve_interface::parameters::{ReadParams, WriteParams};
-use uhyve_interface::{GuestVirtAddr, Hypercall};
+use memory_addresses::VirtAddr;
+use uhyve_interface::GuestPhysAddr;
+use uhyve_interface::v2::Hypercall;
+use uhyve_interface::v2::parameters::{ReadParams, WriteParams};
 
+use crate::arch::mm::paging;
 use crate::errno::Errno;
 use crate::fd::{
 	AccessPermission, FileAttr, ObjectInterface, PollEvent, STDERR_FILENO, STDIN_FILENO,
@@ -15,16 +18,18 @@ impl ObjectInterface for UhyveStdin {
 	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		let mut read_params = ReadParams {
 			fd: STDIN_FILENO,
-			buf: GuestVirtAddr::from_ptr(buf.as_ptr()),
-			len: buf.len(),
-			ret: 0,
+			buf: GuestPhysAddr::new(
+				paging::virtual_to_physical(VirtAddr::from_ptr(buf.as_mut_ptr()))
+					.unwrap()
+					.as_u64(),
+			),
+			len: buf.len().try_into().unwrap(),
+			ret: 0i64,
 		};
 		uhyve_hypercall(Hypercall::FileRead(&mut read_params));
-
-		if read_params.ret < 0 {
-			Err(Errno::Io)
-		} else {
-			Ok(read_params.ret as usize)
+		match read_params.ret {
+			ret if ret >= 0 => Ok(ret.try_into().unwrap()),
+			_ => Err((read_params.ret as i32).abs().try_into().unwrap()),
 		}
 	}
 
@@ -56,14 +61,29 @@ impl ObjectInterface for UhyveStdout {
 	}
 
 	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
-		let write_params = WriteParams {
+		let mut write_params = WriteParams {
 			fd: STDOUT_FILENO,
-			buf: GuestVirtAddr::from_ptr(buf.as_ptr()),
-			len: buf.len(),
+			buf: GuestPhysAddr::new(
+				paging::virtual_to_physical(VirtAddr::from_ptr(buf.as_ptr()))
+					.unwrap()
+					.as_u64(),
+			),
+			len: buf.len().try_into().unwrap(),
+			ret: 0i64,
 		};
-		uhyve_hypercall(Hypercall::FileWrite(&write_params));
-
-		Ok(write_params.len)
+		// fd refers to a regular file
+		uhyve_hypercall(Hypercall::FileWrite(&mut write_params));
+		match write_params.ret {
+			// Assumption: fd is a regular file, a zero is only valid if the len
+			// (aka. "count") is also zero. Otherwise, however, we assume that something
+			// is wrong in Hermit<>Uhyve communication.
+			ret if ret > 0 || (ret == 0 && write_params.len == 0) => Ok(ret.try_into().unwrap()),
+			errno if errno < 0 => Err((errno as i32).abs().try_into().unwrap()),
+			_ => {
+				debug!("Uhyve write hypercall yielded a zero.");
+				Err(Errno::Inval)
+			}
+		}
 	}
 
 	async fn isatty(&self) -> io::Result<bool> {
@@ -94,14 +114,30 @@ impl ObjectInterface for UhyveStderr {
 	}
 
 	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
-		let write_params = WriteParams {
+		let mut write_params = WriteParams {
 			fd: STDERR_FILENO,
-			buf: GuestVirtAddr::from_ptr(buf.as_ptr()),
-			len: buf.len(),
+			buf: GuestPhysAddr::new(
+				paging::virtual_to_physical(VirtAddr::from_ptr(buf.as_ptr()))
+					.unwrap()
+					.as_u64(),
+			),
+			len: buf.len().try_into().unwrap(),
+			ret: 0i64,
 		};
-		uhyve_hypercall(Hypercall::FileWrite(&write_params));
 
-		Ok(write_params.len)
+		// fd refers to a regular file
+		uhyve_hypercall(Hypercall::FileWrite(&mut write_params));
+		match write_params.ret {
+			// Assumption: fd is a regular file, a zero is only valid if the len
+			// (aka. "count") is also zero. Otherwise, however, we assume that something
+			// is wrong in Hermit<>Uhyve communication.
+			ret if ret > 0 || (ret == 0 && write_params.len == 0) => Ok(ret.try_into().unwrap()),
+			errno if errno < 0 => Err((errno as i32).abs().try_into().unwrap()),
+			_ => {
+				debug!("Uhyve write hypercall yielded a zero.");
+				Err(Errno::Inval)
+			}
+		}
 	}
 
 	async fn isatty(&self) -> io::Result<bool> {

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -7,10 +7,11 @@ use alloc::sync::Arc;
 use async_lock::Mutex;
 use embedded_io::{ErrorType, Read, Write};
 use memory_addresses::VirtAddr;
-use uhyve_interface::parameters::{
+use uhyve_interface::GuestPhysAddr;
+use uhyve_interface::v2::Hypercall;
+use uhyve_interface::v2::parameters::{
 	CloseParams, LseekParams, OpenParams, ReadParams, UnlinkParams, WriteParams,
 };
-use uhyve_interface::{GuestPhysAddr, GuestVirtAddr, Hypercall};
 
 use crate::arch::mm::paging;
 use crate::env::fdt;
@@ -33,16 +34,20 @@ impl UhyveFileHandleInner {
 	fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
 		let mut lseek_params = LseekParams {
 			fd: self.0,
-			offset,
+			offset: offset.try_into().unwrap(),
 			whence: u8::from(whence).into(),
 		};
 		uhyve_hypercall(Hypercall::FileLseek(&mut lseek_params));
-
-		if lseek_params.offset < 0 {
-			return Err(Errno::Inval);
+		// TODO: Although we can generally assume that what Uhyve delivers should be
+		// correct for now, it might make sense to build in checks (or at least debug_assert's)
+		match lseek_params.offset {
+			offset if offset >= 0 => Ok(offset.try_into().unwrap()),
+			errno if errno < 0 => Err((errno as i32).abs().try_into().unwrap()),
+			_ => {
+				debug!("Uhyve lseek hypercall yielded a zero.");
+				Err(Errno::Inval)
+			}
 		}
-
-		Ok(lseek_params.offset)
 	}
 }
 
@@ -54,30 +59,47 @@ impl Read for UhyveFileHandleInner {
 	fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
 		let mut read_params = ReadParams {
 			fd: self.0,
-			buf: GuestVirtAddr::from_ptr(buf.as_mut_ptr()),
-			len: buf.len(),
-			ret: 0,
+			buf: GuestPhysAddr::new(
+				paging::virtual_to_physical(VirtAddr::from_ptr(buf.as_mut_ptr()))
+					.unwrap()
+					.as_u64(),
+			),
+			len: buf.len().try_into().unwrap(),
+			ret: 0i64,
 		};
 		uhyve_hypercall(Hypercall::FileRead(&mut read_params));
-
-		if read_params.ret < 0 {
-			return Err(Errno::Io);
+		match read_params.ret {
+			ret if ret >= 0 => Ok(ret.try_into().unwrap()),
+			_ => Err((read_params.ret as i32).abs().try_into().unwrap()),
 		}
-
-		Ok(read_params.ret.try_into().unwrap())
 	}
 }
 
 impl Write for UhyveFileHandleInner {
 	fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-		let write_params = WriteParams {
+		let mut write_params = WriteParams {
 			fd: self.0,
-			buf: GuestVirtAddr::from_ptr(buf.as_ptr()),
-			len: buf.len(),
+			buf: GuestPhysAddr::new(
+				paging::virtual_to_physical(VirtAddr::from_ptr(buf.as_ptr()))
+					.unwrap()
+					.as_u64(),
+			),
+			len: buf.len().try_into().unwrap(),
+			ret: 0i64,
 		};
-		uhyve_hypercall(Hypercall::FileWrite(&write_params));
-
-		Ok(write_params.len)
+		// fd refers to a regular file
+		uhyve_hypercall(Hypercall::FileWrite(&mut write_params));
+		match write_params.ret {
+			// Assumption: fd is a regular file, a zero is only valid if the len
+			// (aka. "count") is also zero. Otherwise, however, we assume that something
+			// is wrong in Hermit<>Uhyve communication.
+			ret if ret > 0 || (ret == 0 && write_params.len == 0) => Ok(ret.try_into().unwrap()),
+			errno if errno < 0 => Err((errno as i32).abs().try_into().unwrap()),
+			_ => {
+				debug!("Uhyve write hypercall yielded a zero.");
+				Err(Errno::Inval)
+			}
+		}
 	}
 
 	fn flush(&mut self) -> Result<(), Self::Error> {
@@ -179,14 +201,14 @@ impl VfsNode for UhyveDirectory {
 			ret: -1,
 		};
 		uhyve_hypercall(Hypercall::FileOpen(&mut open_params));
-
-		if open_params.ret <= 0 {
-			return Err(Errno::Io);
+		let ret = open_params.ret; // circumvent packed field access
+		match ret {
+			// Assumption: Uhyve will never return a standard stream.
+			ret if ret >= 0 => Ok(Arc::new(async_lock::RwLock::new(
+				UhyveFileHandle::new(ret).into(),
+			))),
+			_ => Err(ret.abs().try_into().unwrap()),
 		}
-
-		Ok(Arc::new(async_lock::RwLock::new(
-			UhyveFileHandle::new(open_params.ret).into(),
-		)))
 	}
 
 	fn traverse_unlink(&self, path: &str) -> io::Result<()> {
@@ -201,12 +223,11 @@ impl VfsNode for UhyveDirectory {
 			ret: -1,
 		};
 		uhyve_hypercall(Hypercall::FileUnlink(&mut unlink_params));
-
-		if unlink_params.ret != 0 {
-			return Err(Errno::Io);
+		let ret = unlink_params.ret; // circumvent packed field access
+		match ret {
+			0 => Ok(()),
+			_ => Err(unlink_params.ret.abs().try_into().unwrap()),
 		}
-
-		Ok(())
 	}
 
 	fn traverse_rmdir(&self, _path: &str) -> io::Result<()> {

--- a/src/uhyve.rs
+++ b/src/uhyve.rs
@@ -1,8 +1,9 @@
 use core::ptr;
 
 use memory_addresses::VirtAddr;
-use uhyve_interface::parameters::{ExitParams, SerialWriteBufferParams};
-use uhyve_interface::{Hypercall, HypercallAddress};
+use uhyve_interface::GuestPhysAddr;
+use uhyve_interface::v2::parameters::SerialWriteBufferParams;
+use uhyve_interface::v2::{Hypercall, HypercallAddress};
 
 use crate::arch;
 use crate::arch::mm::paging::virtual_to_physical;
@@ -10,15 +11,17 @@ use crate::arch::mm::paging::virtual_to_physical;
 #[cfg(target_os = "none")]
 hermit_entry::define_uhyve_interface_version!(uhyve_interface::UHYVE_INTERFACE_VERSION);
 
-/// Perform a SerialWriteBuffer hypercall with `buf` as payload.
+/// perform a SerialWriteBuffer hypercall with `buf` as payload
 #[inline]
 pub(crate) fn serial_buf_hypercall(buf: &[u8]) {
-	let len = buf.len();
-	let buf = virtual_to_physical(VirtAddr::from_ptr(ptr::from_ref::<[u8]>(buf)))
-		.unwrap()
-		.as_u64()
-		.into();
-	let p = SerialWriteBufferParams { buf, len };
+	let p = SerialWriteBufferParams {
+		buf: GuestPhysAddr::new(
+			virtual_to_physical(VirtAddr::from_ptr(ptr::from_ref::<[u8]>(buf)))
+				.unwrap()
+				.as_u64(),
+		),
+		len: buf.len() as u64,
+	};
 	uhyve_hypercall(Hypercall::SerialWriteBuffer(&p));
 }
 
@@ -34,9 +37,11 @@ fn data_addr<T>(data: &T) -> u64 {
 #[inline]
 fn hypercall_data(hypercall: &Hypercall<'_>) -> u64 {
 	match hypercall {
-		Hypercall::Cmdsize(data) => data_addr(*data),
-		Hypercall::Cmdval(data) => data_addr(*data),
-		Hypercall::Exit(data) => data_addr(*data),
+		// As we are encoding an exit code (max 32 bits) into "an
+		// address", and memory_addresses complains if an address
+		// has any bits above the 48th one set to 1, we encode
+		// potential negative numbers into a u32, then a u64.
+		Hypercall::Exit(exit_code) => u64::from((*exit_code) as u32),
 		Hypercall::FileClose(data) => data_addr(*data),
 		Hypercall::FileLseek(data) => data_addr(*data),
 		Hypercall::FileOpen(data) => data_addr(*data),
@@ -57,20 +62,25 @@ pub(crate) fn uhyve_hypercall(hypercall: Hypercall<'_>) {
 	let data = hypercall_data(&hypercall);
 
 	#[cfg(target_arch = "x86_64")]
-	unsafe {
-		use x86_64::instructions::port::Port;
-
-		let data =
-			u32::try_from(data).expect("Hypercall data must lie in the first 4GiB of memory");
-		Port::new(ptr).write(data);
+	{
+		unsafe {
+			use core::arch::asm;
+			asm!(
+				"out dx, eax",
+				in("dx") ptr,
+				in("eax") 0x1234u32,
+				in("rdi") data,
+				options(nostack, preserves_flags)
+			);
+		}
 	}
 
 	#[cfg(target_arch = "aarch64")]
 	unsafe {
 		use core::arch::asm;
 		asm!(
-			"str x8, [{ptr}]",
-			ptr = in(reg) u64::from(ptr),
+			"str x8, [{ptr:x}]",
+			ptr = in(reg) ptr,
 			in("x8") data,
 			options(nostack),
 		);
@@ -81,9 +91,7 @@ pub(crate) fn uhyve_hypercall(hypercall: Hypercall<'_>) {
 }
 
 pub fn shutdown(error_code: i32) -> ! {
-	let sysexit = ExitParams { arg: error_code };
-	uhyve_hypercall(Hypercall::Exit(&sysexit));
-
+	uhyve_hypercall(Hypercall::Exit(error_code));
 	loop {
 		arch::processor::halt();
 	}


### PR DESCRIPTION
On x86_64, the data address will be stored in the rcx register to support 64-bit addresses.

This also removes the usage of ExitArgs, as it is a single integer.