### PR TITLE
fix(fs/uhyve): Mount all uhyve directories

### DIFF
--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -259,7 +259,7 @@ pub(crate) fn init() {
 
 		let obj = Box::new(UhyveDirectory::new(Some(mount_point.to_owned())));
 		let Err(errno) = fs::FILESYSTEM.get().unwrap().mount(mount_point, obj) else {
-			return;
+			continue;
 		};
 
 		assert_eq!(errno, Errno::Badf);


### PR DESCRIPTION
This PR makes the kernel properly mount all directories again.
This was broken in [`897939e`](https://github.com/hermit-os/kernel/commit/897939e7dc635ad68dc8c66d25c6b9299cc30956#diff-29eb3ac1b2333d98cb23ddebfa9a22ccbc95de3ad60a16d3ccda78302ea6c15fL239-L265).

This problem was encountered in https://github.com/hermit-os/uhyve/pull/1287

Fixes #2302.