### PR TITLE
fix(soundness): initialize user-provided buffers with random data before writing into them

### DIFF
--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -167,7 +167,7 @@ impl ObjectInterface for Fd {
 			#[allow(dead_code)]
 			async fn getpeername(&self) -> io::Result<Option<Endpoint>>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-			async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)>;
+			async fn recvfrom(&self, buf: &mut [u8]) -> io::Result<(usize, Endpoint)>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
 			async fn sendto(&self, buf: &[u8], _endpoint: Endpoint) -> io::Result<usize>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]

--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -167,9 +167,9 @@ impl ObjectInterface for Fd {
 			#[allow(dead_code)]
 			async fn getpeername(&self) -> io::Result<Option<Endpoint>>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-			async fn recvfrom(&self, _buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)>;
+			async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-			async fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize>;
+			async fn sendto(&self, buf: &[u8], _endpoint: Endpoint) -> io::Result<usize>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
 			async fn shutdown(&self, _how: i32) -> io::Result<()>;
 			async fn status_flags(&self) -> io::Result<StatusFlags>;

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -293,7 +293,7 @@ pub(crate) trait ObjectInterface: Sync + Send {
 
 	/// Receive a message from a socket
 	#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-	async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buf: &mut [u8]) -> io::Result<(usize, Endpoint)> {
 		let _buf = buf;
 		Err(Errno::Nosys)
 	}

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -212,13 +212,15 @@ pub(crate) trait ObjectInterface: Sync + Send {
 
 	/// `async_read` attempts to read `len` bytes from the object references
 	/// by the descriptor
-	async fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+		let _buf = buf;
 		Err(Errno::Nosys)
 	}
 
 	/// `async_write` attempts to write `len` bytes to the object references
 	/// by the descriptor
-	async fn write(&self, _buf: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
+		let _buf = buf;
 		Err(Errno::Nosys)
 	}
 
@@ -235,7 +237,8 @@ pub(crate) trait ObjectInterface: Sync + Send {
 	/// `getdents` fills the given buffer `_buf` with [`Dirent64`](crate::syscalls::Dirent64)
 	/// formatted entries of a directory, imitating the Linux `getdents64` syscall.
 	/// On success, the number of bytes read is returned.  On end of directory, 0 is returned.  On error, -1 is returned
-	async fn getdents(&self, _buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		let _buf = buf;
 		Err(Errno::Inval)
 	}
 
@@ -290,7 +293,8 @@ pub(crate) trait ObjectInterface: Sync + Send {
 
 	/// Receive a message from a socket
 	#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-	async fn recvfrom(&self, _buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
+		let _buf = buf;
 		Err(Errno::Nosys)
 	}
 
@@ -302,7 +306,8 @@ pub(crate) trait ObjectInterface: Sync + Send {
 	/// be sent to the address specified by dest_addr (overriding the pre-specified peer
 	/// address).
 	#[cfg(any(feature = "net", feature = "virtio-vsock"))]
-	async fn sendto(&self, _buffer: &[u8], _endpoint: Endpoint) -> io::Result<usize> {
+	async fn sendto(&self, buf: &[u8], _endpoint: Endpoint) -> io::Result<usize> {
+		let _buf = buf;
 		Err(Errno::Nosys)
 	}
 

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -191,7 +191,7 @@ impl ObjectInterface for Socket {
 		.await
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				let state = socket.state();
@@ -206,8 +206,8 @@ impl ObjectInterface for Socket {
 							Poll::Ready(
 								socket
 									.recv(|data| {
-										let len = core::cmp::min(buffer.len(), data.len());
-										buffer[..len].copy_from_slice(&data[..len]);
+										let len = core::cmp::min(buf.len(), data.len());
+										buf[..len].copy_from_slice(&data[..len]);
 										(len, len)
 									})
 									.map_err(|_| Errno::Io),
@@ -229,10 +229,10 @@ impl ObjectInterface for Socket {
 		.await
 	}
 
-	async fn write(&self, buffer: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let mut pos: usize = 0;
 
-		while pos < buffer.len() {
+		while pos < buf.len() {
 			let n = future::poll_fn(|cx| {
 				self.with(|socket| {
 					match socket.state() {
@@ -245,9 +245,7 @@ impl ObjectInterface for Socket {
 						| tcp::State::TimeWait => Poll::Ready(Err(Errno::Io)),
 						_ => {
 							if socket.can_send() {
-								Poll::Ready(
-									socket.send_slice(&buffer[pos..]).map_err(|_| Errno::Io),
-								)
+								Poll::Ready(socket.send_slice(&buf[pos..]).map_err(|_| Errno::Io))
 							} else if pos > 0 {
 								// we already send some data => return 0 as signal to stop the
 								// async write

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -1,6 +1,5 @@
 use core::ffi::c_int;
 use core::future;
-use core::mem::MaybeUninit;
 use core::task::Poll;
 
 use smoltcp::socket::udp;
@@ -155,7 +154,7 @@ impl ObjectInterface for Socket {
 		self.write_with_meta(buf, &meta).await
 	}
 
-	async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buf: &mut [u8]) -> io::Result<(usize, Endpoint)> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_open() {
@@ -165,7 +164,7 @@ impl ObjectInterface for Socket {
 							// fit the payload.
 							Ok((data, meta)) if data.len() <= buf.len() => {
 								if self.remote_endpoint.is_none_or(|ep| meta.endpoint == ep) {
-									buf[..data.len()].write_copy_of_slice(data);
+									buf[..data.len()].copy_from_slice(data);
 									Poll::Ready(Ok((data.len(), meta.endpoint)))
 								} else {
 									socket.register_recv_waker(cx.waker());

--- a/src/fd/socket/udp.rs
+++ b/src/fd/socket/udp.rs
@@ -155,7 +155,7 @@ impl ObjectInterface for Socket {
 		self.write_with_meta(buf, &meta).await
 	}
 
-	async fn recvfrom(&self, buffer: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
+	async fn recvfrom(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<(usize, Endpoint)> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_open() {
@@ -163,9 +163,9 @@ impl ObjectInterface for Socket {
 						match socket.recv() {
 							// Drop the packet when the provided buffer cannot
 							// fit the payload.
-							Ok((data, meta)) if data.len() <= buffer.len() => {
+							Ok((data, meta)) if data.len() <= buf.len() => {
 								if self.remote_endpoint.is_none_or(|ep| meta.endpoint == ep) {
-									buffer[..data.len()].write_copy_of_slice(data);
+									buf[..data.len()].write_copy_of_slice(data);
 									Poll::Ready(Ok((data.len(), meta.endpoint)))
 								} else {
 									socket.register_recv_waker(cx.waker());
@@ -187,7 +187,7 @@ impl ObjectInterface for Socket {
 		.map(|(len, endpoint)| (len, Endpoint::Ip(endpoint)))
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		future::poll_fn(|cx| {
 			self.with(|socket| {
 				if socket.is_open() {
@@ -195,9 +195,9 @@ impl ObjectInterface for Socket {
 						match socket.recv() {
 							// Drop the packet when the provided buffer cannot
 							// fit the payload.
-							Ok((data, meta)) if data.len() <= buffer.len() => {
+							Ok((data, meta)) if data.len() <= buf.len() => {
 								if self.remote_endpoint.is_none_or(|ep| meta.endpoint == ep) {
-									buffer[..data.len()].copy_from_slice(data);
+									buf[..data.len()].copy_from_slice(data);
 									Poll::Ready(Ok(data.len()))
 								} else {
 									socket.register_recv_waker(cx.waker());

--- a/src/fd/socket/vsock.rs
+++ b/src/fd/socket/vsock.rs
@@ -314,7 +314,7 @@ impl ObjectInterface for Socket {
 		Ok(())
 	}
 
-	async fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
 		let port = self.port;
 		future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
@@ -322,7 +322,7 @@ impl ObjectInterface for Socket {
 
 			match raw.state {
 				VsockState::Connected => {
-					let len = core::cmp::min(buffer.len(), raw.buffer.len());
+					let len = core::cmp::min(buf.len(), raw.buffer.len());
 
 					if len == 0 {
 						if self.is_nonblocking {
@@ -333,19 +333,19 @@ impl ObjectInterface for Socket {
 						}
 					} else {
 						let tmp: Vec<_> = raw.buffer.drain(..len).collect();
-						buffer[..len].copy_from_slice(tmp.as_slice());
+						buf[..len].copy_from_slice(tmp.as_slice());
 
 						Poll::Ready(Ok(len))
 					}
 				}
 				VsockState::Shutdown => {
-					let len = core::cmp::min(buffer.len(), raw.buffer.len());
+					let len = core::cmp::min(buf.len(), raw.buffer.len());
 
 					if len == 0 {
 						Poll::Ready(Ok(0))
 					} else {
 						let tmp: Vec<_> = raw.buffer.drain(..len).collect();
-						buffer[..len].copy_from_slice(tmp.as_slice());
+						buf[..len].copy_from_slice(tmp.as_slice());
 
 						Poll::Ready(Ok(len))
 					}
@@ -356,7 +356,7 @@ impl ObjectInterface for Socket {
 		.await
 	}
 
-	async fn write(&self, buffer: &[u8]) -> io::Result<usize> {
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
 		let port = self.port;
 		future::poll_fn(|cx| {
 			let mut guard = VSOCK_MAP.lock();
@@ -377,7 +377,7 @@ impl ObjectInterface for Socket {
 						let mut driver_guard = hardware::get_vsock_driver().unwrap().lock();
 						let local_cid = driver_guard.get_cid();
 						let len = core::cmp::min(
-							buffer.len(),
+							buf.len(),
 							usize::try_from(raw.peer_buf_alloc - diff).unwrap(),
 						);
 
@@ -400,7 +400,7 @@ impl ObjectInterface for Socket {
 							response.fwd_cnt = le32::from_ne(raw.fwd_cnt);
 
 							virtio_buffer[HEADER_SIZE..HEADER_SIZE + len]
-								.copy_from_slice(&buffer[..len]);
+								.copy_from_slice(&buf[..len]);
 						});
 
 						Poll::Ready(Ok(len))

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -133,7 +133,8 @@ impl DirectoryReader {
 }
 
 impl ObjectInterface for DirectoryReader {
-	async fn getdents(&self, _buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		let _buf = buf;
 		let _ = &self.0; // Dummy statement to avoid warning for the moment
 		unimplemented!()
 	}

--- a/src/init_buf.rs
+++ b/src/init_buf.rs
@@ -1,0 +1,45 @@
+use core::mem::MaybeUninit;
+
+/// Initializes a buffer.
+///
+/// This function initializes the provided buffer with arbitrary data. This is
+/// useful for passing user-allocated maybe-uninitialized memory to
+/// `Read::read` or similar functions.
+///
+/// No guarantee is being made about the values that the buffer is initialized
+/// with.
+///
+/// # Current implementation
+///
+/// This currently performs no actual instructions to initialize the buffer.
+/// Instead, it provides an assembly story that initializes the buffer with
+/// arbitrary values. This might change in the future, if Hermit gains support
+/// for memory allocation techniques. Those memory allocation techniques could
+/// make multiple reads from memory that has not been written to return
+/// different values. In that case, appropriate steps have to be taken here.
+///
+/// An example of such a technique on Linux is `MADV_FREE`, which would require
+/// writing at least once per page.
+///
+/// For details on assembly stories, see [How to use storytelling to fit inline
+/// assembly into Rust].
+///
+/// [How to use storytelling to fit inline assembly into Rust]: https://www.ralfj.de/blog/2026/03/13/inline-asm.html
+#[inline]
+pub fn init_buf(buf: &mut [MaybeUninit<u8>]) -> &mut [u8] {
+	// SAFETY: The story of this assembly block is that it writes arbitrary
+	// data into the buffer, initializing it. On Hermit, there is currently no
+	// way for never-written-to allocated memory contents to change. Thus,
+	// doing nothing is currently sufficient for writing arbitrary data.
+	unsafe {
+		core::arch::asm!(
+			"/* {} {} */",
+			in(reg) buf.as_mut_ptr(),
+			in(reg) buf.len(),
+			options(preserves_flags, nostack)
+		);
+	}
+
+	// SAFETY: We have just provided a story that initializes the slice.
+	unsafe { buf.assume_init_mut() }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ pub mod errno;
 mod executor;
 pub mod fd;
 pub mod fs;
+mod init_buf;
 mod init_cell;
 pub mod io;
 pub mod mm;

--- a/src/syscalls/entropy.rs
+++ b/src/syscalls/entropy.rs
@@ -1,3 +1,4 @@
+use core::mem::MaybeUninit;
 use core::slice;
 
 use hermit_sync::TicketMutex;
@@ -5,6 +6,7 @@ use hermit_sync::TicketMutex;
 use crate::arch::kernel::processor;
 use crate::entropy::{self, Flags};
 use crate::errno::Errno;
+use crate::init_buf;
 
 static PARK_MILLER_LEHMER_SEED: TicketMutex<u32> = TicketMutex::new(0);
 const RAND_MAX: u64 = 0x7fff_ffff;
@@ -25,9 +27,9 @@ unsafe fn read_entropy(buf: *mut u8, len: usize, flags: u32) -> isize {
 		// Cap the number of bytes to be read at a time to isize::MAX to uphold
 		// the safety guarantees of `from_raw_parts`.
 		let len = usize::min(len, isize::MAX as usize);
-		buf.write_bytes(0, len);
-		slice::from_raw_parts_mut(buf, len)
+		slice::from_raw_parts_mut(buf.cast::<MaybeUninit<u8>>(), len)
 	};
+	let buf = init_buf::init_buf(buf);
 
 	entropy::read(buf, flags)
 		.unwrap_or_else(|_| {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -5,6 +5,7 @@ use alloc::ffi::CString;
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::{CStr, c_char};
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 use core::{ptr, slice};
 
 use dirent_display::Dirent64Display;
@@ -20,7 +21,6 @@ pub use self::spinlock::*;
 pub use self::system::*;
 pub use self::tasks::*;
 pub use self::timer::*;
-use crate::env;
 use crate::errno::{Errno, ToErrno};
 use crate::executor::block_on;
 use crate::fd::{
@@ -30,6 +30,7 @@ use crate::fd::{
 use crate::fs::{self, FileAttr, SeekWhence};
 #[cfg(all(target_os = "none", not(feature = "common-os")))]
 use crate::mm::ALLOCATOR;
+use crate::{env, init_buf};
 
 mod condvar;
 mod entropy;
@@ -515,7 +516,8 @@ pub extern "C" fn sys_close(fd: RawFd) -> i32 {
 #[hermit_macro::system(errno)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_read(fd: RawFd, buf: *mut u8, len: usize) -> isize {
-	let slice = unsafe { slice::from_raw_parts_mut(buf.cast(), len) };
+	let slice = unsafe { slice::from_raw_parts_mut(buf.cast::<MaybeUninit<u8>>(), len) };
+	let slice = init_buf::init_buf(slice);
 	fd::read(fd, slice).map_or_else(
 		|e| isize::try_from(-i32::from(e)).unwrap(),
 		|v| v.try_into().unwrap(),

--- a/src/syscalls/socket/mod.rs
+++ b/src/syscalls/socket/mod.rs
@@ -6,6 +6,7 @@ mod addrinfo;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::ffi::{c_char, c_void};
+use core::mem::MaybeUninit;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 #[allow(unused_imports)]
 use core::ops::DerefMut;
@@ -27,6 +28,7 @@ use crate::fd::socket::vsock::{self, VsockEndpoint, VsockListenEndpoint};
 use crate::fd::{
 	self, Endpoint, ListenEndpoint, ObjectInterface, SocketOption, get_object, insert_object,
 };
+use crate::init_buf;
 use crate::syscalls::block_on;
 
 #[derive(TryFromPrimitive, IntoPrimitive, PartialEq, Eq, Clone, Copy, Debug)]
@@ -1096,7 +1098,8 @@ pub extern "C" fn sys_shutdown_socket(fd: i32, how: i32) -> i32 {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sys_recv(fd: i32, buf: *mut u8, len: usize, flags: i32) -> isize {
 	if flags == 0 {
-		let slice = unsafe { slice::from_raw_parts_mut(buf.cast(), len) };
+		let slice = unsafe { slice::from_raw_parts_mut(buf.cast::<MaybeUninit<u8>>(), len) };
+		let slice = init_buf::init_buf(slice);
 		fd::read(fd, slice).map_or_else(
 			|e| isize::try_from(-i32::from(e)).unwrap(),
 			|v| v.try_into().unwrap(),
@@ -1177,7 +1180,8 @@ pub unsafe extern "C" fn sys_recvfrom(
 	addr: *mut sockaddr,
 	addrlen: *mut socklen_t,
 ) -> isize {
-	let slice = unsafe { slice::from_raw_parts_mut(buf.cast(), len) };
+	let slice = unsafe { slice::from_raw_parts_mut(buf.cast::<MaybeUninit<u8>>(), len) };
+	let slice = init_buf::init_buf(slice);
 	let obj = get_object(fd);
 	obj.map_or_else(
 		|e| isize::try_from(-i32::from(e)).unwrap(),


### PR DESCRIPTION
https://github.com/hermit-os/kernel/pull/1606 changed our read methods to take `&mut [MaybeUninit<u8>]` instead of `&mut [u8]`. This was done to avoid UB when applications pass uninitialized buffers to `read` and similar functions, either through C or through Rust's unstable `Read::read_buf`.

https://github.com/hermit-os/kernel/commit/445dac2d046572244a176345c4db9988004b51ed changed this back as part of https://github.com/hermit-os/kernel/pull/1891 to allow integration with the ecosystem's `Read::read` functions, that take a `&mut [u8]`. The soundness implications were not noticed.

This PR harmonizes Hermit's internal API by making `recv` also take a `&mut [u8]` instead of a `&mut [MaybeUninit<u8>]`.

Then, it makes the APIs sound when uninitialized buffers are passed by introducing a `fn init_buf(buf: &mut [MaybeUninit<u8>]) -> &mut [u8]` that is currently an assembler story no-op. This function might need to do actual work if Hermit ever gains support for actual uninitialized memory that might return different values when read without being written to. This is not the case yet, so the no-op is fine.

For details, see https://github.com/rust-lang/unsafe-code-guidelines/issues/527#issuecomment-4717256088.