### PR TITLE
fix(xtask): demangle symbols when testing rftrace

### DIFF
--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -638,7 +638,9 @@ fn check_rftrace(image: &Path) -> Result<()> {
 	let image_name = image.file_name().unwrap().to_str().unwrap();
 
 	let nm = crate::binutil("nm").unwrap();
-	let symbols = cmd!(sh, "{nm} --numeric-sort {image}").output()?.stdout;
+	let symbols = cmd!(sh, "{nm} --demangle --numeric-sort {image}")
+		.output()?
+		.stdout;
 	sh.write_file(format!("shared/tracedir/{image_name}.sym"), symbols)?;
 
 	let replay = cmd!(


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/commit/683dd08db5808c41baceef49368fc82a6c4767bb, the Rust compiler defaults to the [v0 Symbol Format](https://doc.rust-lang.org/stable/rustc/symbol-mangling/v0.html).