### PR TITLE
ci: pin Firecracker to last working version 1.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           tar -xvf opensbi-*-rv-bin.tar.xz opensbi-1.7-rv-bin/share/opensbi/lp64/generic/firmware/fw_jump.bin
       - name: Install Firecracker
         run: |
-          gh release download --repo firecracker-microvm/firecracker --pattern "firecracker-*-${{ matrix.arch }}.tgz"
+          gh release download --repo firecracker-microvm/firecracker v1.12.0 --pattern "firecracker-*-${{ matrix.arch }}.tgz"
           tar -xvf firecracker-*-${{ matrix.arch }}.tgz
 
           mkdir -p $HOME/.local/bin


### PR DESCRIPTION
A proper fix has been worked on for a while. Meanwhile, we should pin the Firecracker version. Pinning makes sense anyway to prevent such breakages.