### PR TITLE
feat: add `uhyve` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,9 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --no-default-features --smp 4 firecracker --sudo
         if: matrix.arch == 'x86_64'
-      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --features fs uhyve --sudo
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --features fs,hermit/uhyve uhyve --sudo
         if: matrix.arch == 'x86_64'
-      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --features fs --smp 4 uhyve --sudo
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --features fs,hermit/uhyve --smp 4 uhyve --sudo
         if: matrix.arch == 'x86_64'
       - run: cargo clean
         working-directory: .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ default = [
 	"pci",
 	"smp",
 	"tcp",
+	"uhyve",
 	"virtio-fs",
 	"virtio-net",
 	"virtio-vsock",
@@ -78,10 +79,18 @@ mman = []
 ## [hermit-c]: https://github.com/hermit-os/hermit-c
 newlib = []
 
+#! ### Platform Features
+
+## Enables [Uhyve] support.
+##
+## Uhyve is a Hermit-specific _virtual machine monitor_ (VMM).
+##
+## [Uhyve]: https://github.com/hermit-os/uhyve
+uhyve = []
+
 #! ### Hardware Features
 #!
 #! [microvm]: https://www.qemu.org/docs/master/system/i386/microvm.html
-#! [Uhyve]: https://github.com/hermit-os/uhyve
 
 ## Enables _Advanced Configuration and Power Interface_ ([ACPI]) support.
 ##

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ newlib = []
 ## Uhyve is a Hermit-specific _virtual machine monitor_ (VMM).
 ##
 ## [Uhyve]: https://github.com/hermit-os/uhyve
-uhyve = []
+uhyve = ["dep:uhyve-interface"]
 
 #! ### Hardware Features
 #!
@@ -347,7 +347,7 @@ talc = { version = "5" }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
 volatile = "0.6"
-uhyve-interface = "0.2"
+uhyve-interface = { version = "0.2", optional = true }
 
 [dependencies.smoltcp]
 version = "0.13"

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -200,6 +200,7 @@ pub fn seed_entropy() -> Option<[u8; 32]> {
 }
 
 /// The halt function stops the processor until the next interrupt arrives
+#[allow(dead_code)]
 pub fn halt() {
 	aarch64_cpu::asm::wfi();
 }

--- a/src/arch/riscv64/kernel/processor.rs
+++ b/src/arch/riscv64/kernel/processor.rs
@@ -220,6 +220,7 @@ pub fn lsb(value: u64) -> Option<u32> {
 }
 
 /// The halt function stops the processor until the next interrupt arrives
+#[allow(dead_code)]
 pub fn halt() {
 	riscv::asm::wfi();
 }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "uhyve")]
 mod uhyve;
 
 use core::{fmt, mem};
@@ -15,6 +16,7 @@ use crate::executor::WakerRegistration;
 const SERIAL_BUFFER_SIZE: usize = 256;
 
 pub(crate) enum IoDevice {
+	#[cfg(feature = "uhyve")]
 	Uhyve(uhyve::UhyveSerial),
 	Uart(SerialDevice),
 	#[cfg(feature = "virtio-console")]
@@ -28,6 +30,7 @@ impl ErrorType for IoDevice {
 impl Read for IoDevice {
 	fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
 		match self {
+			#[cfg(feature = "uhyve")]
 			IoDevice::Uhyve(s) => s.read(buf),
 			IoDevice::Uart(s) => s.read(buf),
 			#[cfg(feature = "virtio-console")]
@@ -39,6 +42,7 @@ impl Read for IoDevice {
 impl ReadReady for IoDevice {
 	fn read_ready(&mut self) -> Result<bool, Self::Error> {
 		match self {
+			#[cfg(feature = "uhyve")]
 			IoDevice::Uhyve(s) => s.read_ready(),
 			IoDevice::Uart(s) => s.read_ready(),
 			#[cfg(feature = "virtio-console")]
@@ -50,6 +54,7 @@ impl ReadReady for IoDevice {
 impl Write for IoDevice {
 	fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
 		match self {
+			#[cfg(feature = "uhyve")]
 			IoDevice::Uhyve(s) => s.write_all(buf)?,
 			IoDevice::Uart(s) => s.write_all(buf)?,
 			#[cfg(feature = "virtio-console")]
@@ -149,6 +154,7 @@ pub(crate) static CONSOLE_WAKER: InterruptTicketMutex<WakerRegistration> =
 pub(crate) static CONSOLE: Lazy<InterruptTicketMutex<Console>> = Lazy::new(|| {
 	crate::CoreLocal::install();
 
+	#[cfg(feature = "uhyve")]
 	if crate::env::is_uhyve() {
 		return InterruptTicketMutex::new(Console::new(IoDevice::Uhyve(uhyve::UhyveSerial::new())));
 	}

--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -11,13 +11,14 @@ use crate::fd::socket::tcp;
 use crate::fd::socket::udp;
 #[cfg(feature = "virtio-vsock")]
 use crate::fd::socket::vsock;
-use crate::fd::stdio::{
-	ConsoleStderr, ConsoleStdin, ConsoleStdout, UhyveStderr, UhyveStdin, UhyveStdout,
-};
+use crate::fd::stdio::{ConsoleStderr, ConsoleStdin, ConsoleStdout};
+#[cfg(feature = "uhyve")]
+use crate::fd::stdio::{UhyveStderr, UhyveStdin, UhyveStdout};
 use crate::fd::{AccessPermission, ObjectInterface, PollEvent, StatusFlags};
 #[cfg(any(feature = "net", feature = "virtio-vsock"))]
 use crate::fd::{Endpoint, ListenEndpoint, SocketOption};
 use crate::fs::mem::{MemDirectoryInterface, RamFileInterface, RomFileInterface};
+#[cfg(feature = "uhyve")]
 use crate::fs::uhyve::UhyveFileHandle;
 #[cfg(feature = "virtio-fs")]
 use crate::fs::virtio_fs::{VirtioFsDirectoryHandle, VirtioFsFileHandle};
@@ -28,8 +29,11 @@ pub(crate) enum Fd {
 	ConsoleStdin(ConsoleStdin),
 	ConsoleStdout(ConsoleStdout),
 	ConsoleStderr(ConsoleStderr),
+	#[cfg(feature = "uhyve")]
 	UhyveStdin(UhyveStdin),
+	#[cfg(feature = "uhyve")]
 	UhyveStdout(UhyveStdout),
+	#[cfg(feature = "uhyve")]
 	UhyveStderr(UhyveStderr),
 	EventFd(EventFd),
 	#[cfg(feature = "tcp")]
@@ -48,6 +52,7 @@ pub(crate) enum Fd {
 	RamFileInterface(RamFileInterface),
 	MemDirectoryInterface(MemDirectoryInterface),
 	DirectoryReader(DirectoryReader),
+	#[cfg(feature = "uhyve")]
 	UhyveFileHandle(UhyveFileHandle),
 }
 
@@ -73,8 +78,11 @@ fd_from! {
 	ConsoleStdin(ConsoleStdin),
 	ConsoleStdout(ConsoleStdout),
 	ConsoleStderr(ConsoleStderr),
+	#[cfg(feature = "uhyve")]
 	UhyveStdin(UhyveStdin),
+	#[cfg(feature = "uhyve")]
 	UhyveStdout(UhyveStdout),
+	#[cfg(feature = "uhyve")]
 	UhyveStderr(UhyveStderr),
 	EventFd(EventFd),
 	#[cfg(feature = "tcp")]
@@ -93,6 +101,7 @@ fd_from! {
 	RamFileInterface(RamFileInterface),
 	MemDirectoryInterface(MemDirectoryInterface),
 	DirectoryReader(DirectoryReader),
+	#[cfg(feature = "uhyve")]
 	UhyveFileHandle(UhyveFileHandle),
 }
 
@@ -102,8 +111,11 @@ impl ObjectInterface for Fd {
 			Self::ConsoleStdin(fd) => fd,
 			Self::ConsoleStdout(fd) => fd,
 			Self::ConsoleStderr(fd) => fd,
+			#[cfg(feature = "uhyve")]
 			Self::UhyveStdin(fd) => fd,
+			#[cfg(feature = "uhyve")]
 			Self::UhyveStdout(fd) => fd,
+			#[cfg(feature = "uhyve")]
 			Self::UhyveStderr(fd) => fd,
 			Self::EventFd(fd) => fd,
 			#[cfg(feature = "tcp")]
@@ -122,6 +134,7 @@ impl ObjectInterface for Fd {
 			Self::RamFileInterface(fd) => fd,
 			Self::MemDirectoryInterface(fd) => fd,
 			Self::DirectoryReader(fd) => fd,
+			#[cfg(feature = "uhyve")]
 			Self::UhyveFileHandle(fd) => fd,
 		} {
 			async fn poll(&self, event: PollEvent) -> io::Result<PollEvent>;

--- a/src/fd/stdio/mod.rs
+++ b/src/fd/stdio/mod.rs
@@ -1,5 +1,12 @@
 mod console;
-mod uhyve;
+
+cfg_select! {
+	feature = "uhyve" => {
+		mod uhyve;
+		pub use self::uhyve::{UhyveStderr, UhyveStdin, UhyveStdout};
+	}
+	_ => {}
+}
 
 use alloc::sync::Arc;
 
@@ -7,10 +14,10 @@ use ahash::RandomState;
 use hashbrown::HashMap;
 
 pub use self::console::{ConsoleStderr, ConsoleStdin, ConsoleStdout};
-pub use self::uhyve::{UhyveStderr, UhyveStdin, UhyveStdout};
 use crate::fd::{Fd, RawFd, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 
 pub(crate) fn setup(fds: &mut HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>) {
+	#[cfg(feature = "uhyve")]
 	if crate::env::is_uhyve() {
 		let stdin = Arc::new(async_lock::RwLock::new(UhyveStdin::new().into()));
 		let stdout = Arc::new(async_lock::RwLock::new(UhyveStdout::new().into()));

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -648,6 +648,7 @@ impl VfsNode for MemDirectory {
 		)
 	}
 
+	#[cfg(any(feature = "uhyve", feature = "virtio-fs"))]
 	fn traverse_mount(&self, path: &str, obj: Box<dyn VfsNode>) -> io::Result<()> {
 		block_on(
 			async {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod mem;
+#[cfg(feature = "uhyve")]
 pub(crate) mod uhyve;
 #[cfg(feature = "virtio-fs")]
 pub(crate) mod virtio_fs;
 
 use alloc::borrow::ToOwned;
+#[cfg(any(feature = "uhyve", feature = "virtio-fs"))]
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::sync::Arc;
@@ -96,6 +98,7 @@ pub(crate) trait VfsNode: Send + Sync + fmt::Debug {
 	}
 
 	/// Mounts a file system
+	#[cfg(any(feature = "uhyve", feature = "virtio-fs"))]
 	fn traverse_mount(&self, _path: &str, _obj: Box<dyn VfsNode>) -> io::Result<()> {
 		Err(Errno::Nosys)
 	}
@@ -225,6 +228,7 @@ impl Filesystem {
 	}
 
 	/// Create new backing-fs at mountpoint mntpath
+	#[cfg(any(feature = "uhyve", feature = "virtio-fs"))]
 	pub fn mount(&self, path: &str, obj: Box<dyn VfsNode>) -> io::Result<()> {
 		debug!("Mounting {path}");
 
@@ -328,6 +332,7 @@ pub(crate) fn init() {
 	#[cfg(feature = "virtio-fs")]
 	virtio_fs::init();
 
+	#[cfg(feature = "uhyve")]
 	if crate::env::is_uhyve() {
 		uhyve::init();
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ mod shell;
 mod synch;
 pub mod syscalls;
 pub mod time;
+#[cfg(feature = "uhyve")]
 mod uhyve;
 
 mod built_info {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -264,6 +264,7 @@ pub(crate) fn shutdown(arg: i32) -> ! {
 	// print some performance statistics
 	crate::arch::kernel::print_statistics();
 
+	#[cfg(feature = "uhyve")]
 	if env::is_uhyve() {
 		crate::uhyve::shutdown(arg);
 	}


### PR DESCRIPTION
Currently, Hermit unikernels can only be specialized to which device drivers to include, but not to which VMM the unikernel is run in.

This PR enables such specialization by feature-gating the Uhyve code. This means when Uhyve is targeted, the `uhyve` feature must be enabled. Currently, this only reduces code size and dependencies for unikernels that do not target Uhyve. In a follow-up PR, I will add the `loader` feature to enable savings for unikernels that do target Uhyve.

In the grander scheme of things, going this direction allows us to nicely specialize for direct PVH support in the future (https://github.com/hermit-os/kernel/pull/2366).

Depends on https://github.com/hermit-os/hermit-rs/pull/976.
I will pull out some of the preparatory refactorings into a separate PR.