### PR TITLE
build(deps): upgrade align-address to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2df0852593ebb4ed15e4fce123daf16a272b8d4449ae75050d6b9d7cea461a21"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "memory_addresses",
+ "memory_addresses 0.2.3",
  "tock-registers 0.9.0",
 ]
 
@@ -814,7 +814,7 @@ version = "0.12.0"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ahash",
- "align-address 0.3.0",
+ "align-address 0.4.0",
  "anstyle",
  "anyhow",
  "arm-gic",
@@ -844,7 +844,7 @@ dependencies = [
  "lock_api",
  "log",
  "mem-barrier",
- "memory_addresses",
+ "memory_addresses 0.3.0",
  "num-traits",
  "num_enum",
  "pci-ids",
@@ -1212,6 +1212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01af0509edc73791972185a4ed1e3e8b2d0f21c3c527f96078586446b61750c4"
 dependencies = [
  "align-address 0.3.0",
+ "cfg-if",
+ "x86_64",
+]
+
+[[package]]
+name = "memory_addresses"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d19077c1bd58a846e275c3bb80527600ab8afbfb2768a80eb39f77cf93f1d"
+dependencies = [
+ "align-address 0.4.0",
  "cfg-if",
  "x86_64",
 ]
@@ -1999,7 +2010,7 @@ checksum = "ff4f1b21b9d7368474a8cebf8e34348ea1eff1c44201a0ee54b129fbe5b8f9d1"
 dependencies = [
  "aarch64",
  "hermit-abi",
- "memory_addresses",
+ "memory_addresses 0.2.3",
  "num_enum",
  "x86_64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ unreadable_literal = "warn"
 hermit-macro = { version = "=0.1.0", path = "hermit-macro" }
 virtio = { package = "virtio-spec", version = "0.3", optional = true, features = ["alloc", "mmio", "nightly", "zerocopy"] }
 ahash = { version = "0.8", default-features = false }
-align-address = "0.3"
+align-address = "0.4"
 anstyle = { version = "1", default-features = false }
 async-executor = { git = "https://github.com/hermit-os/async-executor.git", branch = "no_std", default-features = false, features = ["static"] }
 async-lock = { version = "3.4.2", default-features = false }
@@ -167,7 +167,7 @@ free-list = { version = "0.3", features = ["x86_64"] }
 raw-cpuid = "11"
 uart_16550 = "0.4"
 x86_64 = "0.15"
-memory_addresses = { version = "0.2.3", default-features = false, features = [
+memory_addresses = { version = "0.3", default-features = false, features = [
 	"x86_64",
 	"conv-x86_64",
 ] }
@@ -177,7 +177,7 @@ aarch64-cpu = "11"
 arm-gic = { version = "0.6" }
 arm-pl011-uart = { version = "0.4", default-features = false }
 semihosting = { version = "0.1", optional = true }
-memory_addresses = { version = "0.2.3", default-features = false, features = [
+memory_addresses = { version = "0.3", default-features = false, features = [
 	"aarch64",
 ] }
 
@@ -187,7 +187,7 @@ sbi-rt = "0.0.3"
 semihosting = { version = "0.1", optional = true }
 tock-registers = { version = "0.10", optional = true }
 trapframe = "0.10"
-memory_addresses = { version = "0.2.3", default-features = false, features = [
+memory_addresses = { version = "0.3", default-features = false, features = [
 	"riscv64",
 ] }
 

--- a/src/syscalls/interfaces/uhyve.rs
+++ b/src/syscalls/interfaces/uhyve.rs
@@ -12,10 +12,12 @@ use crate::syscalls::interfaces::SyscallInterface;
 #[inline]
 #[cfg_attr(target_arch = "riscv64", expect(dead_code))]
 pub(crate) fn serial_buf_hypercall(buf: &[u8]) {
-	let p = SerialWriteBufferParams {
-		buf: virtual_to_physical(VirtAddr::from_ptr(core::ptr::from_ref::<[u8]>(buf))).unwrap(),
-		len: buf.len(),
-	};
+	let len = buf.len();
+	let buf = virtual_to_physical(VirtAddr::from_ptr(core::ptr::from_ref::<[u8]>(buf)))
+		.unwrap()
+		.as_u64()
+		.into();
+	let p = SerialWriteBufferParams { buf, len };
 	uhyve_hypercall(Hypercall::SerialWriteBuffer(&p));
 }
 


### PR DESCRIPTION
This also upgrades `memory_addresses` to 0.3.

See https://github.com/hermit-os/kernel/pull/2202.