### PR TITLE
paging: make ALL levels writable, not just P4

### DIFF
--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -325,25 +325,6 @@ fn make_p4_writable() {
 
 	let mut pt = unsafe { identity_mapped_page_table() };
 
-	let p4_page = {
-		let (p4_frame, _) = Cr3::read_raw();
-		let p4_addr = x86_64::VirtAddr::new(p4_frame.start_address().as_u64());
-		Page::<Size4KiB>::from_start_address(p4_addr).unwrap()
-	};
-
-	let TranslateResult::Mapped { frame, flags, .. } = pt.translate(p4_page.start_address()) else {
-		unreachable!()
-	};
-
-	let make_writable = || unsafe {
-		let flags = flags | PageTableEntryFlags::WRITABLE;
-		match frame {
-			MappedFrame::Size1GiB(_) => pt.set_flags_p3_entry(p4_page, flags).unwrap().ignore(),
-			MappedFrame::Size2MiB(_) => pt.set_flags_p2_entry(p4_page, flags).unwrap().ignore(),
-			MappedFrame::Size4KiB(_) => pt.update_flags(p4_page, flags).unwrap().ignore(),
-		}
-	};
-
 	unsafe fn without_protect<F, R>(f: F) -> R
 	where
 		F: FnOnce() -> R,
@@ -359,7 +340,55 @@ fn make_p4_writable() {
 		ret
 	}
 
-	unsafe { without_protect(make_writable) }
+	let (p4_frame, _) = Cr3::read_raw();
+	unsafe {
+		without_protect(|| make_page_table_writable(&mut pt, p4_frame, 4));
+	};
+}
+
+unsafe fn make_page_table_writable(
+	page_table: &mut OffsetPageTable<'static>,
+	pt_frame: PhysFrame,
+	level: u8,
+) {
+	let pt_address = page_table.phys_offset() + pt_frame.start_address().as_u64();
+	let pt = unsafe { pt_address.as_ptr::<PageTable>().as_ref().unwrap() };
+
+	// Unmap the page table
+	let TranslateResult::Mapped { frame, flags, .. } = page_table.translate(pt_address) else {
+		unreachable!()
+	};
+
+	if !flags.contains(PageTableEntryFlags::WRITABLE) {
+		let flags = flags | PageTableEntryFlags::WRITABLE;
+		let page = Page::<Size4KiB>::containing_address(pt_address);
+		unsafe {
+			match frame {
+				MappedFrame::Size1GiB(_) => {
+					page_table.set_flags_p3_entry(page, flags).unwrap().ignore()
+				}
+				MappedFrame::Size2MiB(_) => {
+					page_table.set_flags_p2_entry(page, flags).unwrap().ignore()
+				}
+				MappedFrame::Size4KiB(_) => page_table.update_flags(page, flags).unwrap().ignore(),
+			}
+		}
+		warn!("Page table {pt_frame:x?}, was mapped from RO memory!");
+	}
+
+	for entry in pt.iter() {
+		if entry.is_unused() {
+			continue;
+		}
+
+		let is_page_table = level > 1 && !entry.flags().contains(PageTableEntryFlags::HUGE_PAGE);
+		if is_page_table {
+			let phys = entry.frame().unwrap();
+			unsafe {
+				make_page_table_writable(page_table, phys, level - 1);
+			}
+		}
+	}
 }
 
 pub unsafe fn log_page_tables() {


### PR DESCRIPTION
After investigating PF exceptions, I traced them back to a `pt.set_unused()` call, which failed because the page table was not entirely writable.