### PR TITLE
feat: stub inode numbers and fcntl result

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -8,6 +8,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use core::sync::atomic::{AtomicU64, Ordering};
 use core::{mem, ptr};
 
 use align_address::Align;
@@ -35,6 +36,8 @@ impl RomFileInner {
 		}
 	}
 }
+
+static VFS_INO_NUM: AtomicU64 = AtomicU64::new(10_000);
 
 pub struct RomFileInterface {
 	/// Position within the file
@@ -306,6 +309,7 @@ impl RomFile {
 			st_atim: t,
 			st_mtim: t,
 			st_ctim: t,
+			st_ino: VFS_INO_NUM.fetch_add(1, Ordering::AcqRel),
 			..Default::default()
 		};
 
@@ -361,6 +365,9 @@ impl RamFile {
 			st_atim: t,
 			st_mtim: t,
 			st_ctim: t,
+			st_nlink: 1,
+			st_blksize: 4096,
+			st_ino: VFS_INO_NUM.fetch_add(1, Ordering::AcqRel),
 			..Default::default()
 		};
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -718,7 +718,8 @@ pub extern "C" fn sys_fcntl(fd: i32, cmd: i32, arg: i32) -> i32 {
 			},
 		)
 	} else {
-		-i32::from(Errno::Inval)
+		warn!("[stub] Unknown fcntl flag {cmd} {arg}, returning 0");
+		0
 	}
 }
 


### PR DESCRIPTION
In the process of porting some applications (C) for Hermit, we had to implement a few stub values. I have gated them behind a compilation flag.
In addition, we also fix a few problems/incompatibilities.