### PR TITLE
feat(logging): add extended log filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +858,7 @@ dependencies = [
  "embedded-io",
  "endian-num",
  "enum_dispatch",
+ "env_filter",
  "fdt",
  "float-cmp",
  "free-list",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ elf-symbols = "0.1"
 embedded-io = { version = "0.7", features = ["alloc"] }
 endian-num = { version = "0.2", optional = true, features = ["linux-types"] }
 enum_dispatch = "0.3"
+env_filter = { version = "2.0.0", default-features = false }
 fdt = { version = "0.1", features = ["pretty-printing"] }
 free-list = "0.3"
 fuse-abi = { version = "0.2", optional = true, features = ["linux"] }

--- a/README.md
+++ b/README.md
@@ -38,12 +38,21 @@ If you want to build the kernel for riscv64, please use `riscv64`.
 ### Control the kernel messages verbosity
 
 This kernel uses the lightweight logging crate [log](https://github.com/rust-lang/log) to print kernel messages.
-The environment variable `HERMIT_LOG_LEVEL_FILTER` controls the verbosity. 
-You can change it by setting it at compile time to a string matching the name of a [LevelFilter](https://docs.rs/log/0.4.8/log/enum.LevelFilter.html).
-If the variable is not set, or the name doesn't match, then `LevelFilter::Info` is used by default.
+The environment variable `HERMIT_LOG_LEVEL_FILTER` controls the verbosity and follows [the env_logger format](https://docs.rs/env_logger/latest/env_logger/) but without the regex support.
+You can change it per module (including its submodules) by setting it to a string in the format `[target][=level][,...]`, where the level is a string matching the name of a [LevelFilter](https://docs.rs/log/0.4.8/log/enum.LevelFilter.html).
+If the target is omitted, the level is set as the global level. If the level is
+omitted, logs of all levels are printed for the target. A substring search
+pattern that will filter all modules can be provided after the target-level
+pairs with `/<pattern>`.
+If the variable is not set, cannot be parsed, or it does not provide a global level, then a global level `LevelFilter::Info` is used by default.
+
+> [!NOTE]
+> Although the logger only prints name of the lowest level for the kernel
+  modules, the match filter requires paths to start from the root, i.e. in the
+  format `hermit::MODULE_NAME::SUBMODULE_NAME`.
 
 ```sh
-$ HERMIT_LOG_LEVEL_FILTER=Debug cargo xtask build --arch x86_64
+$ HERMIT_LOG_LEVEL_FILTER="hermit::drivers::net=debug,smoltcp,error" cargo xtask build --arch x86_64
 ```
 
 ## Credits

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,8 +1,11 @@
+use alloc::borrow::Cow;
 use core::fmt;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 
 use anstyle::AnsiColor;
+use env_filter::Builder;
+use hermit_sync::OnceCell;
 use log::{Level, LevelFilter, Metadata, Record};
 
 use crate::arch::kernel::{core_local, processor};
@@ -12,12 +15,14 @@ pub static KERNEL_LOGGER: KernelLogger = KernelLogger::new();
 /// Data structure to filter kernel messages
 pub struct KernelLogger {
 	time: AtomicBool,
+	filter: OnceCell<env_filter::Filter>,
 }
 
 impl KernelLogger {
 	pub const fn new() -> Self {
 		Self {
 			time: AtomicBool::new(false),
+			filter: OnceCell::new(),
 		}
 	}
 
@@ -31,8 +36,8 @@ impl KernelLogger {
 }
 
 impl log::Log for KernelLogger {
-	fn enabled(&self, _: &Metadata<'_>) -> bool {
-		true
+	fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+		self.filter.get().unwrap().enabled(metadata)
 	}
 
 	fn flush(&self) {
@@ -40,7 +45,7 @@ impl log::Log for KernelLogger {
 	}
 
 	fn log(&self, record: &Record<'_>) {
-		if !self.enabled(record.metadata()) {
+		if !self.filter.get().unwrap().matches(record) {
 			return;
 		}
 
@@ -114,31 +119,19 @@ fn no_color() -> bool {
 }
 
 pub unsafe fn init() {
-	log::set_logger(&KERNEL_LOGGER).expect("Can't initialize logger");
-	// Determines LevelFilter at compile time
-	let log_level = hermit_var!("HERMIT_LOG_LEVEL_FILTER");
-	let mut max_level = LevelFilter::Info;
+	let filter = hermit_var!("HERMIT_LOG_LEVEL_FILTER").unwrap_or(Cow::from("info"));
 
-	if let Some(log_level) = log_level {
-		max_level = if log_level.eq_ignore_ascii_case("off") {
-			LevelFilter::Off
-		} else if log_level.eq_ignore_ascii_case("error") {
-			LevelFilter::Error
-		} else if log_level.eq_ignore_ascii_case("warn") {
-			LevelFilter::Warn
-		} else if log_level.eq_ignore_ascii_case("info") {
-			LevelFilter::Info
-		} else if log_level.eq_ignore_ascii_case("debug") {
-			LevelFilter::Debug
-		} else if log_level.eq_ignore_ascii_case("trace") {
-			LevelFilter::Trace
-		} else {
-			error!("Could not parse HERMIT_LOG_LEVEL_FILTER, falling back to `info`.");
-			LevelFilter::Info
-		};
+	let mut builder = Builder::new();
+	// The default. It may get overwritten by the parsed filter if it has a global level.
+	builder.filter_level(LevelFilter::Info);
+	if let Err(err) = builder.try_parse(&filter) {
+		println!("{err}");
 	}
+	let filter = builder.build();
 
-	log::set_max_level(max_level);
+	log::set_max_level(filter.filter());
+	KERNEL_LOGGER.filter.set(filter).unwrap();
+	log::set_logger(&KERNEL_LOGGER).expect("Can't initialize logger");
 }
 
 #[cfg_attr(target_arch = "riscv64", allow(unused_macros))]


### PR DESCRIPTION
~The new environment variable `HERMIT_LOG_EXTENDED_FILTER`~ allows log filters of different levels to be applied on a per module basis. ~It also allows filtering by regex.~

The new filter depends on the `env_filter` crate that was originally developed for the `env_logger` crate. Given it is from the  Rust CLI WG and the crate is not particularly big I think it is a reasonable inclusion. Alternatively, we can consider parsing the filter ourselves. ~The PR currently enables the regex filter from the crate. Since it pulls in a larger crate with it, we may consider disabling that.~ Lastly, we can also consider making the whole thing an optional feature. I wanted to go with the simplest proof of concept for now.

Some changes were needed to the `env_filter` crate for it to work with `no_std`. I think they are non-intrusive enough to be acceptable for the upstream. EDIT: They got accepted.

~The PR also includes changes to things that I noticed while reading the module.~