### PR TITLE
feat(xtask): replace `--randomize-layout` with feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,15 @@ instrument-mcount = []
 ## This only implemented for x86-64 and AArch64 CPUs.
 kernel-stack = []
 
+## Randomizes the layout of `repr(Rust)` types.
+##
+## This enables the `-Z randomize-layout` flag.
+##
+## For details see [randomize_layout - The Rust Unstable Book].
+##
+## [randomize_layout - The Rust Unstable Book]: https://doc.rust-lang.org/stable/unstable-book/compiler-flags/randomize-layout.html
+randomize-layout = []
+
 ## Enables a kernel shell.
 ##
 ## The shell can be used for displaying the current number of received interrupts and for shutting

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -16,7 +16,7 @@ pub struct Build {
 	#[arg(long)]
 	pub instrument_mcount: bool,
 
-	/// Enable the `-Z randomize-layout` flag.
+	/// Deprecated: use `--features randomize-layout` instead.
 	#[arg(long)]
 	pub randomize_layout: bool,
 }
@@ -29,6 +29,12 @@ impl Build {
 			self.cargo_build
 				.features
 				.push("instrument-mcount".to_owned());
+		}
+
+		if self.randomize_layout {
+			self.cargo_build
+				.features
+				.push("randomize-layout".to_owned());
 		}
 
 		self.cargo_build.artifact.arch.install_for_build()?;
@@ -111,7 +117,11 @@ impl Build {
 			rustflags.push("-Cpasses=ee-instrument<post-inline>");
 		}
 
-		if self.randomize_layout {
+		if self
+			.cargo_build
+			.features()
+			.any(|feature| feature == "randomize-layout")
+		{
 			rustflags.push("-Zrandomize-layout");
 		}
 


### PR DESCRIPTION
Similar to https://github.com/hermit-os/kernel/commit/0d1d3c8fe4dadffbb24a48e89f673f92b8bbbeab, this allows us to reduce special casing of the wrapper crate's features.