### PR TITLE
fix(pci): warn when virtio is disabled

### DIFF
--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -501,6 +501,9 @@ pub(crate) fn init() {
 				adapter.device_id()
 			);
 
+			#[cfg(not(feature = "virtio"))]
+			error!("Virtio support is disabled.");
+
 			#[cfg(feature = "virtio")]
 			match pci_virtio::init_device(adapter) {
 				#[cfg(feature = "virtio-console")]


### PR DESCRIPTION
For MMIO devices, something similar would be nice, but I'd rather do that during the overdue MMIO driver detection rework.