### PR TITLE
feat(syscalls): reimplement alloc syscalls with stricter requirements

### DIFF
--- a/src/syscalls/alloc.rs
+++ b/src/syscalls/alloc.rs
@@ -1,83 +1,26 @@
-use core::alloc::{GlobalAlloc, Layout};
-use core::ptr;
+//! Alloc syscalls.
 
-use crate::mm::ALLOCATOR;
+use alloc::alloc::{alloc, alloc_zeroed, dealloc, realloc};
+use core::alloc::Layout;
 
-/// Interface to allocate memory from system heap
-///
-/// # Errors
-/// Returning a null pointer indicates that either memory is exhausted or
-/// `size` and `align` do not meet this allocator's size or alignment constraints.
-///
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc(layout_from_size_align(size, align)) }
 }
 
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!(
-			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
-		);
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
-
-	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
+	unsafe { dealloc(ptr, layout_from_size_align(size, align)) }
 }
 
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc_zeroed(layout_from_size_align(size, align)) }
 }
 
-/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
-/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
-/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
-/// deallocated, and should be considered unusable (unless of course it was transferred back to the
-/// caller again via the return value of this method). The new memory block is allocated with
-/// layout, but with the size updated to new_size.
-/// If this method returns null, then ownership of the memory block has not been transferred to this
-/// allocator, and the contents of the memory block are unaltered.
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-/// - `ptr` must be currently allocated via this allocator,
-/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// Returns null if the new layout does not meet the size and alignment constraints of the
-/// allocator, or if reallocation otherwise fails.
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_realloc(
@@ -86,70 +29,27 @@ pub unsafe extern "C" fn sys_realloc(
 	align: usize,
 	new_size: usize,
 ) -> *mut u8 {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 || new_size == 0 {
-			warn!(
-				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
-			);
-			return ptr::null_mut();
-		}
-		let layout = layout_res.unwrap();
-		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
-
-		if new_ptr.is_null() {
-			debug!(
-				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
-			);
-		} else {
-			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
-		}
-		new_ptr
-	}
+	unsafe { realloc(ptr, layout_from_size_align(size, align), new_size) }
 }
 
-/// Interface to deallocate a memory region from the system heap
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
-/// - ptr must denote a block of memory currently allocated via this allocator,
-/// - `size` and `align` must be the same values that were used to allocate that block of memory
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
+/// Deprecated
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!(
-				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
-			);
-			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
+pub unsafe extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc(layout_from_size_align(size, align)) }
 }
 
+/// Deprecated
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
-			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
+	unsafe { dealloc(ptr, layout_from_size_align(size, align)) }
+}
+
+unsafe fn layout_from_size_align(size: usize, align: usize) -> Layout {
+	if cfg!(debug_assertions) {
+		Layout::from_size_align(size, align).unwrap()
+	} else {
+		unsafe { Layout::from_size_align_unchecked(size, align) }
 	}
 }

--- a/src/syscalls/alloc.rs
+++ b/src/syscalls/alloc.rs
@@ -1,0 +1,155 @@
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr;
+
+use crate::mm::ALLOCATOR;
+
+/// Interface to allocate memory from system heap
+///
+/// # Errors
+/// Returning a null pointer indicates that either memory is exhausted or
+/// `size` and `align` do not meet this allocator's size or alignment constraints.
+///
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc(layout) };
+
+	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!(
+			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
+		);
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
+
+	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc(layout) };
+
+	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
+/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
+/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
+/// deallocated, and should be considered unusable (unless of course it was transferred back to the
+/// caller again via the return value of this method). The new memory block is allocated with
+/// layout, but with the size updated to new_size.
+/// If this method returns null, then ownership of the memory block has not been transferred to this
+/// allocator, and the contents of the memory block are unaltered.
+///
+/// # Safety
+/// This function is unsafe because undefined behavior can result if the caller does not ensure all
+/// of the following:
+/// - `ptr` must be currently allocated via this allocator,
+/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
+/// ToDO: verify if the same values for size and align always lead to the same layout
+///
+/// # Errors
+/// Returns null if the new layout does not meet the size and alignment constraints of the
+/// allocator, or if reallocation otherwise fails.
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_realloc(
+	ptr: *mut u8,
+	size: usize,
+	align: usize,
+	new_size: usize,
+) -> *mut u8 {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 || new_size == 0 {
+			warn!(
+				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
+			);
+			return ptr::null_mut();
+		}
+		let layout = layout_res.unwrap();
+		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
+
+		if new_ptr.is_null() {
+			debug!(
+				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
+			);
+		} else {
+			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
+		}
+		new_ptr
+	}
+}
+
+/// Interface to deallocate a memory region from the system heap
+///
+/// # Safety
+/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
+/// - ptr must denote a block of memory currently allocated via this allocator,
+/// - `size` and `align` must be the same values that were used to allocate that block of memory
+/// ToDO: verify if the same values for size and align always lead to the same layout
+///
+/// # Errors
+/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 {
+			warn!(
+				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
+			);
+			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
+			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
+		} else {
+			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
+		}
+		let layout = layout_res.unwrap();
+		ALLOCATOR.dealloc(ptr, layout);
+	}
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 {
+			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
+			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
+			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
+		} else {
+			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
+		}
+		let layout = layout_res.unwrap();
+		ALLOCATOR.dealloc(ptr, layout);
+	}
+}

--- a/src/syscalls/alloc_.rs
+++ b/src/syscalls/alloc_.rs
@@ -1,83 +1,26 @@
-use core::alloc::{GlobalAlloc, Layout};
-use core::ptr;
+//! Alloc syscalls.
 
-use crate::mm::ALLOCATOR;
+use alloc::alloc::{alloc, alloc_zeroed, dealloc, realloc};
+use core::alloc::Layout;
 
-/// Interface to allocate memory from system heap
-///
-/// # Errors
-/// Returning a null pointer indicates that either memory is exhausted or
-/// `size` and `align` do not meet this allocator's size or alignment constraints.
-///
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc(layout_from_size_align(size, align)) }
 }
 
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!(
-			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
-		);
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
-
-	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
+	unsafe { dealloc(ptr, layout_from_size_align(size, align)) }
 }
 
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
+pub unsafe extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc_zeroed(layout_from_size_align(size, align)) }
 }
 
-/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
-/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
-/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
-/// deallocated, and should be considered unusable (unless of course it was transferred back to the
-/// caller again via the return value of this method). The new memory block is allocated with
-/// layout, but with the size updated to new_size.
-/// If this method returns null, then ownership of the memory block has not been transferred to this
-/// allocator, and the contents of the memory block are unaltered.
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-/// - `ptr` must be currently allocated via this allocator,
-/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// Returns null if the new layout does not meet the size and alignment constraints of the
-/// allocator, or if reallocation otherwise fails.
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_realloc(
@@ -86,70 +29,27 @@ pub unsafe extern "C" fn sys_realloc(
 	align: usize,
 	new_size: usize,
 ) -> *mut u8 {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 || new_size == 0 {
-			warn!(
-				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
-			);
-			return ptr::null_mut();
-		}
-		let layout = layout_res.unwrap();
-		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
-
-		if new_ptr.is_null() {
-			debug!(
-				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
-			);
-		} else {
-			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
-		}
-		new_ptr
-	}
+	unsafe { realloc(ptr, layout_from_size_align(size, align), new_size) }
 }
 
-/// Interface to deallocate a memory region from the system heap
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
-/// - ptr must denote a block of memory currently allocated via this allocator,
-/// - `size` and `align` must be the same values that were used to allocate that block of memory
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
+/// Deprecated
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!(
-				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
-			);
-			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
+pub unsafe extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
+	unsafe { alloc(layout_from_size_align(size, align)) }
 }
 
+/// Deprecated
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
-			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
+	unsafe { dealloc(ptr, layout_from_size_align(size, align)) }
+}
+
+unsafe fn layout_from_size_align(size: usize, align: usize) -> Layout {
+	if cfg!(debug_assertions) {
+		Layout::from_size_align(size, align).unwrap()
+	} else {
+		unsafe { Layout::from_size_align_unchecked(size, align) }
 	}
 }

--- a/src/syscalls/alloc_.rs
+++ b/src/syscalls/alloc_.rs
@@ -1,0 +1,155 @@
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr;
+
+use crate::mm::ALLOCATOR;
+
+/// Interface to allocate memory from system heap
+///
+/// # Errors
+/// Returning a null pointer indicates that either memory is exhausted or
+/// `size` and `align` do not meet this allocator's size or alignment constraints.
+///
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc(layout) };
+
+	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!(
+			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
+		);
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
+
+	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
+	let layout_res = Layout::from_size_align(size, align);
+	if layout_res.is_err() || size == 0 {
+		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
+		return ptr::null_mut();
+	}
+	let layout = layout_res.unwrap();
+	let ptr = unsafe { ALLOCATOR.alloc(layout) };
+
+	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
+
+	ptr
+}
+
+/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
+/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
+/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
+/// deallocated, and should be considered unusable (unless of course it was transferred back to the
+/// caller again via the return value of this method). The new memory block is allocated with
+/// layout, but with the size updated to new_size.
+/// If this method returns null, then ownership of the memory block has not been transferred to this
+/// allocator, and the contents of the memory block are unaltered.
+///
+/// # Safety
+/// This function is unsafe because undefined behavior can result if the caller does not ensure all
+/// of the following:
+/// - `ptr` must be currently allocated via this allocator,
+/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
+/// ToDO: verify if the same values for size and align always lead to the same layout
+///
+/// # Errors
+/// Returns null if the new layout does not meet the size and alignment constraints of the
+/// allocator, or if reallocation otherwise fails.
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_realloc(
+	ptr: *mut u8,
+	size: usize,
+	align: usize,
+	new_size: usize,
+) -> *mut u8 {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 || new_size == 0 {
+			warn!(
+				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
+			);
+			return ptr::null_mut();
+		}
+		let layout = layout_res.unwrap();
+		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
+
+		if new_ptr.is_null() {
+			debug!(
+				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
+			);
+		} else {
+			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
+		}
+		new_ptr
+	}
+}
+
+/// Interface to deallocate a memory region from the system heap
+///
+/// # Safety
+/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
+/// - ptr must denote a block of memory currently allocated via this allocator,
+/// - `size` and `align` must be the same values that were used to allocate that block of memory
+/// ToDO: verify if the same values for size and align always lead to the same layout
+///
+/// # Errors
+/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 {
+			warn!(
+				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
+			);
+			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
+			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
+		} else {
+			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
+		}
+		let layout = layout_res.unwrap();
+		ALLOCATOR.dealloc(ptr, layout);
+	}
+}
+
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
+	unsafe {
+		let layout_res = Layout::from_size_align(size, align);
+		if layout_res.is_err() || size == 0 {
+			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
+			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
+			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
+		} else {
+			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
+		}
+		let layout = layout_res.unwrap();
+		ALLOCATOR.dealloc(ptr, layout);
+	}
+}

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,14 +1,12 @@
 #![allow(clippy::result_unit_err)]
 
-use alloc::boxed::Box;
-use alloc::ffi::CString;
-use alloc::vec::Vec;
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::{CStr, c_char};
 use core::marker::PhantomData;
 use core::{ptr, slice};
 
+use ::alloc::boxed::Box;
+use ::alloc::ffi::CString;
+use ::alloc::vec::Vec;
 use dirent_display::Dirent64Display;
 
 pub use self::condvar::*;
@@ -30,9 +28,9 @@ use crate::fd::{
 	dup_object, dup_object2, get_object, isatty, remove_object,
 };
 use crate::fs::{self, FileAttr, SeekWhence};
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-use crate::mm::ALLOCATOR;
 
+#[cfg(all(target_os = "none", not(feature = "common-os")))]
+mod alloc;
 mod condvar;
 mod entropy;
 mod futex;
@@ -65,163 +63,6 @@ const IOV_MAX: usize = 1024;
 
 pub(crate) fn init() {
 	init_entropy();
-}
-
-/// Interface to allocate memory from system heap
-///
-/// # Errors
-/// Returning a null pointer indicates that either memory is exhausted or
-/// `size` and `align` do not meet this allocator's size or alignment constraints.
-///
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!(
-			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
-		);
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
-
-	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
-/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
-/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
-/// deallocated, and should be considered unusable (unless of course it was transferred back to the
-/// caller again via the return value of this method). The new memory block is allocated with
-/// layout, but with the size updated to new_size.
-/// If this method returns null, then ownership of the memory block has not been transferred to this
-/// allocator, and the contents of the memory block are unaltered.
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-/// - `ptr` must be currently allocated via this allocator,
-/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// Returns null if the new layout does not meet the size and alignment constraints of the
-/// allocator, or if reallocation otherwise fails.
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_realloc(
-	ptr: *mut u8,
-	size: usize,
-	align: usize,
-	new_size: usize,
-) -> *mut u8 {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 || new_size == 0 {
-			warn!(
-				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
-			);
-			return ptr::null_mut();
-		}
-		let layout = layout_res.unwrap();
-		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
-
-		if new_ptr.is_null() {
-			debug!(
-				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
-			);
-		} else {
-			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
-		}
-		new_ptr
-	}
-}
-
-/// Interface to deallocate a memory region from the system heap
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
-/// - ptr must denote a block of memory currently allocated via this allocator,
-/// - `size` and `align` must be the same values that were used to allocate that block of memory
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!(
-				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
-			);
-			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
-			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
 }
 
 pub(crate) fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::result_unit_err)]
 
+use alloc::boxed::Box;
 use alloc::ffi::CString;
+use alloc::vec::Vec;
 #[cfg(all(target_os = "none", not(feature = "common-os")))]
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::{CStr, c_char};
@@ -223,9 +225,6 @@ pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 }
 
 pub(crate) fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {
-	use alloc::boxed::Box;
-	use alloc::vec::Vec;
-
 	let mut argv = Vec::new();
 
 	let name = Box::leak(Box::new("bin\0")).as_ptr();

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,15 +1,13 @@
 #![allow(clippy::result_unit_err)]
 
-use alloc::boxed::Box;
-use alloc::ffi::CString;
-use alloc::vec::Vec;
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::{CStr, c_char};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::{mem, ptr, slice};
 
+use alloc::boxed::Box;
+use alloc::ffi::CString;
+use alloc::vec::Vec;
 use align_address::Align;
 use dirent_display::Dirent64Display;
 
@@ -30,10 +28,10 @@ use crate::fd::{
 	dup_object, dup_object2, get_object, isatty, remove_object,
 };
 use crate::fs::{self, FileAttr, SeekWhence};
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-use crate::mm::ALLOCATOR;
 use crate::{env, init_buf};
 
+#[cfg(all(target_os = "none", not(feature = "common-os")))]
+mod alloc_;
 mod condvar;
 mod entropy;
 mod futex;
@@ -65,163 +63,6 @@ const IOV_MAX: usize = 1024;
 
 pub(crate) fn init() {
 	init_entropy();
-}
-
-/// Interface to allocate memory from system heap
-///
-/// # Errors
-/// Returning a null pointer indicates that either memory is exhausted or
-/// `size` and `align` do not meet this allocator's size or alignment constraints.
-///
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!(
-			"__sys_alloc_zeroed called with size {size:#x}, align {align:#x} is an invalid layout!"
-		);
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
-
-	trace!("__sys_alloc_zeroed: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
-	let layout_res = Layout::from_size_align(size, align);
-	if layout_res.is_err() || size == 0 {
-		warn!("__sys_malloc called with size {size:#x}, align {align:#x} is an invalid layout!");
-		return ptr::null_mut();
-	}
-	let layout = layout_res.unwrap();
-	let ptr = unsafe { ALLOCATOR.alloc(layout) };
-
-	trace!("__sys_malloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");
-
-	ptr
-}
-
-/// Shrink or grow a block of memory to the given `new_size`. The block is described by the given
-/// ptr pointer and layout. If this returns a non-null pointer, then ownership of the memory block
-/// referenced by ptr has been transferred to this allocator. The memory may or may not have been
-/// deallocated, and should be considered unusable (unless of course it was transferred back to the
-/// caller again via the return value of this method). The new memory block is allocated with
-/// layout, but with the size updated to new_size.
-/// If this method returns null, then ownership of the memory block has not been transferred to this
-/// allocator, and the contents of the memory block are unaltered.
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-/// - `ptr` must be currently allocated via this allocator,
-/// - `size` and `align` must be the same layout that was used to allocate that block of memory.
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// Returns null if the new layout does not meet the size and alignment constraints of the
-/// allocator, or if reallocation otherwise fails.
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_realloc(
-	ptr: *mut u8,
-	size: usize,
-	align: usize,
-	new_size: usize,
-) -> *mut u8 {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 || new_size == 0 {
-			warn!(
-				"__sys_realloc called with ptr {ptr:p}, size {size:#x}, align {align:#x}, new_size {new_size:#x} is an invalid layout!"
-			);
-			return ptr::null_mut();
-		}
-		let layout = layout_res.unwrap();
-		let new_ptr = ALLOCATOR.realloc(ptr, layout, new_size);
-
-		if new_ptr.is_null() {
-			debug!(
-				"__sys_realloc failed to resize ptr {ptr:p} with size {size:#x}, align {align:#x}, new_size {new_size:#x} !"
-			);
-		} else {
-			trace!("__sys_realloc: resized memory at {ptr:p}, new address {new_ptr:p}");
-		}
-		new_ptr
-	}
-}
-
-/// Interface to deallocate a memory region from the system heap
-///
-/// # Safety
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all of the following:
-/// - ptr must denote a block of memory currently allocated via this allocator,
-/// - `size` and `align` must be the same values that were used to allocate that block of memory
-/// ToDO: verify if the same values for size and align always lead to the same layout
-///
-/// # Errors
-/// May panic if debug assertions are enabled and invalid parameters `size` or `align` where passed.
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_dealloc(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!(
-				"__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
-			);
-			debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
-}
-
-#[cfg(all(target_os = "none", not(feature = "common-os")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
-	unsafe {
-		let layout_res = Layout::from_size_align(size, align);
-		if layout_res.is_err() || size == 0 {
-			warn!("__sys_free called with size {size:#x}, align {align:#x} is an invalid layout!");
-			debug_assert!(layout_res.is_err(), "__sys_free error: Invalid layout");
-			debug_assert_ne!(size, 0, "__sys_free error: size cannot be 0");
-		} else {
-			trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
-		}
-		let layout = layout_res.unwrap();
-		ALLOCATOR.dealloc(ptr, layout);
-	}
 }
 
 pub(crate) fn get_application_parameters() -> (i32, *const *const u8, *const *const u8) {


### PR DESCRIPTION
This PR reimplements the alloc syscalls similar to https://github.com/hermit-os/kernel/pull/2426.

Changes:
- No more trace logging. Alloc system calls can still be traced with `feature = "strace"` as before.
- No more argument checking. We now have the same soundness preconditions as `GlobalAlloc`.
- No more direct access to `ALLOCATOR`. We now go through Rust's `#[global_allocator]` machinery. The generated code is the same.
- Deprecating `sys_malloc()` and `sys_free()`.

The wins in performance are small, but since allocations are often in the hot path, this should be good anyway.
If useful, checks and prints could be added back in `cfg!(debug_assertions)`.

#### Benchmark

Valgrind benchmark using [Gungraun](https://gungraun.github.io/gungraun/).

```toml
# Cargo.toml
[package]
name = "alloc-benchmark"
edition = "2024"

[dev-dependencies]
gungraun = "0.18"
log = "0.4"
spinning_top = "0.3"
talc = "5"

[[bench]]
harness = false
name = "gungraun"
path = "benches/gungraun.rs"

[profile.bench]
debug = true
lto = "thin"
codegen-units = 1
```

```rust
use std::alloc::{GlobalAlloc, Layout, alloc, dealloc};
use std::hint::black_box;
use std::ptr;

use gungraun::prelude::*;
use log::{trace, warn};
use talc::TalcLock;
use talc::source::Claim;

#[global_allocator]
static TALC: TalcLock<spinning_top::RawSpinlock, Claim> = TalcLock::new(unsafe {
    static mut INITIAL_HEAP: [u8; 0x1_0000] = [0; _];

    Claim::array(&raw mut INITIAL_HEAP)
});

#[library_benchmark]
#[bench::page(0x1000, 1)]
#[bench::cache_line(128, 128)]
fn bench_new(size: usize, align: usize) {
    let size = black_box(size);
    let align = black_box(align);
    let ptr = unsafe { black_box(alloc_new(size, align)) };
    unsafe {
        dealloc_new(ptr, size, align);
    }
}

#[library_benchmark]
#[bench::page(0x1000, 1)]
#[bench::cache_line(128, 128)]
fn bench_old(size: usize, align: usize) {
    let size = black_box(size);
    let align = black_box(align);
    let ptr = unsafe { black_box(alloc_old(size, align)) };
    unsafe {
        dealloc_old(ptr, size, align);
    }
}

library_benchmark_group!(
    name = bench,
    compare_by_id = true,
    benchmarks = [bench_new, bench_old]
);

main!(library_benchmark_groups = bench);

unsafe fn alloc_new(size: usize, align: usize) -> *mut u8 {
    unsafe { alloc(layout_from_size_align(size, align)) }
}

unsafe fn dealloc_new(ptr: *mut u8, size: usize, align: usize) {
    unsafe {
        dealloc(ptr, layout_from_size_align(size, align));
    }
}

unsafe fn layout_from_size_align(size: usize, align: usize) -> Layout {
    if cfg!(debug_assertions) {
        Layout::from_size_align(size, align).unwrap()
    } else {
        unsafe { Layout::from_size_align_unchecked(size, align) }
    }
}

unsafe fn alloc_old(size: usize, align: usize) -> *mut u8 {
    let layout_res = Layout::from_size_align(size, align);
    if layout_res.is_err() || size == 0 {
        warn!("__sys_alloc called with size {size:#x}, align {align:#x} is an invalid layout!");
        return ptr::null_mut();
    }
    let layout = layout_res.unwrap();
    let ptr = unsafe { TALC.alloc(layout) };

    trace!("__sys_alloc: allocate memory at {ptr:p} (size {size:#x}, align {align:#x})");

    ptr
}

unsafe fn dealloc_old(ptr: *mut u8, size: usize, align: usize) {
    unsafe {
        let layout_res = Layout::from_size_align(size, align);
        if layout_res.is_err() || size == 0 {
            warn!(
                "__sys_dealloc called with size {size:#x}, align {align:#x} is an invalid layout!"
            );
            debug_assert!(layout_res.is_err(), "__sys_dealloc error: Invalid layout");
            debug_assert_ne!(size, 0, "__sys_dealloc error: size cannot be 0");
        } else {
            trace!("sys_free: deallocate memory at {ptr:p} (size {size:#x})");
        }
        let layout = layout_res.unwrap();
        TALC.dealloc(ptr, layout);
    }
}
```

#### Results

```console
gungraun::bench::bench_new page:(0x1000, 1)
  Instructions:                         238|238                  (No change)
  L1 Hits:                              322|322                  (No change)
  LL Hits:                                0|0                    (No change)
  RAM Hits:                               4|4                    (No change)
  Total read+write:                     326|326                  (No change)
  Estimated Cycles:                     462|462                  (No change)
gungraun::bench::bench_new cache_line:(128, 128)
  Instructions:                         250|250                  (No change)
  L1 Hits:                              331|331                  (No change)
  LL Hits:                                0|0                    (No change)
  RAM Hits:                               7|7                    (No change)
  Total read+write:                     338|338                  (No change)
  Estimated Cycles:                     576|576                  (No change)
gungraun::bench::bench_old page:(0x1000, 1)
  Instructions:                         283|283                  (No change)
  L1 Hits:                              380|380                  (No change)
  LL Hits:                                0|0                    (No change)
  RAM Hits:                               8|8                    (No change)
  Total read+write:                     388|388                  (No change)
  Estimated Cycles:                     660|660                  (No change)
  Comparison with bench_new page:(0x1000, 1)
  Instructions:                         238|283                  (-15.9011%) [-1.18908x]
  L1 Hits:                              322|380                  (-15.2632%) [-1.18012x]
  LL Hits:                                0|0                    (No change)
  RAM Hits:                               4|8                    (-50.0000%) [-2.00000x]
  Total read+write:                     326|388                  (-15.9794%) [-1.19018x]
  Estimated Cycles:                     462|660                  (-30.0000%) [-1.42857x]
gungraun::bench::bench_old cache_line:(128, 128)
  Instructions:                         295|295                  (No change)
  L1 Hits:                              388|388                  (No change)
  LL Hits:                                0|0                    (No change)
  RAM Hits:                              12|12                   (No change)
  Total read+write:                     400|400                  (No change)
  Estimated Cycles:                     808|808                  (No change)
  Comparison with bench_new cache_line:(128, 128)
  Instructions:                         250|295                  (-15.2542%) [-1.18000x]
  L1 Hits:                              331|388                  (-14.6907%) [-1.17221x]
  LL Hits:                                0|0                    (No change)
  RAM Hits:                               7|12                   (-41.6667%) [-1.71429x]
  Total read+write:                     338|400                  (-15.5000%) [-1.18343x]
  Estimated Cycles:                     576|808                  (-28.7129%) [-1.40278x]

Gungraun result: Ok. 4 without regressions; 0 regressed; 0 filtered; 4 benchmarks finished in 0.81081s
```