### PR TITLE
fix(virtio-fs): de-assert interrupts

### DIFF
--- a/src/drivers/fs/mod.rs
+++ b/src/drivers/fs/mod.rs
@@ -156,6 +156,24 @@ impl VirtioFsDriver {
 
 		Ok(())
 	}
+
+	pub fn handle_interrupt(&mut self) {
+		let status = self.isr_stat.is_queue_interrupt();
+
+		#[cfg(not(feature = "pci"))]
+		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
+			info!("Configuration changes are not possible! Aborting");
+			todo!("Implement possibility to change config on the fly...")
+		}
+
+		#[cfg(feature = "pci")]
+		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+			info!("Configuration changes are not possible! Aborting");
+			todo!("Implement possibility to change config on the fly...")
+		}
+
+		self.isr_stat.acknowledge();
+	}
 }
 
 impl FuseInterface for VirtioFsDriver {

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -387,7 +387,11 @@ impl PciDriver {
 			}
 			#[cfg(feature = "virtio-fs")]
 			Self::VirtioFs(drv) => {
-				fn fuse_handler() {}
+				fn fuse_handler() {
+					if let Some(driver) = get_filesystem_driver() {
+						driver.lock().handle_interrupt();
+					}
+				}
 
 				let irq_number = drv.lock().get_interrupt_number();
 


### PR DESCRIPTION
Running httpd via virtio-net with virtio-fs also enabled, we run into https://github.com/hermit-os/kernel/issues/1680.

The symptoms are as follows:
1. We set up the virtio-net device.
2. We get an IP via DHCP and get two interrupts during configuration.
3. We set up the virtio-fs device.
4. We mount the virtio-fs directory and get one interrupt during configuration.
5. We never get an virtio interrupt again.
   - Non-interrupt-based networking (with `feature = "idle-poll"`) is not affected.
   - Sending other interrupts such as the serial device interrupt via the keyboard let's us make progress, since we currently always poll the network stack in all interrupts (until https://github.com/hermit-os/kernel/pull/2086).
   - Virtio-fs does not care, since we block on every operation.

The reason for this issue is related to virtio's [ISR status capability](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-131003r130):

> To avoid an extra access, simply reading this register resets it to 0 and causes the device to de-assert the interrupt.
>
> In this way, driver read of ISR status causes the device to de-assert an interrupt.

The problem is that for some reason, we never read the ISR status register for virtio-fs interrupts. This causes virtio-fs interrupts to never be de-asserted, preventing other virtio interrupt to be triggered.

The fix is straight forward: read the ISR status registers to deassert the virtio-fs interrupt as we already do for the other virtio devices. This PR just duplicates virtio-net's logic. In a follow up PR I will refactor the method name from `is_queue_interrupt` to something that signals that this is an active operation, not just a getter. In the future, I will merge the logic, deduplicating and unifying the methods.

Closes https://github.com/hermit-os/kernel/issues/1680.