### PR TITLE
feat: add dist profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,5 +446,5 @@ lto = "thin"
 codegen-units = 1
 
 [profile.profiling]
-inherits = "release"
+inherits = "dist"
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -440,6 +440,11 @@ unreadable_literal = "warn"
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
 
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+
 [profile.profiling]
 inherits = "release"
 debug = "line-tables-only"

--- a/hermit-builtins/Cargo.toml
+++ b/hermit-builtins/Cargo.toml
@@ -9,6 +9,11 @@ libm = "0.2"
 crate-type = ["staticlib"]
 harness = false
 
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+
 [profile.profiling]
 inherits = "release"
 debug = "line-tables-only"

--- a/hermit-builtins/Cargo.toml
+++ b/hermit-builtins/Cargo.toml
@@ -15,7 +15,7 @@ lto = "thin"
 codegen-units = 1
 
 [profile.profiling]
-inherits = "release"
+inherits = "dist"
 debug = "line-tables-only"
 
 [workspace]

--- a/xtask/src/artifact.rs
+++ b/xtask/src/artifact.rs
@@ -46,7 +46,7 @@ impl Artifact {
 		if self.profile_path_component() == "profiling" {
 			self.profile_path_component()
 		} else {
-			"release"
+			"dist"
 		}
 	}
 


### PR DESCRIPTION
This PR adds a dist profile that

- enables thin LTO and
- builds with a single codegen unit.

This is what is done for `rustc` on `x86_64-linux`: [src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile#L96-L97](https://github.com/rust-lang/rust/blob/1.95.0/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile#L96-L97)

This is an alternative to https://github.com/hermit-os/kernel/pull/2085, which requires users to explicitly pass Rust flags.
Since incremental builds suffer from LTO, this PR opts for a new profile instead.

This PR also makes hermit-builtins default to the new dist profile.
Lastly, the profiling profile is rebased on the new dist profile.

### Benchmark

This benchmark is not a real-world application but a synthetic benchmark.

#### Setup

```rust
use std::fs::File;
use std::io::{Read, Write};
use std::time::Instant;

#[cfg(target_os = "hermit")]
use hermit as _;

const BUF_SIZE: usize = 8 * 1024;

fn main() {
	let mut file = File::create("/tmp/hello.txt").unwrap();
	let mut buf = vec![0; BUF_SIZE];

	let now = Instant::now();
	for _ in 0..100_000 {
		file.write(b"Hello, world!\n").unwrap();
		file.read(&mut buf).unwrap();
	}
	println!("{:?}", now.elapsed());
}
```

Default kernel features enabled.

#### Running

Kernel build time:

```bash
cargo clean && time cargo xtask build --arch x86_64 --release
```

Kernel size:

```bash
ls -lah target/x86_64/release/libhermit.a
```

App build time:

```bash
cargo clean && time cargo build --target=x86_64-unknown-hermit -Zbuild-std=std,panic_abort --release --package hello_world
```

App size:

```bash
ls -lah target/x86_64-unknown-hermit/release/hello_world
```

App runtime:

```bash
hyperfine --shell=none "qemu-system-x86_64 -display none -serial stdio -kernel kernel/hermit-loader-x86_64 -initrd target/x86_64-unknown-hermit/release/hello_world -cpu Skylake-Client -smp 1 -m 64M"
```

#### Results

| Commit   | Description | Kernel build time | Kernel size | App build time | App size | Runtime |
| -------- | ----------- | -----------------:| -----------:| --------------:| --------:| -------:|
| dd4c82a4 | Before      |           41 secs |         27M |        44 secs |     4.6M |  1.00 s |
| 12edadf0 | LTO         |           42 secs |         28M |        45 secs |     8.0M |  880 ms |
| 9aad1a4e | Single CGU  |           48 secs |         26M |        46 secs |     7.8M |  830 ms |

Depends on https://github.com/hermit-os/kernel/pull/2420.
Closes https://github.com/hermit-os/kernel/pull/2085.
Closes https://github.com/hermit-os/hermit-rs/pull/864.