### PR TITLE
smp: always wake up core when ready

### DIFF
--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -886,10 +886,7 @@ pub fn ipi_tlb_flush() {
 #[allow(unused_variables)]
 pub fn wakeup_core(core_id_to_wakeup: CoreId) {
 	#[cfg(all(feature = "smp", not(feature = "idle-poll")))]
-	if core_id_to_wakeup != core_id()
-		&& !processor::supports_mwait()
-		&& scheduler::take_core_hlt_state(core_id_to_wakeup)
-	{
+	if core_id_to_wakeup != core_id() && !processor::supports_mwait() {
 		without_interrupts(|| {
 			let apic_ids = CPU_LOCAL_APIC_IDS.lock();
 			let local_apic_id = apic_ids[core_id_to_wakeup as usize];

--- a/src/arch/x86_64/kernel/core_local.rs
+++ b/src/arch/x86_64/kernel/core_local.rs
@@ -1,8 +1,6 @@
 use alloc::boxed::Box;
 use core::arch::asm;
 use core::cell::Cell;
-#[cfg(feature = "smp")]
-use core::sync::atomic::AtomicBool;
 use core::sync::atomic::Ordering;
 use core::{mem, ptr};
 
@@ -34,8 +32,6 @@ pub(crate) struct CoreLocal {
 	irq_statistics: &'static IrqStatistics,
 	/// The core-local async executor.
 	ex: StaticLocalExecutor<RawSpinMutex, RawRwSpinLock>,
-	#[cfg(feature = "smp")]
-	pub hlt: AtomicBool,
 	/// Queues to handle incoming requests from the other cores
 	#[cfg(feature = "smp")]
 	pub scheduler_input: InterruptTicketMutex<SchedulerInput>,
@@ -62,8 +58,6 @@ impl CoreLocal {
 			kernel_stack: Cell::new(ptr::null_mut()),
 			irq_statistics,
 			ex: StaticLocalExecutor::new(),
-			#[cfg(feature = "smp")]
-			hlt: AtomicBool::new(false),
 			#[cfg(feature = "smp")]
 			scheduler_input: InterruptTicketMutex::new(SchedulerInput::new()),
 		};

--- a/src/arch/x86_64/kernel/interrupts.rs
+++ b/src/arch/x86_64/kernel/interrupts.rs
@@ -82,8 +82,6 @@ pub(crate) fn enable_and_wait() {
 			);
 		}
 	} else {
-		#[cfg(feature = "smp")]
-		crate::CoreLocal::get().hlt.store(true, Ordering::Relaxed);
 		enable_and_hlt();
 	}
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -8,8 +8,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::ptr;
-#[cfg(all(target_arch = "x86_64", feature = "smp"))]
-use core::sync::atomic::AtomicBool;
 use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 
 use ahash::RandomState;
@@ -40,8 +38,6 @@ static NO_TASKS: AtomicU32 = AtomicU32::new(0);
 #[cfg(feature = "smp")]
 static SCHEDULER_INPUTS: SpinMutex<Vec<&InterruptTicketMutex<SchedulerInput>>> =
 	SpinMutex::new(Vec::new());
-#[cfg(all(target_arch = "x86_64", feature = "smp"))]
-static CORE_HLT_STATE: SpinMutex<Vec<&AtomicBool>> = SpinMutex::new(Vec::new());
 /// Map between Task ID and Queue of waiting tasks
 static WAITING_TASKS: InterruptTicketMutex<BTreeMap<TaskId, VecDeque<TaskHandle>>> =
 	InterruptTicketMutex::new(BTreeMap::new());
@@ -891,17 +887,7 @@ pub(crate) fn add_current_core() {
 			core_id.try_into().unwrap(),
 			&CoreLocal::get().scheduler_input,
 		);
-		#[cfg(target_arch = "x86_64")]
-		CORE_HLT_STATE
-			.lock()
-			.insert(core_id.try_into().unwrap(), &CoreLocal::get().hlt);
 	}
-}
-
-#[inline]
-#[cfg(all(target_arch = "x86_64", feature = "smp", not(feature = "idle-poll")))]
-pub(crate) fn take_core_hlt_state(core_id: CoreId) -> bool {
-	CORE_HLT_STATE.lock()[usize::try_from(core_id).unwrap()].swap(false, Ordering::Acquire)
 }
 
 #[inline]


### PR DESCRIPTION
This is a partial revert of commit f0bb0a0e.

This fixes a very tricky race condition that caused some cores to not be woken up, causing tests to fail (and weird bugs in the scheduling also)

# Context

In some PRs, `cargo xtask ci rs --arch x86_64 --profile dev  --package rusty_demo --features fs --smp 4 qemu --accel --sudo --devices virtio-fs-pci` fails due to timeout. 

This bug is reproducible locally, and is even more frequent with higher core counts (e.g., try it with `cargo xtask ci rs --arch x86_64 --profile dev  --package rusty_demo --features fs --smp 32 qemu --accel --sudo --devices virtio-fs-pci` on main and you're almost certain to get the bug. You can similarly confirm that this patch solves the bug.

The symptom is that the "Laplace" computation will get stuck. You can confirm this is not just the loop taking a long time by adding a small log in `compute` in `laplace.rs`

```rust
	for i in 0..iterations {
		iteration(current, next, size_x, size_y);
		mem::swap(&mut current, &mut next);
		println!("iteration {i}")
	}
```

You will observe the counter go up, then suddenly stop and nothing happens. This is the bug.

I initially believed this was a futex problem (so I rewrote them partially, another PR is incoming), but it was actually something different.

# The Bug (i think)

The thing that tipped me was that the bug was absent with the `idle-loop` flag. This greatly reduce the area that needed to be searched, since this flag is only present in a couple of places.

The bug is caused by a race condition when a core B wants to wake up a core A, which is going into halt.

The relevant call points are these:

- `PerCoreScheduler::run`. This is the idle task. It uses a backoff, checking periodically the core inbox to see if there is work. If there is none and the backoff is exhausted, it goes to sleep, calling `enable_and_wait`.
- `wakeup_core`. This is called by another CPU, after adding a task to the inbox. It sends an interrupt to the other core, to wake it up.

f0bb0a0e introduced a boolean for each core that indicates if the core is halting. If this boolean is set to `false`, `wakeup_core` skips the interrupt and returns immediately.
This works most of the time because `PerCoreScheduler::run` will always pick up tasks when some are available.

However, there is a possible race condition. Imagine the two following cores:

```
Core 1                                     Core 2

                                           run:
                                              check_inbox // inbox is empty
                                              enable_and_wait // go to enable interrupts

                                           enable_and_wait:
custom_wakeup:
  add_task_to_inbox
  wakeup_core

wakeup_core:
  check_hlt_state // hlt state is currently false
  return          // do nothing

                                              set_hlt_state(true)
                                              interrupts_enable
                                              hlt
```

I hope you appreciate my artistic talents, but that's the gist.

# The fix

Simply a partial revert of f0bb0a0e.
I was considering changing the boolean into a state machine, with a "don't sleep please" variant that could be sent by `wakeup_core` if the halt state was false, to indicate to a core that was about to go to sleep that it should not. 
I'm not sure it was working well because I was getting weird values in my `compare_and_exchange` calls, but this may be a viable alternative to reduce the number of interrupts we send.

# Notes

Increasing the core count increases the likelihood of the race condition happening. Laplace appears to be a good test-case because all threads are waiting on each other, so if ONE thread does not wake up, the program remains stuck.

It is possible that this patch will also solve other issues related to the scheduler suddenly becoming unresponsive until you cause an interrupt, but I have not tested that yet.

Fixes #2317