### PR TITLE
executor: Don't run background tasks if future is ready

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -147,19 +147,19 @@ where
 		// check future
 		let result = future.as_mut().poll(&mut cx);
 
-		// run background all tasks, which poll also the network device
-		run();
-
-		let now = crate::arch::kernel::systemtime::now_micros();
 		if let Poll::Ready(t) = result {
 			return t;
 		}
 
+		let now = crate::arch::kernel::systemtime::now_micros();
 		if let Some(duration) = timeout
 			&& Duration::from_micros(now - start) >= duration
 		{
 			return Err(Errno::Time);
 		}
+
+		// run background all tasks, which poll also the network device
+		run();
 
 		if backoff.is_completed() {
 			let wakeup_time =


### PR DESCRIPTION
Often times, the future is ready immediately and yet we will still run the background tasks every time, adding significant overhead that is noticable when benchmarking a HTTP server.

The blocking httpd example gains anywhere between 20-50% more throughput for me with these changes, while the netbench TCP bandwidth benchmark only slightly regresses by about 5%. The httpd example ported to axum sees an increase in throughput by 500-600%:

before:

```
Beginning round 1...
Benchmarking 128 connections @ http://127.0.0.1:9975 for 15 second(s)
  Latencies:
    Avg      Stdev    Min      Max
    6.27ms   83.92ms  1.25ms   11608.18ms
  Requests:
    Total: 212052  Req/Sec: 14143.12
  Transfer:
    Total: 43.26 MB Transfer Rate: 2.89 MB/Sec
```

after:

```
Beginning round 1...
Benchmarking 128 connections @ http://127.0.0.1:9975 for 15 second(s)
  Latencies:
    Avg      Stdev    Min      Max
    0.57ms   0.56ms   0.12ms   209.94ms
  Requests:
    Total: 1197609 Req/Sec: 79857.55
  Transfer:
    Total: 244.29 MB Transfer Rate: 16.29 MB/Sec
```

This was suggested by @zyuiop in https://github.com/hermit-os/kernel/pull/2086#issuecomment-3846763432.