### PR TITLE
fix(virtio): do not fail on device configuration change if possible

### DIFF
--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -292,7 +292,7 @@ impl VirtioConsoleDriver {
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) {
+		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 

--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -293,8 +293,7 @@ impl VirtioConsoleDriver {
 		};
 
 		if status.contains(config_change) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
+			todo!("Device configuration change notification cannot be handled yet");
 		}
 
 		crate::console::CONSOLE_WAKER.lock().wake();

--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -287,14 +287,12 @@ impl VirtioConsoleDriver {
 	pub fn handle_interrupt(&mut self) {
 		let status = self.isr_stat.acknowledge();
 
-		#[cfg(not(feature = "pci"))]
-		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
-		}
+		let config_change = cfg_select! {
+			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
+			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
+		};
 
-		#[cfg(feature = "pci")]
-		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+		if status.contains(config_change) {
 			info!("Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}

--- a/src/drivers/fs/mod.rs
+++ b/src/drivers/fs/mod.rs
@@ -161,14 +161,12 @@ impl VirtioFsDriver {
 	pub fn handle_interrupt(&mut self) {
 		let status = self.isr_stat.acknowledge();
 
-		#[cfg(not(feature = "pci"))]
-		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
-		}
+		let config_change = cfg_select! {
+			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
+			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
+		};
 
-		#[cfg(feature = "pci")]
-		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+		if status.contains(config_change) {
 			info!("Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}

--- a/src/drivers/fs/mod.rs
+++ b/src/drivers/fs/mod.rs
@@ -166,7 +166,7 @@ impl VirtioFsDriver {
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) {
+		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}

--- a/src/drivers/fs/mod.rs
+++ b/src/drivers/fs/mod.rs
@@ -167,8 +167,7 @@ impl VirtioFsDriver {
 		};
 
 		if status.contains(config_change) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
+			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}
 }

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -527,7 +527,7 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) {
+		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -528,8 +528,7 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 		};
 
 		if status.contains(config_change) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
+			todo!("Device configuration change notification cannot be handled yet");
 		}
 
 		wake_network_waker();

--- a/src/drivers/net/virtio/mod.rs
+++ b/src/drivers/net/virtio/mod.rs
@@ -522,14 +522,12 @@ impl NetworkDriver for VirtioNetDriver<Init> {
 	fn handle_interrupt(&mut self) {
 		let status = self.isr_stat.acknowledge();
 
-		#[cfg(not(feature = "pci"))]
-		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
-		}
+		let config_change = cfg_select! {
+			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
+			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
+		};
 
-		#[cfg(feature = "pci")]
-		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+		if status.contains(config_change) {
 			info!("Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -208,6 +208,14 @@ impl ComCfg {
 			.update(|status| status | DeviceStatus::DRIVER_OK);
 	}
 
+	pub fn does_device_need_reset(&self) -> bool {
+		self.com_cfg
+			.as_ptr()
+			.status()
+			.read()
+			.contains(DeviceStatus::DEVICE_NEEDS_RESET)
+	}
+
 	pub fn print_information(&mut self) {
 		let ptr = self.com_cfg.as_ptr();
 

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -361,6 +361,11 @@ impl ComCfg {
 			.device_status()
 			.update(|s| s | DeviceStatus::DRIVER_OK);
 	}
+
+	pub fn does_device_need_reset(&self) -> bool {
+		let status = self.com_cfg.as_ptr().device_status().read();
+		status.contains(DeviceStatus::DEVICE_NEEDS_RESET)
+	}
 }
 
 /// Notification Structure to handle virtqueue notification settings.

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -483,6 +483,8 @@ impl IsrStatus {
 	}
 
 	pub fn acknowledge(&mut self) -> IsrStatusRaw {
+		// Driver read of ISR status causes the device to de-assert an interrupt.
+		// VIRTIO spec. v1.4 sec. 4.1.4.5
 		self.isr_stat.as_ptr().read()
 	}
 }

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -314,8 +314,7 @@ impl VirtioVsockDriver {
 		};
 
 		if status.contains(config_change) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
+			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}
 

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -313,7 +313,7 @@ impl VirtioVsockDriver {
 			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
 		};
 
-		if status.contains(config_change) {
+		if status.contains(config_change) && self.com_cfg.does_device_need_reset() {
 			todo!("Device configuration change notification cannot be handled yet");
 		}
 	}

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -308,14 +308,12 @@ impl VirtioVsockDriver {
 	pub fn handle_interrupt(&mut self) {
 		let status = self.isr_stat.acknowledge();
 
-		#[cfg(not(feature = "pci"))]
-		if status.contains(virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION) {
-			info!("Configuration changes are not possible! Aborting");
-			todo!("Implement possibility to change config on the fly...")
-		}
+		let config_change = cfg_select! {
+			feature = "pci" => virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT,
+			_ => virtio::mmio::InterruptStatus::CONFIGURATION_CHANGE_NOTIFICATION,
+		};
 
-		#[cfg(feature = "pci")]
-		if status.contains(virtio::pci::IsrStatus::DEVICE_CONFIGURATION_INTERRUPT) {
+		if status.contains(config_change) {
 			info!("Configuration changes are not possible! Aborting");
 			todo!("Implement possibility to change config on the fly...")
 		}


### PR DESCRIPTION
Some of the device configuration change interrupts are only relevant if configuration values are cached by the driver. However, we do not make use of any such configurations. Thus, only panic if the interrupt is sent because the device needs reset, which we currently cannot handle and must not ignore.