### PR TITLE
fix(physicalmem): don't claim low addresses

### DIFF
--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -9,7 +9,7 @@ use memory_addresses::{PhysAddr, VirtAddr};
 
 #[cfg(target_arch = "x86_64")]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
-use crate::arch::mm::paging::{self, HugePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::mm::paging::{self, HugePageSize, LargePageSize, PageSize, PageTableEntryFlags};
 use crate::env;
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
@@ -17,6 +17,13 @@ use crate::mm::{PageRangeAllocator, PageRangeBox};
 static PHYSICAL_FREE_LIST: InterruptTicketMutex<FreeList<16>> =
 	InterruptTicketMutex::new(FreeList::new());
 pub static TOTAL_MEMORY: AtomicUsize = AtomicUsize::new(0);
+
+/// When claiming physical memory, ignore all addresses below this one.
+/// This ensures we don't accidentally clash with hardcoded low addresses, such
+/// as `SMP_BOOT_CODE_ADDRESS` in x86_64 with SMP enabled.
+///
+/// We use a 2MIB size for now, but this is arbitrary, and could likely be lowered.
+const MIN_PHYSICAL_ADDRESS: u64 = LargePageSize::SIZE;
 
 pub struct FrameAlloc;
 
@@ -70,7 +77,7 @@ pub unsafe fn map_frame_range(frame_range: PageRange) {
 			type IdentityPageSize = HugePageSize;
 		}
 		target_arch = "x86_64" => {
-			type IdentityPageSize = paging::LargePageSize;
+			type IdentityPageSize = LargePageSize;
 		}
 	}
 
@@ -131,6 +138,18 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 			} else {
 				VirtAddr::new(start_address)
 			};
+
+		let start_address = if start_address.as_u64() < MIN_PHYSICAL_ADDRESS {
+			// Do not free any address in the real mode addressable range
+			// We have hardcoded some stuff in the kernel (e.g. SMP_BOOT_CODE_ADDRESS and friends),
+			// so we don't want to accidentally overwrite them by having an allocation on top
+			if size <= MIN_PHYSICAL_ADDRESS {
+				continue;
+			}
+			VirtAddr::new(MIN_PHYSICAL_ADDRESS)
+		} else {
+			start_address
+		};
 
 		let range = PageRange::new(start_address.as_usize(), end_address as usize).unwrap();
 		unsafe {

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -9,7 +9,7 @@ use memory_addresses::VirtAddr;
 
 #[cfg(all(target_arch = "x86_64", feature = "hermit-entry"))]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
-use crate::arch::mm::paging::{self, HugePageSize, PageSize};
+use crate::arch::mm::paging::{self, HugePageSize, LargePageSize, PageSize};
 use crate::env::{self, MemmapType, StartInfo};
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
@@ -76,7 +76,7 @@ pub unsafe fn map_frame_range(frame_range: PageRange) {
 			type IdentityPageSize = HugePageSize;
 		}
 		target_arch = "x86_64" => {
-			type IdentityPageSize = paging::LargePageSize;
+			type IdentityPageSize = LargePageSize;
 		}
 	}
 
@@ -118,8 +118,13 @@ unsafe fn detect_from_start_info() {
 		let mut start_addr = memmap_entry.phys_addr;
 		let mut end_addr = start_addr + memmap_entry.len;
 
-		// Don't use the zero page.
-		start_addr = start_addr.max(0x1000);
+		// Do not free any address in the real mode addressable range.
+		//
+		// When claiming physical memory, ignore all addresses below this one. This ensures we
+		// don't accidentally clash with hardcoded low addresses, such as `SMP_BOOT_CODE_ADDRESS`
+		// in x86_64 with SMP enabled. We use a 2MIB size for now, but this is arbitrary, and could
+		// likely be lowered.
+		start_addr = start_addr.max(LargePageSize::SIZE as usize);
 
 		#[cfg(all(target_arch = "x86_64", feature = "hermit-entry"))]
 		if paging::is_recursive() {


### PR DESCRIPTION
## Context

While working on patches for AMD SEV-SNP, we use the DeviceMapper with an offset early at boot to allocate a (plaintext) page to communicate with the hypervisor (the GHCB).

We observed that _randomly_ an application compiled with hermit would crash or enter a spin-loop sometimes _around_ the introduction of the IDT. This bug was _random_ in that recompilation with some changes at unrelated places in the code could eliminate the bug. This made debugging "fun" (as in: adding a print makes the bug disappear fun).

This clearly _screams_ of "memory corruption" somewhere. But where, actually? I don't really know, but this patch is an attempt at fixing one possible source.

## What this does, and why?

This fix is actually two fixes in one.

- First, `map_frame_range` (in `physicalmem.rs`) will, when an offset is used, map all pages _also_ at a fixed offset. This will obviously require spawning new page tables, and it turns out that the physical free list may at this point contain `0x0` as a valid frame, which may get picked up. I don't know if it's bad-bad, but since the page table is identity mapped, this means that accessing the page table entry requires dereferencing virtual address 0, aka the null pointer, which certainly cannot be good.

- Second, it turns out that the SMP boot code has a fixed address of `0x8000`. This address is only the 8th frame in the free list, so you can be sure it is going to be used, either by the offset mapping, or later on when mapping the heap. However, when the SMP boot code is loaded, it will _overwrite_ that page table entry, and corrupt the page table. I guess this bug can happen if you use a heap intensive application, it will reach a point where it accesses a part of the heap which is corrupt and crash. Maybe. I'm not certain.

To avoid these two problems, we propose a quickfix: just ignore the first 2 MB of physical addresses.

## What else?

The `detect_from_fdt` method looks a bit "dangerous" to me, in that it detects memory and immediately uses it to map it (sometimes). In most cases, no mapping is created, because UEFI already identity mapped everything, but in the cases where it does use it immediately, it may use pages that should be reserved and would have left the free list later in the procedure. The fact that pages are mapped immediately _may_ cause issues. But not sure.

## UPDATE

I now believe that the memory corruption was more likely happening at the end of the stack, which happened to be the page table - see #2462. However, I am still not sure it's a good idea to have 0x0 used as a page table, and the possible corruption with SMP is still there.