### PR TITLE
fix(vsock): restore listener after accept

### DIFF
--- a/src/executor/vsock.rs
+++ b/src/executor/vsock.rs
@@ -136,6 +136,11 @@ async fn vsock_run() {
 					raw.state = VsockState::Connected;
 					raw.peer_buf_alloc = header.buf_alloc.to_ne();
 					raw.peer_fwd_cnt = header.fwd_cnt.to_ne();
+					// The blocking `connect()` future parks on `rx_waker` (see
+					// `Socket::connect`'s Connecting arm), so it MUST be woken
+					// here or the connect never returns. Wake `tx_waker` too:
+					// a freshly-connected socket is immediately writable.
+					raw.rx_waker.wake();
 					raw.tx_waker.wake();
 				}
 			} else if raw.remote_cid == header_cid {

--- a/src/executor/vsock.rs
+++ b/src/executor/vsock.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, btree_map};
+use alloc::collections::{BTreeMap, VecDeque, btree_map};
 use alloc::vec::Vec;
 use core::future;
 use core::task::Poll;
@@ -13,6 +13,7 @@ use crate::arch::kernel::mmio as hardware;
 use crate::drivers::pci as hardware;
 use crate::errno::Errno;
 use crate::executor::{WakerRegistration, spawn};
+use crate::fd::socket::SOMAXCONN;
 use crate::io;
 
 pub(crate) static VSOCK_MAP: InterruptTicketMutex<VsockMap> =
@@ -34,6 +35,30 @@ pub(crate) enum VsockState {
 
 pub(crate) const RAW_SOCKET_BUFFER_SIZE: usize = 256 * 1024;
 
+/// Default depth of a listener's pending-connection backlog, used when
+/// `accept()` is called without an explicit `listen()`. Mirrors the TCP
+/// socket's `DEFAULT_BACKLOG`.
+pub(crate) const DEFAULT_BACKLOG: usize = 128;
+
+/// A pending inbound connection request waiting to be `accept()`ed, captured
+/// from an `Op::Request` packet.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingRequest {
+	pub remote_cid: u32,
+	pub remote_port: u32,
+	pub peer_buf_alloc: u32,
+}
+
+/// Identifies an established connection by its local (listen) port and the
+/// remote endpoint `(remote_cid, remote_port)`. Multiple connections may share
+/// one local port, mirroring how TCP demultiplexes by the connection 4-tuple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ConnKey {
+	pub local_port: u32,
+	pub remote_cid: u32,
+	pub remote_port: u32,
+}
+
 #[derive(Debug)]
 pub(crate) struct RawSocket {
 	pub remote_cid: u32,
@@ -46,6 +71,12 @@ pub(crate) struct RawSocket {
 	pub rx_waker: WakerRegistration,
 	pub tx_waker: WakerRegistration,
 	pub buffer: Vec<u8>,
+	/// Inbound connection requests queued on a listener, awaiting `accept()`.
+	/// Only used by listener sockets; empty for connections.
+	pub pending: VecDeque<PendingRequest>,
+	/// Maximum depth of `pending` for a listener (set by `listen()`, clamped to
+	/// `SOMAXCONN`). Further requests beyond this are reset.
+	pub backlog: usize,
 }
 
 impl RawSocket {
@@ -61,6 +92,8 @@ impl RawSocket {
 			rx_waker: WakerRegistration::new(),
 			tx_waker: WakerRegistration::new(),
 			buffer: Vec::with_capacity(RAW_SOCKET_BUFFER_SIZE),
+			pending: VecDeque::new(),
+			backlog: DEFAULT_BACKLOG,
 		}
 	}
 }
@@ -75,6 +108,9 @@ async fn vsock_run() {
 		let mut driver_guard = driver.lock();
 		let mut hdr: Option<Hdr> = None;
 		let mut fwd_cnt: u32 = 0;
+		// Force the reply to be `Op::Rst` regardless of the incoming op (used
+		// for packets addressed to a socket that no longer exists).
+		let mut force_rst: bool = false;
 
 		driver_guard.process_packet(|header, data| {
 			let op = Op::try_from(header.op.to_ne()).unwrap();
@@ -82,22 +118,62 @@ async fn vsock_run() {
 			let type_ = Type::try_from(header.type_.to_ne()).unwrap();
 			let mut vsock_guard = VSOCK_MAP.lock();
 			let header_cid: u32 = header.src_cid.to_ne().try_into().unwrap();
+			let remote_port = header.src_port.to_ne();
 
-			let Some(raw) = vsock_guard.get_mut_socket(port) else {
+			// Packets for an established connection address the local listen
+			// port but belong to a specific remote endpoint, so route them to
+			// the connection entry keyed by `(port, remote_cid, remote_port)`.
+			// `Op::Request` (and outbound-connect responses) have no such entry
+			// yet and fall back to the listener/connect socket in `port_map`.
+			let raw = if let Some(conn) = vsock_guard.get_mut_connection(ConnKey {
+				local_port: port,
+				remote_cid: header_cid,
+				remote_port,
+			}) {
+				conn
+			} else if let Some(s) = vsock_guard.get_mut_socket(port) {
+				s
+			} else {
+				// No socket owns this port: the connection is gone (or never
+				// existed). Reply `Op::Rst` so the peer tears its side down
+				// promptly instead of waiting for a close timeout — but never
+				// reset an `Rst` (that would ping-pong forever).
+				if op != Op::Rst {
+					hdr = Some(*header);
+					force_rst = true;
+				}
 				return;
 			};
 
-			if op == Op::Request && raw.state == VsockState::Listen && type_ == Type::Stream {
-				raw.state = VsockState::ReceiveRequest;
-				raw.remote_cid = header_cid;
-				raw.remote_port = header.src_port.to_ne();
-				raw.peer_buf_alloc = header.buf_alloc.to_ne();
-				raw.rx_waker.wake();
+			if op == Op::Request
+				&& (raw.state == VsockState::Listen || raw.state == VsockState::ReceiveRequest)
+				&& type_ == Type::Stream
+			{
+				// Queue the inbound request on the listener's backlog so several
+				// concurrent connects on the same port can be accepted in turn.
+				// `ReceiveRequest` means "at least one request is pending accept".
+				if raw.pending.len() < raw.backlog {
+					raw.pending.push_back(PendingRequest {
+						remote_cid: header_cid,
+						remote_port: header.src_port.to_ne(),
+						peer_buf_alloc: header.buf_alloc.to_ne(),
+					});
+					raw.state = VsockState::ReceiveRequest;
+					raw.rx_waker.wake();
+				} else {
+					// Backlog full: reset so the peer backs off and retries.
+					hdr = Some(*header);
+					fwd_cnt = raw.fwd_cnt;
+				}
 			} else if (raw.state == VsockState::Connected || raw.state == VsockState::Shutdown)
 				&& type_ == Type::Stream
 				&& op == Op::Rw
 			{
-				if raw.remote_cid == header_cid {
+				// Match the full remote endpoint, not just the CID: distinct
+				// services on one peer (e.g. two host ports) share a CID, so a
+				// stray packet from another connection's tuple must not be
+				// delivered here.
+				if raw.remote_cid == header_cid && raw.remote_port == remote_port {
 					raw.buffer.extend_from_slice(data);
 					raw.fwd_cnt = raw.fwd_cnt.wrapping_add(u32::try_from(data.len()).unwrap());
 					raw.peer_fwd_cnt = header.fwd_cnt.to_ne();
@@ -109,14 +185,14 @@ async fn vsock_run() {
 					trace!("Receive message from invalid source {header_cid}");
 				}
 			} else if op == Op::CreditUpdate {
-				if raw.remote_cid == header_cid {
+				if raw.remote_cid == header_cid && raw.remote_port == remote_port {
 					raw.peer_fwd_cnt = header.fwd_cnt.to_ne();
 					raw.tx_waker.wake();
 				} else {
 					trace!("Receive message from invalid source {header_cid}");
 				}
 			} else if op == Op::Shutdown {
-				if raw.remote_cid == header_cid {
+				if raw.remote_cid == header_cid && raw.remote_port == remote_port {
 					raw.state = VsockState::Shutdown;
 					raw.rx_waker.wake();
 					raw.tx_waker.wake();
@@ -124,7 +200,11 @@ async fn vsock_run() {
 					trace!("Receive message from invalid source {header_cid}");
 				}
 			} else if op == Op::Rst {
-				if raw.remote_cid == header_cid {
+				// A reset must come from the exact endpoint this socket is
+				// connected to. This is the arm that killed reused ephemeral
+				// ports: a delayed RST from a previously-closed connection's
+				// peer (same CID, different port) reset the port's new owner.
+				if raw.remote_cid == header_cid && raw.remote_port == remote_port {
 					raw.state = VsockState::Reset;
 					raw.rx_waker.wake();
 					raw.tx_waker.wake();
@@ -132,7 +212,10 @@ async fn vsock_run() {
 					trace!("Receive message from invalid source {header_cid}");
 				}
 			} else if op == Op::Response && type_ == Type::Stream {
-				if raw.remote_cid == header_cid && raw.state == VsockState::Connecting {
+				if raw.remote_cid == header_cid
+					&& raw.remote_port == remote_port
+					&& raw.state == VsockState::Connecting
+				{
 					raw.state = VsockState::Connected;
 					raw.peer_buf_alloc = header.buf_alloc.to_ne();
 					raw.peer_fwd_cnt = header.fwd_cnt.to_ne();
@@ -143,6 +226,12 @@ async fn vsock_run() {
 					raw.rx_waker.wake();
 					raw.tx_waker.wake();
 				}
+			} else if op == Op::Request {
+				// A request that did not match the listener backlog arm above
+				// (e.g. addressed to a non-listening socket). Reset so the peer
+				// fails fast instead of blocking until it times out.
+				hdr = Some(*header);
+				fwd_cnt = raw.fwd_cnt;
 			} else if raw.remote_cid == header_cid {
 				hdr = Some(*header);
 				fwd_cnt = raw.fwd_cnt;
@@ -159,8 +248,9 @@ async fn vsock_run() {
 				response.dst_port = hdr.src_port;
 				response.len = le32::from_ne(0);
 				response.type_ = hdr.type_;
-				if hdr.op.to_ne() == u16::from(Op::CreditRequest)
-					|| hdr.op.to_ne() == u16::from(Op::Rw)
+				if !force_rst
+					&& (hdr.op.to_ne() == u16::from(Op::CreditRequest)
+						|| hdr.op.to_ne() == u16::from(Op::Rw))
 				{
 					response.op = le16::from_ne(Op::CreditUpdate.into());
 				} else {
@@ -180,14 +270,30 @@ async fn vsock_run() {
 	.await;
 }
 
+/// Start of the ephemeral port range used for outbound connects.
+const EPHEMERAL_START: u32 = u32::MAX / 4;
+
 pub(crate) struct VsockMap {
+	/// Listeners (keyed by listen port) and outbound-connect sockets (keyed by
+	/// a synthetic ephemeral port).
 	port_map: BTreeMap<u32, RawSocket>,
+	/// Established inbound connections, keyed by `(local_port, remote_cid,
+	/// remote_port)`, so several connections can share one listen port.
+	conn_map: BTreeMap<ConnKey, RawSocket>,
+	/// Next ephemeral port to try for an outbound connect. Cycles through
+	/// `[EPHEMERAL_START, u32::MAX]` instead of always taking the first vacant
+	/// port, so a just-freed port is not immediately reused: late packets
+	/// addressed to the previous owner (e.g. a peer's delayed close `Rst`)
+	/// would otherwise hit the new connection.
+	next_ephemeral: u32,
 }
 
 impl VsockMap {
 	pub const fn new() -> Self {
 		Self {
 			port_map: BTreeMap::new(),
+			conn_map: BTreeMap::new(),
+			next_ephemeral: EPHEMERAL_START,
 		}
 	}
 
@@ -203,31 +309,81 @@ impl VsockMap {
 		}
 	}
 
-	pub fn connect(&mut self, port: u32, cid: u32) -> io::Result<u32> {
-		for i in u32::MAX / 4..u32::MAX {
-			let mut raw = RawSocket::new(VsockState::Connecting);
-			raw.remote_cid = cid;
-			raw.remote_port = port;
+	/// Set the pending-connection backlog depth for the listener on `port`,
+	/// clamped to `SOMAXCONN`.
+	pub fn set_backlog(&mut self, port: u32, backlog: usize) -> io::Result<()> {
+		let listener = self.port_map.get_mut(&port).ok_or(Errno::Inval)?;
+		listener.backlog = backlog.min(SOMAXCONN as usize);
+		Ok(())
+	}
 
-			if let btree_map::Entry::Vacant(vacant_entry) = self.port_map.entry(i) {
+	pub fn connect(&mut self, port: u32, cid: u32) -> io::Result<u32> {
+		for _ in 0..=(u32::MAX - EPHEMERAL_START) {
+			let candidate = self.next_ephemeral;
+			self.next_ephemeral = if candidate == u32::MAX {
+				EPHEMERAL_START
+			} else {
+				candidate + 1
+			};
+
+			if let btree_map::Entry::Vacant(vacant_entry) = self.port_map.entry(candidate) {
+				let mut raw = RawSocket::new(VsockState::Connecting);
+				raw.remote_cid = cid;
+				raw.remote_port = port;
 				vacant_entry.insert(raw);
-				return Ok(i);
+				return Ok(candidate);
 			}
 		}
 
 		Err(Errno::Badf)
 	}
 
-	pub fn get_socket(&self, port: u32) -> Option<&RawSocket> {
-		self.port_map.get(&port)
-	}
-
 	pub fn get_mut_socket(&mut self, port: u32) -> Option<&mut RawSocket> {
 		self.port_map.get_mut(&port)
 	}
 
+	pub fn get_mut_connection(&mut self, key: ConnKey) -> Option<&mut RawSocket> {
+		self.conn_map.get_mut(&key)
+	}
+
 	pub fn remove_socket(&mut self, port: u32) {
 		self.port_map.remove(&port);
+	}
+
+	pub fn remove_connection(&mut self, key: ConnKey) {
+		self.conn_map.remove(&key);
+	}
+
+	/// Pop the next pending request from the listener on `listen_port`'s backlog,
+	/// move it into `conn_map` keyed by `(listen_port, remote_cid, remote_port)`,
+	/// and return the new connection's key. The listener stays in
+	/// `ReceiveRequest` while more requests remain queued, otherwise returns to
+	/// `Listen`. Resetting fields in place preserves the listener's wakers, so an
+	/// `accept()` future already parked on it is not lost.
+	pub fn establish(&mut self, listen_port: u32) -> io::Result<ConnKey> {
+		let listener = self.port_map.get_mut(&listen_port).ok_or(Errno::Inval)?;
+		let req = listener.pending.pop_front().ok_or(Errno::Again)?;
+		let key = ConnKey {
+			local_port: listen_port,
+			remote_cid: req.remote_cid,
+			remote_port: req.remote_port,
+		};
+
+		let mut conn = RawSocket::new(VsockState::Connected);
+		conn.remote_cid = req.remote_cid;
+		conn.remote_port = req.remote_port;
+		conn.peer_buf_alloc = req.peer_buf_alloc;
+
+		// Stay in ReceiveRequest if more requests are queued so `accept()` keeps
+		// draining them; otherwise go back to plain Listen.
+		listener.state = if listener.pending.is_empty() {
+			VsockState::Listen
+		} else {
+			VsockState::ReceiveRequest
+		};
+
+		self.conn_map.insert(key, conn);
+		Ok(key)
 	}
 }
 

--- a/src/executor/vsock.rs
+++ b/src/executor/vsock.rs
@@ -24,7 +24,12 @@ pub(crate) enum VsockState {
 	ReceiveRequest,
 	Connected,
 	Connecting,
+	/// The peer sent a graceful `Op::Shutdown`. Buffered data may still be
+	/// read; once drained, reads report EOF.
 	Shutdown,
+	/// The peer (or the device) sent an abortive `Op::Rst`. Buffered data may
+	/// still be read; once drained, reads report `ECONNRESET`.
+	Reset,
 }
 
 pub(crate) const RAW_SOCKET_BUFFER_SIZE: usize = 256 * 1024;
@@ -113,6 +118,16 @@ async fn vsock_run() {
 			} else if op == Op::Shutdown {
 				if raw.remote_cid == header_cid {
 					raw.state = VsockState::Shutdown;
+					raw.rx_waker.wake();
+					raw.tx_waker.wake();
+				} else {
+					trace!("Receive message from invalid source {header_cid}");
+				}
+			} else if op == Op::Rst {
+				if raw.remote_cid == header_cid {
+					raw.state = VsockState::Reset;
+					raw.rx_waker.wake();
+					raw.tx_waker.wake();
 				} else {
 					trace!("Receive message from invalid source {header_cid}");
 				}

--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -44,8 +44,6 @@ pub(crate) enum Fd {
 	#[cfg(feature = "udp")]
 	UdpSocket(udp::Socket),
 	#[cfg(feature = "virtio-vsock")]
-	VsockNullSocket(vsock::NullSocket),
-	#[cfg(feature = "virtio-vsock")]
 	VsockSocket(vsock::Socket),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFsFileHandle(VirtioFsFileHandle),
@@ -94,8 +92,6 @@ fd_from! {
 	#[cfg(feature = "udp")]
 	UdpSocket(udp::Socket),
 	#[cfg(feature = "virtio-vsock")]
-	VsockNullSocket(vsock::NullSocket),
-	#[cfg(feature = "virtio-vsock")]
 	VsockSocket(vsock::Socket),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFsFileHandle(VirtioFsFileHandle),
@@ -127,8 +123,6 @@ impl ObjectInterface for Fd {
 			Self::TcpSocket(fd) => fd,
 			#[cfg(feature = "udp")]
 			Self::UdpSocket(fd) => fd,
-			#[cfg(feature = "virtio-vsock")]
-			Self::VsockNullSocket(fd) => fd,
 			#[cfg(feature = "virtio-vsock")]
 			Self::VsockSocket(fd) => fd,
 			#[cfg(feature = "virtio-fs")]

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -1,6 +1,15 @@
+#![cfg_attr(not(feature = "tcp"), expect(dead_code))]
+
 #[cfg(feature = "tcp")]
 pub(crate) mod tcp;
 #[cfg(feature = "udp")]
 pub(crate) mod udp;
 #[cfg(feature = "virtio-vsock")]
 pub(crate) mod vsock;
+
+/// Further receives will be disallowed
+pub const SHUT_RD: i32 = 0;
+/// Further sends will be disallowed
+pub const SHUT_WR: i32 = 1;
+/// Further sends and receives will be disallowed
+pub const SHUT_RDWR: i32 = 2;

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -16,3 +16,7 @@ pub const SHUT_RDWR: i32 = 2;
 
 /// The default queue size for incoming connections
 pub const DEFAULT_BACKLOG: i32 = 128;
+
+/// The maximum queue size for incoming connections,
+/// based on the default maximum used by modern Linux.
+pub const SOMAXCONN: i32 = 4096;

--- a/src/fd/socket/mod.rs
+++ b/src/fd/socket/mod.rs
@@ -13,3 +13,6 @@ pub const SHUT_RD: i32 = 0;
 pub const SHUT_WR: i32 = 1;
 /// Further sends and receives will be disallowed
 pub const SHUT_RDWR: i32 = 2;
+
+/// The default queue size for incoming connections
+pub const DEFAULT_BACKLOG: i32 = 128;

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -10,7 +10,7 @@ use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
 
-use super::{SHUT_RD, SHUT_RDWR, SHUT_WR};
+use super::{DEFAULT_BACKLOG, SHUT_RD, SHUT_RDWR, SHUT_WR};
 use crate::config::DEFAULT_KEEP_ALIVE_INTERVAL;
 use crate::errno::Errno;
 use crate::executor::block_on;
@@ -19,8 +19,6 @@ use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent, 
 use crate::io;
 use crate::syscalls::socket::Af;
 
-/// The default queue size for incoming connections
-pub const DEFAULT_BACKLOG: i32 = 128;
 /// The maximum queue size for incoming connections,
 /// based on the default maximum used by modern Linux.
 pub const SOMAXCONN: i32 = 4096;

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -10,6 +10,7 @@ use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
 
+use super::{SHUT_RD, SHUT_RDWR, SHUT_WR};
 use crate::config::DEFAULT_KEEP_ALIVE_INTERVAL;
 use crate::errno::Errno;
 use crate::executor::block_on;
@@ -18,12 +19,6 @@ use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent, 
 use crate::io;
 use crate::syscalls::socket::Af;
 
-/// Further receives will be disallowed
-pub const SHUT_RD: i32 = 0;
-/// Further sends will be disallowed
-pub const SHUT_WR: i32 = 1;
-/// Further sends and receives will be disallowed
-pub const SHUT_RDWR: i32 = 2;
 /// The default queue size for incoming connections
 pub const DEFAULT_BACKLOG: i32 = 128;
 /// The maximum queue size for incoming connections,

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -10,7 +10,7 @@ use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
 
-use super::{DEFAULT_BACKLOG, SHUT_RD, SHUT_RDWR, SHUT_WR};
+use super::{DEFAULT_BACKLOG, SHUT_RD, SHUT_RDWR, SHUT_WR, SOMAXCONN};
 use crate::config::DEFAULT_KEEP_ALIVE_INTERVAL;
 use crate::errno::Errno;
 use crate::executor::block_on;
@@ -18,10 +18,6 @@ use crate::executor::network::{Handle, NIC, wake_network_waker};
 use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
 use crate::io;
 use crate::syscalls::socket::Af;
-
-/// The maximum queue size for incoming connections,
-/// based on the default maximum used by modern Linux.
-pub const SOMAXCONN: i32 = 4096;
 
 fn get_ephemeral_port() -> u16 {
 	static LOCAL_ENDPOINT: AtomicU16 = AtomicU16::new(49152);

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -6,12 +6,13 @@ use core::task::Poll;
 use virtio::vsock::{Hdr, Op, Type};
 use virtio::{le16, le32, le64};
 
+use super::{SHUT_RD, SHUT_RDWR, SHUT_WR};
 #[cfg(not(feature = "pci"))]
 use crate::arch::kernel::mmio as hardware;
 #[cfg(feature = "pci")]
 use crate::drivers::pci as hardware;
 use crate::errno::Errno;
-use crate::executor::vsock::{VSOCK_MAP, VsockState};
+use crate::executor::vsock::{ConnKey, RawSocket, VSOCK_MAP, VsockMap, VsockState};
 use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent};
 use crate::io;
 
@@ -39,18 +40,14 @@ impl VsockEndpoint {
 	}
 }
 
-pub struct NullSocket;
-
-impl NullSocket {
-	pub const fn new() -> Self {
-		Self {}
-	}
-}
-
-impl ObjectInterface for NullSocket {}
-
 pub struct Socket {
+	/// The local port this socket is bound/listening on, or the synthetic
+	/// ephemeral port of an outbound connection.
 	port: u32,
+	/// Set for sockets returned by `accept`: identifies the established
+	/// connection in the executor's connection map. `None` for listeners and
+	/// outbound-connect sockets, which are keyed by `port` instead.
+	conn: Option<ConnKey>,
 	cid: u32,
 	is_nonblocking: bool,
 }
@@ -59,8 +56,19 @@ impl Socket {
 	pub fn new() -> Self {
 		Self {
 			port: 0,
+			conn: None,
 			cid: u32::MAX,
 			is_nonblocking: false,
+		}
+	}
+
+	/// Borrow this socket's `RawSocket` from the executor map, whether it is a
+	/// listener/connect socket (keyed by `port`) or an accepted connection
+	/// (keyed by `conn`).
+	fn raw_mut<'a>(&self, map: &'a mut VsockMap) -> Option<&'a mut RawSocket> {
+		match self.conn {
+			Some(key) => map.get_mut_connection(key),
+			None => map.get_mut_socket(self.port),
 		}
 	}
 }
@@ -69,7 +77,7 @@ impl ObjectInterface for Socket {
 	async fn poll(&self, event: PollEvent) -> io::Result<PollEvent> {
 		future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
-			let raw = guard.get_mut_socket(self.port).ok_or(Errno::Inval)?;
+			let raw = self.raw_mut(&mut guard).ok_or(Errno::Inval)?;
 
 			match raw.state {
 				VsockState::Shutdown | VsockState::ReceiveRequest => {
@@ -235,8 +243,8 @@ impl ObjectInterface for Socket {
 	}
 
 	async fn getpeername(&self) -> io::Result<Option<Endpoint>> {
-		let guard = VSOCK_MAP.lock();
-		let raw = guard.get_socket(self.port).ok_or(Errno::Inval)?;
+		let mut guard = VSOCK_MAP.lock();
+		let raw = self.raw_mut(&mut guard).ok_or(Errno::Inval)?;
 
 		Ok(Some(Endpoint::Vsock(VsockEndpoint::new(
 			raw.remote_port,
@@ -253,14 +261,19 @@ impl ObjectInterface for Socket {
 		))))
 	}
 
-	async fn listen(&mut self, _backlog: i32) -> io::Result<()> {
-		Ok(())
+	async fn listen(&mut self, backlog: i32) -> io::Result<()> {
+		if backlog <= 0 {
+			return Err(Errno::Inval);
+		}
+		VSOCK_MAP
+			.lock()
+			.set_backlog(self.port, usize::try_from(backlog).unwrap())
 	}
 
 	async fn accept(&mut self) -> io::Result<(Arc<async_lock::RwLock<Fd>>, Endpoint)> {
 		let port = self.port;
 
-		let endpoint = future::poll_fn(|cx| {
+		let (conn_key, endpoint) = future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
 			let raw = guard.get_mut_socket(port).ok_or(Errno::Inval)?;
 
@@ -274,48 +287,79 @@ impl ObjectInterface for Socket {
 					}
 				}
 				VsockState::ReceiveRequest => {
-					let result = {
-						const HEADER_SIZE: usize = size_of::<Hdr>();
-						let mut driver_guard = hardware::get_vsock_driver().unwrap().lock();
-						let local_cid = driver_guard.get_cid();
-
-						driver_guard.send_packet(HEADER_SIZE, |buffer| {
-							let response = unsafe { &mut *buffer.as_mut_ptr().cast::<Hdr>() };
-
-							response.src_cid = le64::from_ne(local_cid);
-							response.dst_cid = le64::from_ne(raw.remote_cid.into());
-							response.src_port = le32::from_ne(port);
-							response.dst_port = le32::from_ne(raw.remote_port);
-							response.len = le32::from_ne(0);
-							response.type_ = le16::from_ne(Type::Stream.into());
-							response.op = le16::from_ne(Op::Response.into());
-							response.flags = le32::from_ne(0);
-							response.buf_alloc = le32::from_ne(
-								crate::executor::vsock::RAW_SOCKET_BUFFER_SIZE as u32,
-							);
-							response.fwd_cnt = le32::from_ne(raw.fwd_cnt);
-						});
-
-						raw.state = VsockState::Connected;
-
-						Ok(VsockEndpoint::new(raw.remote_port, raw.remote_cid))
+					// Peek the head of the listener's backlog to build the
+					// handshake response for the request we're about to accept.
+					let Some(req) = raw.pending.front().copied() else {
+						// Spurious ReceiveRequest with an empty queue: wait.
+						raw.rx_waker.register(cx.waker());
+						return Poll::Pending;
 					};
+					let fwd_cnt = raw.fwd_cnt;
 
-					Poll::Ready(result)
+					const HEADER_SIZE: usize = size_of::<Hdr>();
+					let mut driver_guard = hardware::get_vsock_driver().unwrap().lock();
+					let local_cid = driver_guard.get_cid();
+
+					driver_guard.send_packet(HEADER_SIZE, |buffer| {
+						let response = unsafe { &mut *buffer.as_mut_ptr().cast::<Hdr>() };
+
+						response.src_cid = le64::from_ne(local_cid);
+						response.dst_cid = le64::from_ne(req.remote_cid.into());
+						response.src_port = le32::from_ne(port);
+						response.dst_port = le32::from_ne(req.remote_port);
+						response.len = le32::from_ne(0);
+						response.type_ = le16::from_ne(Type::Stream.into());
+						response.op = le16::from_ne(Op::Response.into());
+						response.flags = le32::from_ne(0);
+						response.buf_alloc =
+							le32::from_ne(crate::executor::vsock::RAW_SOCKET_BUFFER_SIZE as u32);
+						response.fwd_cnt = le32::from_ne(fwd_cnt);
+					});
+					drop(driver_guard);
+
+					let endpoint = VsockEndpoint::new(req.remote_port, req.remote_cid);
+
+					// Pop the request into the connection map. If more requests
+					// remain queued, re-wake so a subsequent `accept()` drains
+					// them (the listener stays in ReceiveRequest).
+					let conn_key = guard.establish(port)?;
+					if let Some(listener) = guard.get_mut_socket(port)
+						&& !listener.pending.is_empty()
+					{
+						listener.rx_waker.wake();
+					}
+
+					Poll::Ready(Ok((conn_key, endpoint)))
 				}
 				_ => Poll::Ready(Err(Errno::Badf)),
 			}
 		})
 		.await?;
 
+		// Return the accepted connection as a DISTINCT Socket addressing the
+		// established connection. The listener `self` is left untouched, so it
+		// keeps accepting further connections on the same port.
+		let conn = Socket {
+			port,
+			conn: Some(conn_key),
+			cid: self.cid,
+			is_nonblocking: self.is_nonblocking,
+		};
+
 		Ok((
-			Arc::new(async_lock::RwLock::new(NullSocket::new().into())),
+			Arc::new(async_lock::RwLock::new(conn.into())),
 			Endpoint::Vsock(endpoint),
 		))
 	}
 
-	async fn shutdown(&self, _how: i32) -> io::Result<()> {
-		Ok(())
+	async fn shutdown(&self, how: i32) -> io::Result<()> {
+		// Validate `how` for parity with the other socket types. This does not
+		// yet emit an `Op::Shutdown` to the peer, so a remote `read` is not
+		// woken with EOF by a local shutdown.
+		match how {
+			SHUT_RD | SHUT_WR | SHUT_RDWR => Ok(()),
+			_ => Err(Errno::Inval),
+		}
 	}
 
 	async fn status_flags(&self) -> io::Result<fd::StatusFlags> {
@@ -334,10 +378,9 @@ impl ObjectInterface for Socket {
 	}
 
 	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-		let port = self.port;
 		future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
-			let raw = guard.get_mut_socket(port).ok_or(Errno::Inval)?;
+			let raw = self.raw_mut(&mut guard).ok_or(Errno::Inval)?;
 
 			match raw.state {
 				VsockState::Connected => {
@@ -389,7 +432,7 @@ impl ObjectInterface for Socket {
 		let port = self.port;
 		future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
-			let raw = guard.get_mut_socket(port).ok_or(Errno::Inval)?;
+			let raw = self.raw_mut(&mut guard).ok_or(Errno::Inval)?;
 			let diff = raw.tx_cnt.abs_diff(raw.peer_fwd_cnt);
 
 			match raw.state {
@@ -449,7 +492,65 @@ impl ObjectInterface for Socket {
 
 impl Drop for Socket {
 	fn drop(&mut self) {
-		let mut guard = VSOCK_MAP.lock();
-		guard.remove_socket(self.port);
+		// Remove our state and snapshot the peer first, releasing VSOCK_MAP
+		// before touching the driver: the RX dispatch locks driver -> VSOCK_MAP,
+		// so holding VSOCK_MAP while taking the driver lock would invert the
+		// lock order.
+		let peer = {
+			let mut guard = VSOCK_MAP.lock();
+			match self.conn {
+				Some(key) => {
+					let peer = guard
+						.get_mut_connection(key)
+						.map(|raw| (raw.state, raw.remote_cid, raw.remote_port, key.local_port));
+					guard.remove_connection(key);
+					peer
+				}
+				None => {
+					let peer = guard
+						.get_mut_socket(self.port)
+						.map(|raw| (raw.state, raw.remote_cid, raw.remote_port, self.port));
+					guard.remove_socket(self.port);
+					peer
+				}
+			}
+		};
+
+		// Complete the close handshake: tell the peer this connection is gone.
+		// Without this the peer never learns the socket died. A peer that
+		// closed first (half-open) sits in its close timeout (~8 s on Linux
+		// virtio-vsock) and then fires an `Op::Rst` at our local port — which
+		// the ephemeral allocator may have already handed to a NEW connection.
+		// A peer with the connection still open blocks in `read()` forever.
+		// Only states with a live peer are notified.
+		let Some((state, remote_cid, remote_port, local_port)) = peer else {
+			return;
+		};
+		if !matches!(
+			state,
+			VsockState::Connected | VsockState::Shutdown | VsockState::Connecting
+		) {
+			return;
+		}
+		if let Some(driver) = hardware::get_vsock_driver() {
+			const HEADER_SIZE: usize = size_of::<Hdr>();
+			let mut driver_guard = driver.lock();
+			let local_cid = driver_guard.get_cid();
+			driver_guard.send_packet(HEADER_SIZE, |buffer| {
+				let response = unsafe { &mut *buffer.as_mut_ptr().cast::<Hdr>() };
+
+				response.src_cid = le64::from_ne(local_cid);
+				response.dst_cid = le64::from_ne(remote_cid.into());
+				response.src_port = le32::from_ne(local_port);
+				response.dst_port = le32::from_ne(remote_port);
+				response.len = le32::from_ne(0);
+				response.type_ = le16::from_ne(Type::Stream.into());
+				response.op = le16::from_ne(Op::Rst.into());
+				response.flags = le32::from_ne(0);
+				response.buf_alloc =
+					le32::from_ne(crate::executor::vsock::RAW_SOCKET_BUFFER_SIZE as u32);
+				response.fwd_cnt = le32::from_ne(0);
+			});
+		}
 	}
 }

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -152,12 +152,19 @@ impl ObjectInterface for Socket {
 	async fn bind(&mut self, endpoint: ListenEndpoint) -> io::Result<()> {
 		match endpoint {
 			ListenEndpoint::Vsock(ep) => {
-				self.port = ep.port;
-				if let Some(cid) = ep.cid {
-					self.cid = cid;
-				} else {
-					self.cid = u32::MAX;
+				// A socket may only listen on `VMADDR_CID_ANY` or this guest's
+				// own CID. Binding to any other CID is rejected, mirroring Linux
+				// `AF_VSOCK` (which returns `EADDRNOTAVAIL`).
+				let cid = ep.cid.unwrap_or(u32::MAX);
+				if cid != u32::MAX {
+					let local_cid = hardware::get_vsock_driver().unwrap().lock().get_cid();
+					if u64::from(cid) != local_cid {
+						return Err(Errno::Addrnotavail);
+					}
 				}
+
+				self.port = ep.port;
+				self.cid = cid;
 				VSOCK_MAP.lock().bind(ep.port)
 			}
 			#[cfg(feature = "net")]
@@ -252,7 +259,6 @@ impl ObjectInterface for Socket {
 
 	async fn accept(&mut self) -> io::Result<(Arc<async_lock::RwLock<Fd>>, Endpoint)> {
 		let port = self.port;
-		let cid = self.cid;
 
 		let endpoint = future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
@@ -282,11 +288,7 @@ impl ObjectInterface for Socket {
 							response.dst_port = le32::from_ne(raw.remote_port);
 							response.len = le32::from_ne(0);
 							response.type_ = le16::from_ne(Type::Stream.into());
-							if local_cid != u64::from(cid) && cid != u32::MAX {
-								response.op = le16::from_ne(Op::Rst.into());
-							} else {
-								response.op = le16::from_ne(Op::Response.into());
-							}
+							response.op = le16::from_ne(Op::Response.into());
 							response.flags = le32::from_ne(0);
 							response.buf_alloc = le32::from_ne(
 								crate::executor::vsock::RAW_SOCKET_BUFFER_SIZE as u32,

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -88,6 +88,20 @@ impl ObjectInterface for Socket {
 						Poll::Ready(Ok(ret))
 					}
 				}
+				VsockState::Reset => {
+					// Reset is readable/writable so the next read/write
+					// observes ECONNRESET, and signals error + hangup.
+					let available = PollEvent::POLLIN
+						| PollEvent::POLLRDNORM
+						| PollEvent::POLLRDBAND
+						| PollEvent::POLLOUT
+						| PollEvent::POLLWRNORM
+						| PollEvent::POLLWRBAND;
+
+					Poll::Ready(Ok((event & available)
+						| PollEvent::POLLERR
+						| PollEvent::POLLHUP))
+				}
 				VsockState::Listen | VsockState::Connecting => {
 					raw.rx_waker.register(cx.waker());
 					raw.tx_waker.register(cx.waker());
@@ -200,6 +214,9 @@ impl ObjectInterface for Socket {
 							raw.rx_waker.register(cx.waker());
 							Poll::Pending
 						}
+						// A reset in response to our request means the peer
+						// refused the connection.
+						VsockState::Reset => Poll::Ready(Err(Errno::Connrefused)),
 						_ => Poll::Ready(Err(Errno::Badf)),
 					}
 				})
@@ -338,19 +355,29 @@ impl ObjectInterface for Socket {
 						Poll::Ready(Ok(len))
 					}
 				}
-				VsockState::Shutdown => {
+				VsockState::Shutdown | VsockState::Reset => {
 					let len = core::cmp::min(buf.len(), raw.buffer.len());
 
-					if len == 0 {
-						Poll::Ready(Ok(0))
-					} else {
+					if len != 0 {
+						// Deliver any data buffered before the peer closed or
+						// reset the connection.
 						let tmp: Vec<_> = raw.buffer.drain(..len).collect();
 						buf[..len].copy_from_slice(tmp.as_slice());
 
 						Poll::Ready(Ok(len))
+					} else if raw.state == VsockState::Reset {
+						// Abortive close with no remaining data: surface
+						// ECONNRESET, matching Linux `AF_VSOCK`.
+						Poll::Ready(Err(Errno::Connreset))
+					} else {
+						// Graceful shutdown, buffer drained: report EOF.
+						Poll::Ready(Ok(0))
 					}
 				}
-				_ => Poll::Ready(Err(Errno::Io)),
+				// A connection-keyed socket only ever holds Connected, Shutdown,
+				// or Reset; the remaining states cannot occur here. Treat them
+				// as EOF defensively.
+				_ => Poll::Ready(Ok(0)),
 			}
 		})
 		.await
@@ -406,7 +433,12 @@ impl ObjectInterface for Socket {
 						Poll::Ready(Ok(len))
 					}
 				}
-				_ => Poll::Ready(Err(Errno::Io)),
+				// Peer reset the connection: writing fails with ECONNRESET.
+				VsockState::Reset => Poll::Ready(Err(Errno::Connreset)),
+				// Peer closed its receive half (graceful shutdown) or the
+				// connection is otherwise gone: writing fails with EPIPE,
+				// matching Linux `AF_VSOCK`.
+				_ => Poll::Ready(Err(Errno::Pipe)),
 			}
 		})
 		.await

--- a/src/syscalls/socket/mod.rs
+++ b/src/syscalls/socket/mod.rs
@@ -684,7 +684,10 @@ pub unsafe extern "C" fn sys_accept(
 		|v| {
 			block_on(async { v.write().await.accept().await }, None).map_or_else(
 				|e| -i32::from(e),
-				#[cfg_attr(not(feature = "net"), expect(unused_variables))]
+				#[cfg_attr(
+					not(any(feature = "net", feature = "virtio-vsock")),
+					expect(unused_variables)
+				)]
 				|(obj, endpoint)| match endpoint {
 					#[cfg(feature = "net")]
 					Endpoint::Ip(endpoint) => {
@@ -717,7 +720,7 @@ pub unsafe extern "C" fn sys_accept(
 					}
 					#[cfg(feature = "virtio-vsock")]
 					Endpoint::Vsock(endpoint) => {
-						let new_fd = insert_object(v.clone()).unwrap();
+						let new_fd = insert_object(obj).unwrap();
 
 						if !addr.is_null() && !addrlen.is_null() {
 							let addrlen = unsafe { &mut *addrlen };

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -182,7 +182,11 @@ impl Qemu {
 					.iter()
 					.flat_map(|s| s.split(&[' ', ','][..]))
 					.any(|feature| feature == "client");
-				test_vsock(has_client)?;
+				if has_client {
+					test_vsock_client()?;
+				} else {
+					test_vsock_server()?;
+				}
 			}
 			_ => {}
 		}
@@ -610,16 +614,7 @@ fn test_stdin(child: &mut Child) -> Result<()> {
 	Ok(())
 }
 
-fn test_vsock(has_client: bool) -> Result<()> {
-	let mut stream = if has_client {
-		let listener = VsockListener::bind_with_cid_port(vsock::VMADDR_CID_ANY, 9975)?;
-		let (stream, _addr) = listener.accept()?;
-		stream
-	} else {
-		thread::sleep(Duration::from_secs(10));
-		VsockStream::connect_with_cid_port(3, 9975)?
-	};
-
+fn test_vsock_connection(mut stream: VsockStream) -> Result<()> {
 	let messages = ["Hello, there!", "Hello, again!", "Bye-bye!"];
 	for message in messages {
 		writeln!(&mut stream, "{message}")?;
@@ -633,12 +628,31 @@ fn test_vsock(has_client: bool) -> Result<()> {
 	let received_messages = s.trim().split('\n').collect::<Vec<_>>();
 	assert_eq!(received_messages, messages);
 
-	drop(stream);
+	Ok(())
+}
 
-	if has_client {
-		let dur = Duration::from_secs(10);
-		eprintln!("[CI] Sleeping {dur:?} to free up VSOCK port again.");
-		thread::sleep(dur);
+fn test_vsock_client() -> Result<()> {
+	let listener = VsockListener::bind_with_cid_port(vsock::VMADDR_CID_ANY, 9975)?;
+	let (stream, _addr) = listener.accept()?;
+
+	test_vsock_connection(stream)?;
+
+	let dur = Duration::from_secs(10);
+	eprintln!("[CI] Sleeping {dur:?} to free up VSOCK port again.");
+	thread::sleep(dur);
+
+	Ok(())
+}
+
+fn test_vsock_server() -> Result<()> {
+	thread::sleep(Duration::from_secs(10));
+
+	for i in 0usize..10 {
+		eprintln!("[CI] Opening connection {i}...");
+		let stream = VsockStream::connect_with_cid_port(3, 9975)?;
+
+		test_vsock_connection(stream)?;
+		thread::sleep(Duration::from_secs(1));
 	}
 
 	Ok(())


### PR DESCRIPTION
After accepting a connection, move the accepted socket to an ephemeral port and reset the listener entry to Listen state. Track the listen port separately in Socket so subsequent accept calls always find the listener entry regardless of how many connections have been accepted.

Depends on https://github.com/hermit-os/hermit-rs/pull/996.
Pre-Rebase: https://github.com/hermit-os/kernel/commit/b10475e1cd5fefe26db1c4a2683832ffeac07ac9

Fixes #2433