### PR TITLE
feat(env): remove comptime env vars

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -97,14 +97,7 @@ pub(crate) use dbg;
 #[allow(unused_macros)]
 macro_rules! hermit_var {
 	($name:expr) => {
-		match $crate::env::var($name) {
-			::core::option::Option::Some(val) => {
-				::core::option::Option::Some(::alloc::borrow::Cow::from(val))
-			}
-			::core::option::Option::None => {
-				::core::option_env!($name).map(::alloc::borrow::Cow::Borrowed)
-			}
-		}
+		$crate::env::var($name).map(|s| s.as_str())
 	};
 }
 
@@ -117,8 +110,6 @@ pub(crate) use hermit_var;
 #[allow(unused_macros)]
 macro_rules! hermit_var_or {
 	($name:expr, $default:expr) => {
-		$crate::macros::hermit_var!($name)
-			.as_deref()
-			.unwrap_or($default)
+		$crate::macros::hermit_var!($name).unwrap_or($default)
 	};
 }


### PR DESCRIPTION
The kernel is currently compiling the value of the following environment variables into the image:

- `NO_COLOR`
- `HERMIT_LOG_LEVEL_FILTER`
- `HERMIT_MTU`
- `HERMIT_MRG_RXBUF_SIZE`
- `HERMIT_IP`
- `HERMIT_GATEWAY`
- `HERMIT_MASK`
- `HERMIT_DNS1`
- `HERMIT_DNS2`
- `UHYVE_MOUNT`

The following variables are only set via the runtime environment:

- `HERMIT_PCAP_PATH`

The following variables affect the compilation but are not visible to the kernel:

- `HERMIT_CAREFUL` (via xtask)
- `HERMIT_LOG_STATIC_MAX_LEVEL` (future, via xtask)
- `HERMIT_MANIFEST_DIR` (wrapper crate only)

This PR proposes making all kernel-visible environment variables runtime-only, since there is no inherent benefit of compiling them into the image. Instead, they should be set via kernel args (e.g., `env=NO_COLOR=1`). This avoids recompilation and forces users to not compile them into the image. This also reduces maintenance of the wrapper crate by reducing the rebuild-inducing env vars.

What are your opinions on this? I am also fine with going into the other direction, if that turns out to be the consensus.

Depends on:
- https://github.com/hermit-os/kernel/pull/2415
- https://github.com/hermit-os/kernel/pull/2638