### PR TITLE
feat: device alloc: appropriate entire pages, lazily

### DIFF
--- a/src/mm/device_alloc.rs
+++ b/src/mm/device_alloc.rs
@@ -6,12 +6,14 @@ use free_list::{PageLayout, PageRange};
 use memory_addresses::{PhysAddr, VirtAddr};
 
 use crate::arch::mm::paging::{BasePageSize, PageSize};
-use crate::mm::{FrameAlloc, PageRangeAllocator, virtualmem};
+use crate::mm::{PageRangeAllocator, virtualmem};
 
 /// An [`Allocator`] for memory that is used to communicate with devices.
 ///
 /// Allocations from this allocator always correspond to contiguous physical memory.
 pub struct DeviceAlloc;
+
+pub const ENABLE_PHYS_OFFSET: bool = cfg!(careful);
 
 unsafe impl Allocator for DeviceAlloc {
 	fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
@@ -19,7 +21,11 @@ unsafe impl Allocator for DeviceAlloc {
 		let size = layout.size().align_up(BasePageSize::SIZE as usize);
 		let frame_layout = PageLayout::from_size(size).unwrap();
 
-		let frame_range = FrameAlloc::allocate(frame_layout).map_err(|_| AllocError)?;
+		let frame_range = cfg_select! {
+			careful => super::device_free_list::DeviceFreeList::allocate(frame_layout),
+			_ => crate::mm::FrameAlloc::allocate(frame_layout),
+		}
+		.map_err(|_| AllocError)?;
 
 		let phys_addr = PhysAddr::from(frame_range.start());
 		let ptr = self.ptr_from(phys_addr);
@@ -35,7 +41,10 @@ unsafe impl Allocator for DeviceAlloc {
 		let range = PageRange::from_start_len(phys_addr.as_usize(), size).unwrap();
 
 		unsafe {
-			FrameAlloc::deallocate(range);
+			cfg_select! {
+				careful => super::device_free_list::DeviceFreeList::deallocate(range),
+				_ => crate::mm::FrameAlloc::deallocate(range),
+			};
 		}
 	}
 }
@@ -46,6 +55,13 @@ impl DeviceAlloc {
 	pub fn ptr_from<T>(&self, phys_addr: PhysAddr) -> *mut T {
 		let addr = phys_addr.as_usize() + self.phys_offset().as_usize();
 		ptr::with_exposed_provenance_mut(addr)
+	}
+
+	/// Returns a VirtAddr corresponding to `phys_addr`.
+	#[inline]
+	pub fn virt_addr_from(&self, phys_addr: PhysAddr) -> VirtAddr {
+		let addr = phys_addr.as_usize() + self.phys_offset().as_usize();
+		VirtAddr::from(addr)
 	}
 
 	/// Returns the physical address of `ptr`.
@@ -62,7 +78,7 @@ impl DeviceAlloc {
 	/// This device allocator expects the complete physical memory to be mapped device-readable at this offset.
 	#[inline]
 	pub fn phys_offset(&self) -> VirtAddr {
-		if cfg!(careful) {
+		if ENABLE_PHYS_OFFSET {
 			virtualmem::kernel_heap_end().as_u64().div_ceil(4).into()
 		} else {
 			0u64.into()

--- a/src/mm/device_free_list.rs
+++ b/src/mm/device_free_list.rs
@@ -1,0 +1,149 @@
+use core::alloc::AllocError;
+
+use align_address::Align;
+use free_list::{FreeList, PageLayout, PageRange};
+use hermit_sync::InterruptTicketMutex;
+use memory_addresses::VirtAddr;
+use x86_64::PhysAddr;
+use x86_64::structures::paging::{PageSize, PhysFrame, Size2MiB};
+
+use crate::arch::mm::paging;
+use crate::arch::mm::paging::{PageTableEntryFlags, PageTableEntryFlagsExt};
+use crate::mm::device_alloc::DeviceAlloc;
+use crate::mm::physicalmem::IdentityPageSize;
+use crate::mm::{FrameAlloc, PageRangeAllocator};
+
+static DEVICE_FREE_LIST: InterruptTicketMutex<FreeList<16>> =
+	InterruptTicketMutex::new(FreeList::new());
+
+pub(super) struct DeviceFreeList;
+
+const _: () = {
+	// Static assertions
+	assert!(
+		IdentityPageSize::SIZE == Size2MiB::SIZE,
+		"identity pages must be precisely 2MB big"
+	);
+	assert!(
+		super::device_alloc::ENABLE_PHYS_OFFSET,
+		"physical offset must be enabled - are you sure compilation flags match between this module inclusion and the constant?"
+	)
+};
+
+impl PageRangeAllocator for DeviceFreeList {
+	unsafe fn init() {
+		// Nothing to do
+	}
+
+	fn allocate(layout: PageLayout) -> Result<PageRange, AllocError> {
+		let allocation = DEVICE_FREE_LIST.lock().allocate(layout);
+
+		match allocation {
+			Err(_) => {
+				// Failed allocation: try to claim pages from the main FrameAllocator then retry
+				let aligned_layout = PageLayout::from_size_align(
+					layout.size().align_up(Size2MiB::SIZE as usize),
+					Size2MiB::SIZE as usize,
+				)
+				.unwrap();
+
+				let allocated_frames = FrameAlloc::allocate(aligned_layout)?;
+				unsafe {
+					Self::map_claim_frames(allocated_frames)?;
+				}
+				DEVICE_FREE_LIST
+					.lock()
+					.allocate(layout)
+					.map_err(|_| AllocError)
+			}
+			Ok(r) => Ok(r),
+		}
+	}
+
+	fn allocate_at(range: PageRange) -> Result<(), AllocError> {
+		let allocation = DEVICE_FREE_LIST.lock().allocate_at(range);
+
+		match allocation {
+			Err(_) => {
+				// Failed allocation: try to claim a page from the main FrameAllocator then retry
+				let aligned_range = PageRange::new(
+					range.start().align_down(Size2MiB::SIZE as usize),
+					range.end().align_up(Size2MiB::SIZE as usize),
+				)
+				.unwrap();
+
+				FrameAlloc::allocate_at(aligned_range)?;
+				unsafe {
+					Self::map_claim_frames(aligned_range)?;
+				}
+				DEVICE_FREE_LIST
+					.lock()
+					.allocate_at(range)
+					.map_err(|_| AllocError)
+			}
+			Ok(r) => Ok(r),
+		}
+	}
+
+	unsafe fn deallocate(range: PageRange) {
+		DEVICE_FREE_LIST.lock().deallocate(range).unwrap();
+
+		// OPTIONAL: if we have too much memory in the list we may return it to the physical free list
+		// In this case, we MUST unmap it/remap it as identity
+	}
+}
+
+impl DeviceFreeList {
+	unsafe fn map_claim_frames(frames: PageRange) -> Result<(), AllocError> {
+		assert!(
+			frames.start().is_aligned_to(Size2MiB::SIZE as usize),
+			"invalid range start alignment"
+		);
+		assert!(
+			frames.end().is_aligned_to(Size2MiB::SIZE as usize),
+			"invalid range end alignment"
+		);
+
+		let frames = (frames.start()..frames.end())
+			.step_by(Size2MiB::SIZE as usize)
+			.map(|start| PhysFrame::from_start_address(PhysAddr::new(start as u64)).unwrap());
+
+		for frame in frames {
+			Self::map_claim_frame(frame)?;
+		}
+
+		Ok(())
+	}
+
+	/// Claims the given frame into the device free list.
+	///
+	/// The identity mapping for the frame will be removed and a new mapping will be inserted at
+	/// the offset for devices.
+	///
+	/// The frame will then be added to the free list.
+	unsafe fn map_claim_frame(frame: PhysFrame<Size2MiB>) -> Result<(), AllocError> {
+		// 1. Remove page table entry in identity mapped table for this page
+		paging::unmap::<IdentityPageSize>(
+			VirtAddr::new(frame.start_address().as_u64()),
+			(Size2MiB::SIZE / IdentityPageSize::SIZE) as usize,
+		);
+
+		// 2. Add an entry at the device offset
+		let flags = {
+			let mut flags = PageTableEntryFlags::empty();
+			flags.normal().writable().execute_disable().device();
+			flags
+		};
+
+		let phys_addr = frame.start_address().into();
+		let virt_addr = VirtAddr::from_ptr(DeviceAlloc.ptr_from::<()>(phys_addr));
+		paging::map::<Size2MiB>(virt_addr, phys_addr, 1, flags);
+
+		unsafe {
+			DEVICE_FREE_LIST
+				.lock()
+				.deallocate(frame.into())
+				.map_err(|_| AllocError)
+		}
+	}
+}

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -44,6 +44,8 @@ pub(crate) mod device_alloc;
 mod page_range_alloc;
 mod physicalmem;
 mod virtualmem;
+#[cfg(careful)]
+mod device_free_list;
 
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
@@ -65,6 +67,7 @@ pub use self::virtualmem::{PageAlloc, PageBox};
 use crate::arch::mm::paging::HugePageSize;
 pub use crate::arch::mm::paging::virtual_to_physical;
 use crate::arch::mm::paging::{BasePageSize, LargePageSize, PageSize};
+use crate::mm::device_alloc::DeviceAlloc;
 use crate::{arch, env};
 
 #[cfg(target_os = "none")]

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -61,19 +61,16 @@ pub fn total_memory_size() -> usize {
 	TOTAL_MEMORY.load(Ordering::Relaxed)
 }
 
-pub unsafe fn map_frame_range(frame_range: PageRange) {
-	cfg_select! {
-		target_arch = "aarch64" => {
-			type IdentityPageSize = paging::BasePageSize;
-		}
-		target_arch = "riscv64" => {
-			type IdentityPageSize = HugePageSize;
-		}
-		target_arch = "x86_64" => {
-			type IdentityPageSize = paging::LargePageSize;
-		}
-	}
+#[cfg(target_arch = "aarch64")]
+pub type IdentityPageSize = crate::arch::mm::paging::BasePageSize;
 
+#[cfg(target_arch = "riscv64")]
+pub type IdentityPageSize = crate::arch::mm::paging::HugePageSize;
+
+#[cfg(target_arch = "x86_64")]
+pub type IdentityPageSize = crate::arch::mm::paging::LargePageSize;
+
+pub unsafe fn map_frame_range(frame_range: PageRange) {
 	let start = frame_range
 		.start()
 		.align_down(IdentityPageSize::SIZE.try_into().unwrap());
@@ -85,22 +82,6 @@ pub unsafe fn map_frame_range(frame_range: PageRange) {
 		.step_by(IdentityPageSize::SIZE.try_into().unwrap())
 		.map(|addr| PhysAddr::new(addr.try_into().unwrap()))
 		.for_each(paging::identity_map::<IdentityPageSize>);
-
-	// Map the physical memory again if DeviceAlloc operates at an offset
-	if DeviceAlloc.phys_offset() != VirtAddr::zero() {
-		let flags = {
-			let mut flags = PageTableEntryFlags::empty();
-			flags.normal().writable().execute_disable();
-			flags
-		};
-		(start..end)
-			.step_by(IdentityPageSize::SIZE.try_into().unwrap())
-			.for_each(|addr| {
-				let phys_addr = PhysAddr::new(addr.try_into().unwrap());
-				let virt_addr = VirtAddr::from_ptr(DeviceAlloc.ptr_from::<()>(phys_addr));
-				paging::map::<IdentityPageSize>(virt_addr, phys_addr, 1, flags);
-			});
-	}
 }
 
 unsafe fn detect_from_fdt() -> Result<(), ()> {
@@ -226,6 +207,7 @@ unsafe fn detect_from_limits() -> Result<(), ()> {
 
 unsafe fn init() {
 	if env::is_uefi() && DeviceAlloc.phys_offset() != VirtAddr::zero() {
+		// Remove all mappings in the device allocator range
 		let start = DeviceAlloc.phys_offset();
 		let count = DeviceAlloc.phys_offset().as_u64() / HugePageSize::SIZE;
 		let count = usize::try_from(count).unwrap();


### PR DESCRIPTION
This is a partial rewrite of #1815.

The goal is to mapping memory lazily when it's requested, but by 2MB blocks. 
When memory is requested, if there is not enough memory in the free list, we claim a 2MB page from the available free list, then we remap it at the offset