### PR TITLE
fix(socket): use smoltcp's Socket::recv_slice

### DIFF
--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -203,15 +203,7 @@ impl ObjectInterface for Socket {
 					| tcp::State::TimeWait => Poll::Ready(Err(Errno::Io)),
 					_ => {
 						if socket.can_recv() {
-							Poll::Ready(
-								socket
-									.recv(|data| {
-										let len = core::cmp::min(buf.len(), data.len());
-										buf[..len].copy_from_slice(&data[..len]);
-										(len, len)
-									})
-									.map_err(|_| Errno::Io),
-							)
+							Poll::Ready(socket.recv_slice(buf).map_err(|_| Errno::Io))
 						} else if state == tcp::State::CloseWait {
 							// The local end-point has received a connection termination request
 							// and not data are in the receive buffer => return 0 to close the connection

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -159,13 +159,10 @@ impl ObjectInterface for Socket {
 			self.with(|socket| {
 				if socket.is_open() {
 					if socket.can_recv() {
-						match socket.recv() {
-							// Drop the packet when the provided buffer cannot
-							// fit the payload.
-							Ok((data, meta)) if data.len() <= buf.len() => {
-								if self.remote_endpoint.is_none_or(|ep| meta.endpoint == ep) {
-									buf[..data.len()].copy_from_slice(data);
-									Poll::Ready(Ok((data.len(), meta.endpoint)))
+						match socket.recv_slice(buf) {
+							Ok((len, meta)) => {
+								if self.remote_endpoint.is_none_or(|ep| ep == meta.endpoint) {
+									Poll::Ready(Ok((len, meta.endpoint)))
 								} else {
 									socket.register_recv_waker(cx.waker());
 									Poll::Pending
@@ -191,13 +188,10 @@ impl ObjectInterface for Socket {
 			self.with(|socket| {
 				if socket.is_open() {
 					if socket.can_recv() {
-						match socket.recv() {
-							// Drop the packet when the provided buffer cannot
-							// fit the payload.
-							Ok((data, meta)) if data.len() <= buf.len() => {
-								if self.remote_endpoint.is_none_or(|ep| meta.endpoint == ep) {
-									buf[..data.len()].copy_from_slice(data);
-									Poll::Ready(Ok(data.len()))
+						match socket.recv_slice(buf) {
+							Ok((len, meta)) => {
+								if self.remote_endpoint.is_none_or(|ep| ep == meta.endpoint) {
+									Poll::Ready(Ok(len))
 								} else {
 									socket.register_recv_waker(cx.waker());
 									Poll::Pending


### PR DESCRIPTION
Following https://github.com/hermit-os/kernel/pull/2481, this completes the revert of https://github.com/hermit-os/kernel/pull/1606.

In addition to reintroducing the use of `Socket::recv_slice` for UDP, this also introduces it for TCP, which copies from the ringbuffer twice since it may wrap around. This should be strict improvements.