### PR TITLE
experiment: panic on getpid

### DIFF
--- a/.github/benchmarks/misc.yaml
+++ b/.github/benchmarks/misc.yaml
@@ -1,19 +1,19 @@
-- group: Micro
-  name: Micro Benchmarks
-  bin: micro_benchmarks
-  hermit_rs_manifest_path: benches/micro/Cargo.toml
-  command: |
-    sudo qemu-system-x86_64 \
-      -enable-kvm \
-      -cpu host,migratable=no,+invtsc \
-      -smp 4 \
-      -m 512M \
-      -display none \
-      -serial stdio \
-      -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
-      -kernel hermit-loader-x86_64 \
-      -initrd target/x86_64-unknown-hermit/release/micro_benchmarks
-  iterations: 25
+# - group: Micro
+#   name: Micro Benchmarks
+#   bin: micro_benchmarks
+#   hermit_rs_manifest_path: benches/micro/Cargo.toml
+#   command: |
+#     sudo qemu-system-x86_64 \
+#       -enable-kvm \
+#       -cpu host,migratable=no,+invtsc \
+#       -smp 4 \
+#       -m 512M \
+#       -display none \
+#       -serial stdio \
+#       -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+#       -kernel hermit-loader-x86_64 \
+#       -initrd target/x86_64-unknown-hermit/release/micro_benchmarks
+#   iterations: 25
 
 - group: Allocations
   name: Allocation Benchmarks

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -18,7 +18,7 @@ pub type Tid = i32;
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub extern "C" fn sys_getpid() -> Tid {
-	0
+	unimplemented!()
 }
 
 #[cfg(feature = "newlib")]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/153130 makes `getpid` panic in Rust's `std`.

This PR makes `getpid` panic in the kernel to test whether this is used by any Rust apps that we test against.
