### PR TITLE
fix(arch/serial): only be read_ready when data is available

### DIFF
--- a/src/arch/aarch64/kernel/serial.rs
+++ b/src/arch/aarch64/kernel/serial.rs
@@ -66,7 +66,7 @@ impl Read for SerialDevice {
 
 impl ReadReady for SerialDevice {
 	fn read_ready(&mut self) -> Result<bool, Self::Error> {
-		Ok(UART_DEVICE.lock().buffer.read_ready()?)
+		Ok(!UART_DEVICE.lock().buffer.is_empty())
 	}
 }
 

--- a/src/arch/x86_64/kernel/serial.rs
+++ b/src/arch/x86_64/kernel/serial.rs
@@ -57,7 +57,7 @@ impl Read for SerialDevice {
 
 impl ReadReady for SerialDevice {
 	fn read_ready(&mut self) -> Result<bool, Self::Error> {
-		Ok(UART_DEVICE.lock().buffer.read_ready()?)
+		Ok(!UART_DEVICE.lock().buffer.is_empty())
 	}
 }
 


### PR DESCRIPTION
This reverts changes from 44c00247.

Background:

`VecDeque` implements `read_ready` as `return true`. This is correct for them, because reading a VecDeque never blocks.

However, in `stdio.rs`, the `read` function blocks if `read` returned 0 bytes.

So we have a situation where polling stdin ALWAYS returns POLLIN, but immediately reading causes a lock (until there is something to read)