### PR TITLE
fix(tcp): only accept connections that may send

### DIFF
--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -317,7 +317,16 @@ impl ObjectInterface for Socket {
 			let socket_handle = self
 				.handle
 				.extract_if(.., |handle| {
-					nic.get_mut_socket::<tcp::Socket<'_>>(*handle).is_active()
+					let socket = nic.get_mut_socket::<tcp::Socket<'_>>(*handle);
+
+					// We are checking not only for ESTABLISHED, but also for CLOSE-WAIT.
+					//
+					// CLOSE-WAIT may occur here when the other side connects to us and
+					// immediately closes their transmit half (our receive half),
+					// potentially sending something in between. It is still useful for
+					// the application to be able to read any received data and to send a
+					// response.
+					socket.may_send()
 				})
 				.next();
 


### PR DESCRIPTION
This PR prevents returning sockets from `accept()` that are in the `SYN-RECEIVED` state and have thus not been `ESTABLISHED` yet and might never be. This is causing https://github.com/hermit-os/kernel/issues/906, but has also been observed in other scenarios.

When we listen for connections, the following state transitions take place:

```
      TCP A                                                TCP B

  1.  CLOSED                                               LISTEN

  2.  SYN-SENT    --> <SEQ=100><CTL=SYN>               --> SYN-RECEIVED

  3.  ESTABLISHED <-- <SEQ=300><ACK=101><CTL=SYN,ACK>  <-- SYN-RECEIVED

  4.  ESTABLISHED --> <SEQ=101><ACK=301><CTL=ACK>       --> ESTABLISHED

  5.  ESTABLISHED --> <SEQ=101><ACK=301><CTL=ACK><DATA> --> ESTABLISHED

          Basic 3-Way Handshake for Connection Synchronization

                                Figure 7.
```

See [RFC 793](https://datatracker.ietf.org/doc/html/rfc793#autoid-19) for details.

If, for whatever reason, we don't get SYN,ACK in 3., we should not return the socket to the application, since we might never get it and thus the connection has not been `ESTABLISHED` yet. Currently we do, since we currently use [`Socket::is_active`](https://docs.rs/smoltcp/0.13.1/smoltcp/socket/tcp/struct.Socket.html#method.is_active) to decide whether it is ready to be returned. That method returns true if the socket is not `CLOSED`, `TIME-WAIT` or `LISTEN`.

This PR avoids returning such sockets to the application by using [`Socket::may_send`](https://docs.rs/smoltcp/0.13.1/smoltcp/socket/tcp/struct.Socket.html#method.may_send) instead, which is true if the socket is `ESTABLISHED` or `CLOSE-WAIT`.

`CLOSE-WAIT` explicitly makes sense and can be produced when the other side is opening a connection and closes it immediately. Still, data can be received that was sent intermittently, and data can be sent, since it was `ESTABLISHED` before.

Closes https://github.com/hermit-os/kernel/issues/906.