### PR TITLE
fix(scheduler): clippy::uninlined-format-args

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -360,7 +360,7 @@ impl PerCoreScheduler {
 				core_scheduler().ready_queue.push(clone_task);
 				false
 			} else {
-				panic!("Invalid core_id {}!", core_id);
+				panic!("Invalid core_id {core_id}!");
 			}
 		};
 


### PR DESCRIPTION
This PR fixes an oversight from https://github.com/hermit-os/kernel/pull/2310.