### PR TITLE
refactor: clean up arch-specific imports

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -16,6 +16,7 @@ use memory_addresses::{PhysAddr, VirtAddr};
 
 use crate::arch::aarch64::kernel::core_local::{core_id, core_scheduler, increment_irq_counter};
 use crate::arch::aarch64::kernel::scheduler::State;
+use crate::arch::aarch64::kernel::serial::handle_uart_interrupt;
 use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 #[cfg(not(feature = "pci"))]
 use crate::drivers::mmio::get_interrupt_handlers;
@@ -23,7 +24,6 @@ use crate::drivers::mmio::get_interrupt_handlers;
 use crate::drivers::pci::get_interrupt_handlers;
 use crate::drivers::{InterruptHandlerQueue, InterruptLine};
 use crate::env;
-use crate::kernel::serial::handle_uart_interrupt;
 use crate::mm::{PageAlloc, PageRangeAllocator};
 use crate::scheduler::{self, CoreId, timer_interrupts};
 

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -14,7 +14,7 @@ use hashbrown::HashMap;
 use hermit_sync::{InterruptSpinMutex, InterruptTicketMutex, OnceCell, SpinMutex};
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::arch::aarch64::kernel::core_local::increment_irq_counter;
+use crate::arch::aarch64::kernel::core_local::{core_id, core_scheduler, increment_irq_counter};
 use crate::arch::aarch64::kernel::scheduler::State;
 use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 #[cfg(not(feature = "pci"))]
@@ -22,10 +22,10 @@ use crate::drivers::mmio::get_interrupt_handlers;
 #[cfg(feature = "pci")]
 use crate::drivers::pci::get_interrupt_handlers;
 use crate::drivers::{InterruptHandlerQueue, InterruptLine};
+use crate::env;
 use crate::kernel::serial::handle_uart_interrupt;
 use crate::mm::{PageAlloc, PageRangeAllocator};
 use crate::scheduler::{self, CoreId, timer_interrupts};
-use crate::{core_id, core_scheduler, env};
 
 /// The ID of the first Private Peripheral Interrupt.
 const PPI_START: u8 = 16;

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -124,7 +124,7 @@ pub fn boot_next_processor() {
 
 		use memory_addresses::VirtAddr;
 
-		use crate::kernel::start::{TTBR0, smp_start};
+		use crate::arch::aarch64::kernel::start::{TTBR0, smp_start};
 		use crate::mm::virtual_to_physical;
 
 		if cpu_online == 0 {

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -21,6 +21,8 @@ use core::{ptr, str};
 
 use memory_addresses::PhysAddr;
 
+pub(crate) use self::interrupts::wakeup_core;
+pub(crate) use self::processor::set_oneshot_timer;
 use crate::arch::aarch64::kernel::core_local::*;
 use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
 use crate::config::*;

--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -11,11 +11,12 @@ use pci_types::{
 	PciHeader,
 };
 
+use crate::arch::aarch64::kernel::core_local::core_id;
 use crate::arch::aarch64::kernel::interrupts::GIC;
 use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::drivers::pci::{PCI_DEVICES, PciDevice};
+use crate::env;
 use crate::mm::{PageAlloc, PageRangeAllocator};
-use crate::{core_id, env};
 
 const PCI_MAX_DEVICE_NUMBER: u8 = 32;
 const PCI_MAX_FUNCTION_NUMBER: u8 = 8;

--- a/src/arch/aarch64/kernel/scheduler.rs
+++ b/src/arch/aarch64/kernel/scheduler.rs
@@ -15,7 +15,7 @@ use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize, PageTableEntryFla
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 use crate::scheduler::PerCoreSchedulerExt;
 use crate::scheduler::task::{Task, TaskFrame};
-use crate::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
+use crate::config::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
 
 #[derive(Debug)]
 #[repr(C, packed)]

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -11,7 +11,8 @@ use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
 use crate::arch::aarch64::kernel::scheduler::TaskStacks;
-use crate::{KERNEL_STACK_SIZE, env};
+use crate::config::KERNEL_STACK_SIZE;
+use crate::env;
 
 /*
  * Memory types available.

--- a/src/arch/aarch64/kernel/start.rs
+++ b/src/arch/aarch64/kernel/start.rs
@@ -278,7 +278,7 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 				"{preamble} Secondary core booted, but Hermit was not built with SMP support!"
 			);
 			loop {
-				crate::arch::processor::halt();
+				crate::arch::kernel::processor::halt();
 			}
 		}
 		#[cfg(feature = "smp")]

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -80,6 +80,7 @@ bitflags! {
 }
 
 impl PageTableEntryFlags {
+	#[expect(dead_code)]
 	pub fn present(&mut self) -> &mut Self {
 		self.insert(PageTableEntryFlags::PRESENT);
 		self
@@ -102,6 +103,7 @@ impl PageTableEntryFlags {
 		self
 	}
 
+	#[expect(dead_code)]
 	pub fn read_only(&mut self) -> &mut Self {
 		self.insert(PageTableEntryFlags::READ_ONLY);
 		self

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,7 +7,6 @@ cfg_select! {
 
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
-		pub(crate) use self::aarch64::kernel::scheduler;
 		pub(crate) use self::aarch64::kernel::{
 			get_processor_count,
 		};
@@ -21,7 +20,6 @@ cfg_select! {
 			set_oneshot_timer,
 			wakeup_core,
 		};
-		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		pub(crate) use self::x86_64::kernel::{
 			get_processor_count,
@@ -37,7 +35,6 @@ cfg_select! {
 		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
 			get_processor_count,
-			scheduler,
 			switch,
 		};
 		pub use self::riscv64::mm::paging::{BasePageSize, PageSize};

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -11,7 +11,6 @@ cfg_select! {
 		pub(crate) use self::aarch64::kernel::interrupts;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor;
-		pub(crate) use self::aarch64::kernel::serial::SerialDevice;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 		pub(crate) use self::aarch64::kernel::scheduler;
 		#[cfg(feature = "smp")]
@@ -34,7 +33,6 @@ cfg_select! {
 		pub(crate) use self::x86_64::kernel::core_local;
 		pub(crate) use self::x86_64::kernel::interrupts;
 		pub(crate) use self::x86_64::kernel::processor;
-		pub(crate) use self::x86_64::kernel::serial::SerialDevice;
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(target_os = "none")]
@@ -53,7 +51,6 @@ cfg_select! {
 		#[cfg(feature = "smp")]
 		pub(crate) use self::riscv64::kernel::application_processor_init;
 		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
-		pub(crate) use self::riscv64::kernel::serial::SerialDevice;
 		pub(crate) use self::riscv64::kernel::{
 			boot_processor_init,
 			core_local,

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -5,12 +5,12 @@ cfg_select! {
 		mod aarch64;
 		pub(crate) use self::aarch64::*;
 	}
-	target_arch = "x86_64" => {
-		mod x86_64;
-		pub(crate) use self::x86_64::*;
-	}
 	target_arch = "riscv64" => {
 		mod riscv64;
 		pub(crate) use self::riscv64::*;
+	}
+	target_arch = "x86_64" => {
+		mod x86_64;
+		pub(crate) use self::x86_64::*;
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -16,7 +16,6 @@ cfg_select! {
 			set_oneshot_timer,
 			wakeup_core,
 		};
-		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(feature = "common-os")]
 		pub use self::x86_64::mm::create_new_root_page_table;
 	}
@@ -25,8 +24,5 @@ cfg_select! {
 		pub(crate) use self::riscv64::*;
 
 		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
-		pub(crate) use self::riscv64::kernel::{
-			switch,
-		};
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -34,7 +34,6 @@ cfg_select! {
 		#[cfg(all(target_os = "none", feature = "smp"))]
 		pub(crate) use self::x86_64::kernel::application_processor_init;
 		pub(crate) use self::x86_64::kernel::core_local;
-		pub(crate) use self::x86_64::kernel::gdt::set_current_kernel_stack;
 		pub(crate) use self::x86_64::kernel::interrupts;
 		#[cfg(feature = "pci")]
 		pub(crate) use self::x86_64::kernel::pci;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -16,8 +16,6 @@ cfg_select! {
 			set_oneshot_timer,
 			wakeup_core,
 		};
-		#[cfg(feature = "common-os")]
-		pub use self::x86_64::mm::create_new_root_page_table;
 	}
 	target_arch = "riscv64" => {
 		pub(crate) mod riscv64;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -4,23 +4,13 @@ cfg_select! {
 	target_arch = "aarch64" => {
 		pub(crate) mod aarch64;
 		pub(crate) use self::aarch64::*;
-
-		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
-		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 	}
 	target_arch = "x86_64" => {
 		pub(crate) mod x86_64;
 		pub(crate) use self::x86_64::*;
-
-		pub(crate) use self::x86_64::kernel::apic::{
-			set_oneshot_timer,
-			wakeup_core,
-		};
 	}
 	target_arch = "riscv64" => {
 		pub(crate) mod riscv64;
 		pub(crate) use self::riscv64::*;
-
-		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -9,7 +9,6 @@ cfg_select! {
 		pub(crate) use self::aarch64::kernel::boot_processor_init;
 		pub(crate) use self::aarch64::kernel::interrupts;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
-		pub(crate) use self::aarch64::kernel::processor;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 		pub(crate) use self::aarch64::kernel::scheduler;
 		#[cfg(feature = "smp")]
@@ -30,7 +29,6 @@ cfg_select! {
 		#[cfg(all(target_os = "none", feature = "smp"))]
 		pub(crate) use self::x86_64::kernel::application_processor_init;
 		pub(crate) use self::x86_64::kernel::interrupts;
-		pub(crate) use self::x86_64::kernel::processor;
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(target_os = "none")]
@@ -48,7 +46,7 @@ cfg_select! {
 
 		#[cfg(feature = "smp")]
 		pub(crate) use self::riscv64::kernel::application_processor_init;
-		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
+		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
 			boot_processor_init,
 			get_processor_count,

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -10,8 +10,6 @@ cfg_select! {
 		pub(crate) use self::aarch64::kernel::core_local;
 		pub(crate) use self::aarch64::kernel::interrupts;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
-		#[cfg(feature = "pci")]
-		pub(crate) use self::aarch64::kernel::pci;
 		pub(crate) use self::aarch64::kernel::processor;
 		pub(crate) use self::aarch64::kernel::serial::SerialDevice;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
@@ -35,8 +33,6 @@ cfg_select! {
 		pub(crate) use self::x86_64::kernel::application_processor_init;
 		pub(crate) use self::x86_64::kernel::core_local;
 		pub(crate) use self::x86_64::kernel::interrupts;
-		#[cfg(feature = "pci")]
-		pub(crate) use self::x86_64::kernel::pci;
 		pub(crate) use self::x86_64::kernel::processor;
 		pub(crate) use self::x86_64::kernel::serial::SerialDevice;
 		pub(crate) use self::x86_64::kernel::scheduler;
@@ -56,8 +52,6 @@ cfg_select! {
 
 		#[cfg(feature = "smp")]
 		pub(crate) use self::riscv64::kernel::application_processor_init;
-		#[cfg(feature = "pci")]
-		pub(crate) use self::riscv64::kernel::pci;
 		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::serial::SerialDevice;
 		pub(crate) use self::riscv64::kernel::{

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -2,15 +2,15 @@
 
 cfg_select! {
 	target_arch = "aarch64" => {
-		pub(crate) mod aarch64;
+		mod aarch64;
 		pub(crate) use self::aarch64::*;
 	}
 	target_arch = "x86_64" => {
-		pub(crate) mod x86_64;
+		mod x86_64;
 		pub(crate) use self::x86_64::*;
 	}
 	target_arch = "riscv64" => {
-		pub(crate) mod riscv64;
+		mod riscv64;
 		pub(crate) use self::riscv64::*;
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,7 +7,6 @@ cfg_select! {
 
 		#[cfg(target_os = "none")]
 		pub(crate) use self::aarch64::kernel::boot_processor_init;
-		pub(crate) use self::aarch64::kernel::interrupts;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 		pub(crate) use self::aarch64::kernel::scheduler;
@@ -28,7 +27,6 @@ cfg_select! {
 		};
 		#[cfg(all(target_os = "none", feature = "smp"))]
 		pub(crate) use self::x86_64::kernel::application_processor_init;
-		pub(crate) use self::x86_64::kernel::interrupts;
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
 		#[cfg(target_os = "none")]
@@ -50,7 +48,6 @@ cfg_select! {
 		pub(crate) use self::riscv64::kernel::{
 			boot_processor_init,
 			get_processor_count,
-			interrupts,
 			scheduler,
 			switch,
 		};

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,7 +7,6 @@ cfg_select! {
 
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
-		pub use self::aarch64::mm::paging::{BasePageSize, PageSize};
 	}
 	target_arch = "x86_64" => {
 		pub(crate) mod x86_64;
@@ -18,7 +17,6 @@ cfg_select! {
 			wakeup_core,
 		};
 		pub(crate) use self::x86_64::kernel::switch;
-		pub use self::x86_64::mm::paging::{BasePageSize, PageSize};
 		#[cfg(feature = "common-os")]
 		pub use self::x86_64::mm::create_new_root_page_table;
 	}
@@ -30,6 +28,5 @@ cfg_select! {
 		pub(crate) use self::riscv64::kernel::{
 			switch,
 		};
-		pub use self::riscv64::mm::paging::{BasePageSize, PageSize};
 	}
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,7 +7,6 @@ cfg_select! {
 
 		#[cfg(target_os = "none")]
 		pub(crate) use self::aarch64::kernel::boot_processor_init;
-		pub(crate) use self::aarch64::kernel::core_local;
 		pub(crate) use self::aarch64::kernel::interrupts;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor;
@@ -30,7 +29,6 @@ cfg_select! {
 		};
 		#[cfg(all(target_os = "none", feature = "smp"))]
 		pub(crate) use self::x86_64::kernel::application_processor_init;
-		pub(crate) use self::x86_64::kernel::core_local;
 		pub(crate) use self::x86_64::kernel::interrupts;
 		pub(crate) use self::x86_64::kernel::processor;
 		pub(crate) use self::x86_64::kernel::scheduler;
@@ -53,7 +51,6 @@ cfg_select! {
 		pub(crate) use self::riscv64::kernel::processor::{self, set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
 			boot_processor_init,
-			core_local,
 			get_processor_count,
 			interrupts,
 			scheduler,

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -7,9 +7,6 @@ cfg_select! {
 
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
-		pub(crate) use self::aarch64::kernel::{
-			get_processor_count,
-		};
 		pub use self::aarch64::mm::paging::{BasePageSize, PageSize};
 	}
 	target_arch = "x86_64" => {
@@ -21,9 +18,6 @@ cfg_select! {
 			wakeup_core,
 		};
 		pub(crate) use self::x86_64::kernel::switch;
-		pub(crate) use self::x86_64::kernel::{
-			get_processor_count,
-		};
 		pub use self::x86_64::mm::paging::{BasePageSize, PageSize};
 		#[cfg(feature = "common-os")]
 		pub use self::x86_64::mm::create_new_root_page_table;
@@ -34,7 +28,6 @@ cfg_select! {
 
 		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
-			get_processor_count,
 			switch,
 		};
 		pub use self::riscv64::mm::paging::{BasePageSize, PageSize};

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -5,13 +5,9 @@ cfg_select! {
 		pub(crate) mod aarch64;
 		pub(crate) use self::aarch64::*;
 
-		#[cfg(target_os = "none")]
-		pub(crate) use self::aarch64::kernel::boot_processor_init;
 		pub(crate) use self::aarch64::kernel::interrupts::wakeup_core;
 		pub(crate) use self::aarch64::kernel::processor::set_oneshot_timer;
 		pub(crate) use self::aarch64::kernel::scheduler;
-		#[cfg(feature = "smp")]
-		pub(crate) use self::aarch64::kernel::application_processor_init;
 		pub(crate) use self::aarch64::kernel::{
 			get_processor_count,
 		};
@@ -25,12 +21,8 @@ cfg_select! {
 			set_oneshot_timer,
 			wakeup_core,
 		};
-		#[cfg(all(target_os = "none", feature = "smp"))]
-		pub(crate) use self::x86_64::kernel::application_processor_init;
 		pub(crate) use self::x86_64::kernel::scheduler;
 		pub(crate) use self::x86_64::kernel::switch;
-		#[cfg(target_os = "none")]
-		pub(crate) use self::x86_64::kernel::boot_processor_init;
 		pub(crate) use self::x86_64::kernel::{
 			get_processor_count,
 		};
@@ -42,11 +34,8 @@ cfg_select! {
 		pub(crate) mod riscv64;
 		pub(crate) use self::riscv64::*;
 
-		#[cfg(feature = "smp")]
-		pub(crate) use self::riscv64::kernel::application_processor_init;
 		pub(crate) use self::riscv64::kernel::processor::{set_oneshot_timer, wakeup_core};
 		pub(crate) use self::riscv64::kernel::{
-			boot_processor_init,
 			get_processor_count,
 			scheduler,
 			switch,

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -50,8 +50,6 @@ cfg_select! {
 		pub use self::x86_64::mm::paging::{BasePageSize, PageSize};
 		#[cfg(feature = "common-os")]
 		pub use self::x86_64::mm::create_new_root_page_table;
-		#[cfg(feature = "common-os")]
-		pub use self::x86_64::kernel::{load_application, jump_to_user_land};
 	}
 	target_arch = "riscv64" => {
 		pub(crate) mod riscv64;

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -107,10 +107,12 @@ pub fn boot_processor_init() {
 /// Application Processor initialization
 #[cfg(feature = "smp")]
 pub fn application_processor_init() {
+	use crate::arch::kernel::core_local::CoreLocal;
+
 	unsafe {
 		super::mm::paging::enable_page_table();
 	}
-	crate::CoreLocal::install();
+	CoreLocal::install();
 	interrupts::install();
 	finish_processor_init();
 }

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -19,6 +19,7 @@ use free_list::PageLayout;
 use memory_addresses::PhysAddr;
 use riscv::register::sstatus;
 
+pub(crate) use self::processor::{set_oneshot_timer, wakeup_core};
 use crate::arch::riscv64::kernel::core_local::core_id;
 pub use crate::arch::riscv64::kernel::devicetree::init_drivers;
 use crate::arch::riscv64::kernel::processor::lsb;

--- a/src/arch/riscv64/kernel/scheduler.rs
+++ b/src/arch/riscv64/kernel/scheduler.rs
@@ -7,7 +7,7 @@ use crate::arch::riscv64::mm::paging::{BasePageSize, PageSize, PageTableEntryFla
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 use crate::scheduler::task::{Task, TaskFrame};
 use crate::scheduler::{PerCoreSchedulerExt, timer_interrupts};
-use crate::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
+use crate::config::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
 
 /// For details, see [RISC-V Calling Conventions].
 ///

--- a/src/arch/riscv64/kernel/start.rs
+++ b/src/arch/riscv64/kernel/start.rs
@@ -8,7 +8,8 @@ use super::{CPU_ONLINE, CURRENT_BOOT_ID, HART_MASK, NUM_CPUS};
 use crate::arch::riscv64::kernel::CURRENT_STACK_ADDRESS;
 #[cfg(not(feature = "smp"))]
 use crate::arch::riscv64::kernel::processor;
-use crate::{KERNEL_STACK_SIZE, env};
+use crate::config::KERNEL_STACK_SIZE;
+use crate::env;
 
 //static mut BOOT_STACK: [u8; KERNEL_STACK_SIZE] = [0; KERNEL_STACK_SIZE];
 

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -815,7 +815,7 @@ pub fn boot_application_processors() {
 			init_next_processor_variables();
 
 			// Save the current number of initialized CPUs.
-			let current_processor_count = arch::get_processor_count();
+			let current_processor_count = arch::kernel::get_processor_count();
 
 			// Send an INIT IPI.
 			local_apic_write(
@@ -844,7 +844,7 @@ pub fn boot_application_processors() {
 
 			// Wait until the application processor has finished initializing.
 			// It will indicate this by counting up cpu_online.
-			while current_processor_count == arch::get_processor_count() {
+			while current_processor_count == arch::kernel::get_processor_count() {
 				spin_loop();
 			}
 		}
@@ -855,7 +855,7 @@ pub fn boot_application_processors() {
 
 #[cfg(feature = "smp")]
 pub fn ipi_tlb_flush() {
-	if arch::get_processor_count() > 1 {
+	if arch::kernel::get_processor_count() > 1 {
 		let apic_ids = CPU_LOCAL_APIC_IDS.lock();
 		let core_id = core_id();
 
@@ -998,7 +998,7 @@ pub fn print_information() {
 		"xAPIC"
 	};
 	infoentry!("APIC in use", "{apic}");
-	let processor_count = arch::get_processor_count();
+	let processor_count = arch::kernel::get_processor_count();
 	infoentry!("Initialized CPUs", "{processor_count}");
 	infofooter!();
 }

--- a/src/arch/x86_64/kernel/kernel_stack.rs
+++ b/src/arch/x86_64/kernel/kernel_stack.rs
@@ -1,6 +1,6 @@
 use core::mem;
 
-use crate::core_local::CoreLocal;
+use crate::arch::kernel::core_local::CoreLocal;
 
 type Reg = mem::MaybeUninit<usize>;
 

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -9,6 +9,7 @@ use hermit_entry::boot_info::{PlatformInfo, RawBootInfo};
 use memory_addresses::PhysAddr;
 use x86_64::registers::control::{Cr0, Cr4};
 
+pub(crate) use self::apic::{set_oneshot_timer, wakeup_core};
 use crate::arch::x86_64::kernel::core_local::*;
 use crate::env::{self, is_uhyve};
 

--- a/src/arch/x86_64/kernel/pci.rs
+++ b/src/arch/x86_64/kernel/pci.rs
@@ -130,10 +130,10 @@ mod pcie {
 	use pci_types::{ConfigRegionAccess, PciAddress};
 
 	use super::PciConfigRegion;
+	use crate::arch::kernel::acpi;
 	use crate::arch::mm::paging::{
 		self, LargePageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 	};
-	use crate::kernel::acpi;
 	use crate::mm::device_alloc::DeviceAlloc;
 
 	pub fn init_pcie() -> bool {

--- a/src/arch/x86_64/kernel/start.rs
+++ b/src/arch/x86_64/kernel/start.rs
@@ -3,7 +3,7 @@ use core::arch::naked_asm;
 use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
-use crate::KERNEL_STACK_SIZE;
+use crate::config::KERNEL_STACK_SIZE;
 use crate::arch::kernel::pre_init;
 use crate::arch::kernel::scheduler::TaskStacks;
 

--- a/src/arch/x86_64/kernel/start.rs
+++ b/src/arch/x86_64/kernel/start.rs
@@ -4,8 +4,8 @@ use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
 use crate::KERNEL_STACK_SIZE;
-use crate::kernel::pre_init;
-use crate::kernel::scheduler::TaskStacks;
+use crate::arch::kernel::pre_init;
+use crate::arch::kernel::scheduler::TaskStacks;
 
 #[unsafe(no_mangle)]
 #[unsafe(naked)]

--- a/src/arch/x86_64/kernel/switch.rs
+++ b/src/arch/x86_64/kernel/switch.rs
@@ -2,7 +2,7 @@ use core::arch::naked_asm;
 
 use x86_64::registers::control::Cr0Flags;
 
-use crate::set_current_kernel_stack;
+use crate::arch::kernel::gdt::set_current_kernel_stack;
 
 #[cfg(not(feature = "common-os"))]
 macro_rules! push_gs {

--- a/src/common_os.rs
+++ b/src/common_os.rs
@@ -1,0 +1,1 @@
+pub use crate::arch::kernel::{jump_to_user_land, load_application};

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -7,7 +7,7 @@ use embedded_io::{ErrorType, Read, ReadReady, Write};
 use heapless::Vec;
 use hermit_sync::{InterruptTicketMutex, Lazy};
 
-use crate::arch::SerialDevice;
+use crate::arch::kernel::serial::SerialDevice;
 #[cfg(feature = "virtio-console")]
 use crate::drivers::console::VirtioUART;
 use crate::errno::Errno;

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -152,7 +152,9 @@ impl Write for Console {
 pub(crate) static CONSOLE_WAKER: InterruptTicketMutex<WakerRegistration> =
 	InterruptTicketMutex::new(WakerRegistration::new());
 pub(crate) static CONSOLE: Lazy<InterruptTicketMutex<Console>> = Lazy::new(|| {
-	crate::CoreLocal::install();
+	use crate::arch::kernel::core_local::CoreLocal;
+
+	CoreLocal::install();
 
 	#[cfg(feature = "uhyve")]
 	if crate::env::is_uhyve() {

--- a/src/drivers/console/mod.rs
+++ b/src/drivers/console/mod.rs
@@ -24,7 +24,7 @@ use virtio::console::Config;
 use volatile::VolatileRef;
 use volatile::access::ReadOnly;
 
-use crate::VIRTIO_MAX_QUEUE_SIZE;
+use crate::config::{CONSOLE_PACKET_SIZE, VIRTIO_MAX_QUEUE_SIZE};
 use crate::drivers::error::DriverError;
 #[cfg(not(feature = "pci"))]
 use crate::drivers::mmio::get_console_driver;
@@ -124,7 +124,7 @@ impl RxQueue {
 		Self {
 			vq: None,
 
-			packet_size: crate::CONSOLE_PACKET_SIZE,
+			packet_size: CONSOLE_PACKET_SIZE,
 		}
 	}
 
@@ -189,7 +189,7 @@ impl TxQueue {
 	pub fn new() -> Self {
 		Self {
 			vq: None,
-			packet_length: crate::CONSOLE_PACKET_SIZE,
+			packet_length: CONSOLE_PACKET_SIZE,
 		}
 	}
 

--- a/src/drivers/console/pci.rs
+++ b/src/drivers/console/pci.rs
@@ -2,7 +2,7 @@ use pci_types::CommandRegister;
 use virtio::console::Config;
 use volatile::VolatileRef;
 
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::console::{ConsoleDevCfg, RxQueue, TxQueue, VirtioConsoleDriver};
 use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};

--- a/src/drivers/console/pci.rs
+++ b/src/drivers/console/pci.rs
@@ -2,11 +2,11 @@ use pci_types::CommandRegister;
 use virtio::console::Config;
 use volatile::VolatileRef;
 
+use crate::arch::pci::PciConfigRegion;
 use crate::drivers::console::{ConsoleDevCfg, RxQueue, TxQueue, VirtioConsoleDriver};
 use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};
 use crate::drivers::virtio::transport::pci::{self, PciCap, UniCapsColl};
-use crate::pci::PciConfigRegion;
 
 // Backend-dependent interface for Virtio console driver
 impl VirtioConsoleDriver {

--- a/src/drivers/fs/pci.rs
+++ b/src/drivers/fs/pci.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use volatile::VolatileRef;
 
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::fs::{FsDevCfg, VirtioFsDriver};
 use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -85,5 +85,5 @@ pub(crate) fn init() {
 	#[cfg(target_arch = "riscv64")]
 	crate::arch::riscv64::kernel::init_drivers();
 
-	crate::arch::interrupts::install_handlers();
+	crate::arch::kernel::interrupts::install_handlers();
 }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -78,12 +78,12 @@ pub(crate) fn init() {
 	#[cfg(feature = "pci")]
 	pci::init();
 	#[cfg(all(not(feature = "pci"), feature = "virtio", target_arch = "x86_64"))]
-	crate::arch::x86_64::kernel::mmio::init_drivers();
+	crate::arch::kernel::mmio::init_drivers();
 	#[cfg(all(not(feature = "pci"), feature = "virtio", target_arch = "aarch64"))]
-	crate::arch::aarch64::kernel::mmio::init_drivers();
+	crate::arch::kernel::mmio::init_drivers();
 
 	#[cfg(target_arch = "riscv64")]
-	crate::arch::riscv64::kernel::init_drivers();
+	crate::arch::kernel::init_drivers();
 
 	crate::arch::kernel::interrupts::install_handlers();
 }

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -16,7 +16,7 @@ use volatile::access::{NoAccess, ReadOnly, ReadWrite};
 use volatile::{VolatileFieldAccess, VolatilePtr, VolatileRef, map_field};
 
 use crate::arch::kernel::interrupts::*;
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::Driver;
 use crate::drivers::error::DriverError;
 use crate::drivers::net::{NetworkDriver, mtu};

--- a/src/drivers/net/virtio/pci.rs
+++ b/src/drivers/net/virtio/pci.rs
@@ -3,7 +3,7 @@ use smoltcp::phy::ChecksumCapabilities;
 use volatile::VolatileRef;
 
 use super::{Init, Uninit};
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::net::virtio::{NetDevCfg, VirtioNetDriver};
 use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -19,7 +19,7 @@ use pci_types::{
 	InterruptPin, MAX_BARS, PciAddress, PciHeader, StatusRegister, VendorId,
 };
 
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 #[cfg(feature = "virtio-console")]
 use crate::console::IoDevice;
 #[cfg(feature = "virtio-console")]

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -432,7 +432,7 @@ pub(crate) fn get_interrupt_handlers() -> HashMap<InterruptLine, InterruptHandle
 
 	#[cfg(target_arch = "x86_64")]
 	{
-		use crate::kernel::serial::get_serial_handler;
+		use crate::arch::kernel::serial::get_serial_handler;
 		let (irq_number, handler) = get_serial_handler();
 
 		handlers.entry(irq_number).or_default().push_back(handler);

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -352,7 +352,7 @@ pub(crate) fn init_device(
 			Ok(virt_console_drv) => {
 				info!("Virtio console driver initialized.");
 
-				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
 				info!("Virtio interrupt handler at line {irq_no}");
 
 				Ok(VirtioDriver::Console(alloc::boxed::Box::new(
@@ -371,7 +371,7 @@ pub(crate) fn init_device(
 			match VirtioFsDriver::init(dev_id, registers, irq_no) {
 				Ok(virt_fs_drv) => {
 					info!("Virtio filesystem driver initialized.");
-					crate::arch::interrupts::add_irq_name(irq_no, "virtio");
+					crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
 					Ok(VirtioDriver::Fs(alloc::boxed::Box::new(virt_fs_drv)))
 				}
 				Err(virtio_error) => {
@@ -385,7 +385,7 @@ pub(crate) fn init_device(
 			Ok(virt_net_drv) => {
 				info!("Virtio network driver initialized.");
 
-				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
 				info!("Virtio interrupt handler at line {irq_no}");
 
 				Ok(VirtioDriver::Net(alloc::boxed::Box::new(virt_net_drv)))
@@ -400,7 +400,7 @@ pub(crate) fn init_device(
 			Ok(virt_vsock_drv) => {
 				info!("Virtio sock driver initialized.");
 
-				crate::arch::interrupts::add_irq_name(irq_no, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq_no, "virtio");
 				info!("Virtio interrupt handler at line {irq_no}");
 
 				Ok(VirtioDriver::Vsock(alloc::boxed::Box::new(virt_vsock_drv)))

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -18,7 +18,7 @@ use virtio::{DeviceStatus, le16, le32};
 use volatile::access::ReadOnly;
 use volatile::{VolatilePtr, VolatileRef};
 
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 #[cfg(feature = "virtio-console")]
 use crate::drivers::console::VirtioConsoleDriver;
 use crate::drivers::error::DriverError;

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -654,7 +654,7 @@ pub(crate) fn init_device(
 				info!("Virtio console driver initialized.");
 
 				let irq = device.get_irq().unwrap();
-				crate::arch::interrupts::add_irq_name(irq, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 				info!("Virtio interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Console(alloc::boxed::Box::new(
@@ -674,7 +674,7 @@ pub(crate) fn init_device(
 				Ok(virt_fs_drv) => {
 					info!("Virtio filesystem driver initialized.");
 					let irq = device.get_irq().unwrap();
-					crate::arch::interrupts::add_irq_name(irq, "virtio");
+					crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 					Ok(VirtioDriver::Fs(alloc::boxed::Box::new(virt_fs_drv)))
 				}
 				Err(virtio_error) => {
@@ -695,7 +695,7 @@ pub(crate) fn init_device(
 				info!("Virtio network driver initialized.");
 
 				let irq = device.get_irq().unwrap();
-				crate::arch::interrupts::add_irq_name(irq, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 				info!("Virtio interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Net(alloc::boxed::Box::new(virt_net_drv)))
@@ -713,7 +713,7 @@ pub(crate) fn init_device(
 				info!("Virtio sock driver initialized.");
 
 				let irq = device.get_irq().unwrap();
-				crate::arch::interrupts::add_irq_name(irq, "virtio");
+				crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 				info!("Virtio interrupt handler at line {irq}");
 
 				Ok(VirtioDriver::Vsock(alloc::boxed::Box::new(virt_sock_drv)))

--- a/src/drivers/vsock/mod.rs
+++ b/src/drivers/vsock/mod.rs
@@ -19,7 +19,7 @@ use volatile::VolatileRef;
 use volatile::access::ReadOnly;
 
 use super::virtio::virtqueue::VirtQueue;
-use crate::config::VIRTIO_MAX_QUEUE_SIZE;
+use crate::config::{VIRTIO_MAX_QUEUE_SIZE, VSOCK_PACKET_SIZE};
 use crate::drivers::Driver;
 use crate::drivers::virtio::ControlRegisters;
 use crate::drivers::virtio::error::VirtioVsockError;
@@ -72,7 +72,7 @@ impl RxQueue {
 		Self {
 			vq: None,
 
-			packet_size: crate::VSOCK_PACKET_SIZE,
+			packet_size: VSOCK_PACKET_SIZE,
 		}
 	}
 
@@ -138,7 +138,7 @@ impl TxQueue {
 	pub fn new() -> Self {
 		Self {
 			vq: None,
-			packet_length: crate::VSOCK_PACKET_SIZE + size_of::<Hdr>() as u32,
+			packet_length: VSOCK_PACKET_SIZE + size_of::<Hdr>() as u32,
 		}
 	}
 

--- a/src/drivers/vsock/pci.rs
+++ b/src/drivers/vsock/pci.rs
@@ -1,6 +1,6 @@
 use volatile::VolatileRef;
 
-use crate::arch::pci::PciConfigRegion;
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::pci::PciDevice;
 use crate::drivers::virtio::error::{self, VirtioError};
 use crate::drivers::virtio::transport::pci;

--- a/src/executor/device.rs
+++ b/src/executor/device.rs
@@ -14,7 +14,7 @@ use smoltcp::socket::dns;
 use smoltcp::wire::{EthernetAddress, HardwareAddress, IpCidr, Ipv4Address, Ipv4Cidr};
 
 use super::network::{NetworkInterface, NetworkState};
-use crate::arch;
+use crate::arch::kernel::systemtime;
 #[cfg(feature = "write-pcap-file")]
 use crate::drivers::Driver;
 use crate::drivers::net::NetworkDriver;
@@ -80,7 +80,7 @@ impl<'a> NetworkInterface<'a> {
 
 		// use the current time based on the wall-clock time as seed
 		let mut config = Config::new(hardware_addr);
-		config.random_seed = (arch::kernel::systemtime::now_micros()) / 1_000_000;
+		config.random_seed = systemtime::now_micros() / 1_000_000;
 		if capabilities.medium == Medium::Ethernet {
 			config.hardware_addr = hardware_addr;
 		}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -18,7 +18,7 @@ use core::time::Duration;
 use crossbeam_utils::Backoff;
 use hermit_sync::without_interrupts;
 
-use crate::arch::core_local;
+use crate::arch::kernel::core_local;
 use crate::errno::Errno;
 use crate::executor::task::AsyncTask;
 use crate::io;

--- a/src/executor/network.rs
+++ b/src/executor/network.rs
@@ -22,7 +22,7 @@ use smoltcp::wire::{DnsQueryType, IpAddress};
 #[cfg(feature = "dhcpv4")]
 use smoltcp::wire::{IpCidr, Ipv4Address, Ipv4Cidr};
 
-use crate::arch;
+use crate::arch::kernel::systemtime;
 use crate::drivers::net::{NetworkDevice, NetworkDriver};
 #[cfg(feature = "dns")]
 use crate::errno::Errno;
@@ -123,7 +123,7 @@ fn start_endpoint() -> u16 {
 
 #[inline]
 pub(crate) fn now() -> Instant {
-	Instant::from_micros_const(arch::kernel::systemtime::now_micros().try_into().unwrap())
+	Instant::from_micros_const(systemtime::now_micros().try_into().unwrap())
 }
 
 #[cfg(feature = "dhcpv4")]

--- a/src/fd/socket/tcp.rs
+++ b/src/fd/socket/tcp.rs
@@ -10,12 +10,13 @@ use smoltcp::socket::tcp;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpEndpoint, Ipv4Address, Ipv6Address};
 
+use crate::config::DEFAULT_KEEP_ALIVE_INTERVAL;
 use crate::errno::Errno;
 use crate::executor::block_on;
 use crate::executor::network::{Handle, NIC, wake_network_waker};
 use crate::fd::{self, Endpoint, Fd, ListenEndpoint, ObjectInterface, PollEvent, SocketOption};
+use crate::io;
 use crate::syscalls::socket::Af;
-use crate::{DEFAULT_KEEP_ALIVE_INTERVAL, io};
 
 /// Further receives will be disallowed
 pub const SHUT_RD: i32 = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,9 @@ use core::hint::spin_loop;
 #[cfg(feature = "smp")]
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use self::arch::kernel;
 use self::arch::kernel::core_local::{core_id, core_scheduler};
-use self::arch::{interrupts, kernel};
+use self::arch::kernel::interrupts;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use self::arch::kernel::core_local::{core_id, core_scheduler};
 use self::arch::{interrupts, kernel};
-pub(crate) use crate::config::*;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 
 #[macro_use]
@@ -232,6 +231,8 @@ fn synch_all_cores() {
 /// Entry Point of Hermit for the Boot Processor
 #[cfg(target_os = "none")]
 fn boot_processor_main() -> ! {
+	use crate::config::USER_STACK_SIZE;
+
 	// Initialize the kernel and hardware.
 	mm::claim_initial_heap();
 	hermit_sync::Lazy::force(&console::CONSOLE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ mod macros;
 mod logging;
 
 pub mod arch;
+#[cfg(all(feature = "common-os", target_arch = "x86_64"))]
+pub mod common_os;
 mod config;
 pub mod console;
 mod drivers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use arch::core_local::*;
 
 pub(crate) use crate::arch::*;
-pub use crate::config::DEFAULT_STACK_SIZE;
 pub(crate) use crate::config::*;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 
@@ -111,7 +110,7 @@ mod logging;
 pub mod arch;
 #[cfg(all(feature = "common-os", target_arch = "x86_64"))]
 pub mod common_os;
-mod config;
+pub mod config;
 pub mod console;
 mod drivers;
 mod entropy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ use core::hint::spin_loop;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use self::arch::kernel::core_local::{core_id, core_scheduler};
-pub(crate) use crate::arch::*;
+use self::arch::{interrupts, kernel};
 pub(crate) use crate::config::*;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 
@@ -267,7 +267,7 @@ fn boot_processor_main() -> ! {
 		info!("FDT:\n{fdt:#?}");
 	}
 
-	boot_processor_init();
+	arch::boot_processor_init();
 
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
@@ -293,7 +293,7 @@ fn boot_processor_main() -> ! {
 /// Entry Point of Hermit for an Application Processor
 #[cfg(all(target_os = "none", feature = "smp"))]
 fn application_processor_main() -> ! {
-	application_processor_init();
+	arch::application_processor_init();
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
 	interrupts::enable();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,7 @@ use core::hint::spin_loop;
 #[cfg(feature = "smp")]
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use arch::core_local::*;
-
+use self::arch::kernel::core_local::{core_id, core_scheduler};
 pub(crate) use crate::arch::*;
 pub(crate) use crate::config::*;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ fn boot_processor_main() -> ! {
 		info!("FDT:\n{fdt:#?}");
 	}
 
-	arch::boot_processor_init();
+	kernel::boot_processor_init();
 
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
@@ -295,7 +295,7 @@ fn boot_processor_main() -> ! {
 /// Entry Point of Hermit for an Application Processor
 #[cfg(all(target_os = "none", feature = "smp"))]
 fn application_processor_main() -> ! {
-	arch::application_processor_init();
+	kernel::application_processor_init();
 	#[cfg(not(target_arch = "riscv64"))]
 	scheduler::add_current_core();
 	interrupts::enable();

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,6 +5,7 @@ use core::time::Duration;
 use anstyle::AnsiColor;
 use log::{Level, LevelFilter, Metadata, Record};
 
+use crate::arch::kernel::core_local;
 use crate::arch::processor;
 
 pub static KERNEL_LOGGER: KernelLogger = KernelLogger::new();
@@ -48,7 +49,7 @@ impl log::Log for KernelLogger {
 			.time()
 			.then(|| Duration::from_micros(processor::get_timer_ticks()));
 		let format_time = LogTime(time);
-		let core_id = crate::arch::core_local::core_id();
+		let core_id = core_local::core_id();
 		let level = ColorLevel(record.level());
 
 		let target = record.target();

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,8 +5,7 @@ use core::time::Duration;
 use anstyle::AnsiColor;
 use log::{Level, LevelFilter, Metadata, Record};
 
-use crate::arch::kernel::core_local;
-use crate::arch::processor;
+use crate::arch::kernel::{core_local, processor};
 
 pub static KERNEL_LOGGER: KernelLogger = KernelLogger::new();
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,6 +5,8 @@ use core::time::Duration;
 use anstyle::AnsiColor;
 use log::{Level, LevelFilter, Metadata, Record};
 
+use crate::arch::processor;
+
 pub static KERNEL_LOGGER: KernelLogger = KernelLogger::new();
 
 /// Data structure to filter kernel messages
@@ -44,7 +46,7 @@ impl log::Log for KernelLogger {
 
 		let time = self
 			.time()
-			.then(|| Duration::from_micros(crate::processor::get_timer_ticks()));
+			.then(|| Duration::from_micros(processor::get_timer_ticks()));
 		let format_time = LogTime(time);
 		let core_id = crate::arch::core_local::core_id();
 		let level = ColorLevel(record.level());

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -140,8 +140,8 @@ pub(crate) fn init() {
 		* BasePageSize::SIZE as usize
 		+ 2 * LargePageSize::SIZE as usize;
 	#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
-	let has_1gib_pages = arch::processor::supports_1gib_pages();
-	let has_2mib_pages = arch::processor::supports_2mib_pages();
+	let has_1gib_pages = arch::kernel::processor::supports_1gib_pages();
+	let has_2mib_pages = arch::kernel::processor::supports_2mib_pages();
 
 	let min_mem = if env::is_uefi() {
 		// On UEFI, the given memory is guaranteed free memory and the kernel is located before the given memory

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -18,10 +18,9 @@ use hermit_sync::*;
 use riscv::register::sstatus;
 use timer_interrupts::TimerList;
 
-use crate::arch::get_processor_count;
 use crate::arch::kernel::core_local::*;
-use crate::arch::kernel::interrupts;
 use crate::arch::kernel::scheduler::TaskStacks;
+use crate::arch::kernel::{get_processor_count, interrupts};
 #[cfg(target_arch = "riscv64")]
 use crate::arch::switch::switch_to_task;
 #[cfg(target_arch = "x86_64")]

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -18,7 +18,7 @@ use hermit_sync::*;
 use riscv::register::sstatus;
 use timer_interrupts::TimerList;
 
-use crate::arch::core_local::*;
+use crate::arch::kernel::core_local::*;
 use crate::arch::kernel::scheduler::TaskStacks;
 #[cfg(target_arch = "riscv64")]
 use crate::arch::switch::switch_to_task;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -18,13 +18,14 @@ use hermit_sync::*;
 use riscv::register::sstatus;
 use timer_interrupts::TimerList;
 
+use crate::arch::get_processor_count;
 use crate::arch::kernel::core_local::*;
+use crate::arch::kernel::interrupts;
 use crate::arch::kernel::scheduler::TaskStacks;
 #[cfg(target_arch = "riscv64")]
 use crate::arch::switch::switch_to_task;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::switch::{switch_to_fpu_owner, switch_to_task};
-use crate::arch::{get_processor_count, interrupts};
 use crate::errno::Errno;
 use crate::fd::{Fd, RawFd};
 use crate::scheduler::task::*;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -18,6 +18,7 @@ use hermit_sync::*;
 use riscv::register::sstatus;
 use timer_interrupts::TimerList;
 
+use crate::arch::kernel;
 use crate::arch::kernel::core_local::*;
 use crate::arch::kernel::scheduler::TaskStacks;
 #[cfg(target_arch = "riscv64")]
@@ -27,8 +28,8 @@ use crate::arch::kernel::switch::{switch_to_fpu_owner, switch_to_task};
 use crate::arch::kernel::{get_processor_count, interrupts};
 use crate::errno::Errno;
 use crate::fd::{Fd, RawFd};
+use crate::io;
 use crate::scheduler::task::*;
-use crate::{arch, io};
 
 pub mod task;
 pub mod timer_interrupts;
@@ -288,7 +289,7 @@ impl PerCoreScheduler {
 		debug!("Creating task {tid} with priority {prio} on core {core_id}");
 
 		if wakeup {
-			arch::wakeup_core(core_id);
+			kernel::wakeup_core(core_id);
 		}
 
 		tid
@@ -363,7 +364,7 @@ impl PerCoreScheduler {
 
 		// Wake up the CPU
 		if wakeup {
-			arch::wakeup_core(core_id);
+			kernel::wakeup_core(core_id);
 		}
 
 		tid
@@ -411,7 +412,7 @@ impl PerCoreScheduler {
 				.wakeup_tasks
 				.push_back(task);
 			// Wake up the CPU
-			arch::wakeup_core(task.get_core_id());
+			kernel::wakeup_core(task.get_core_id());
 		}
 	}
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -20,11 +20,11 @@ use timer_interrupts::TimerList;
 
 use crate::arch::kernel::core_local::*;
 use crate::arch::kernel::scheduler::TaskStacks;
-use crate::arch::kernel::{get_processor_count, interrupts};
 #[cfg(target_arch = "riscv64")]
-use crate::arch::switch::switch_to_task;
+use crate::arch::kernel::switch::switch_to_task;
 #[cfg(target_arch = "x86_64")]
-use crate::arch::switch::{switch_to_fpu_owner, switch_to_task};
+use crate::arch::kernel::switch::{switch_to_fpu_owner, switch_to_task};
+use crate::arch::kernel::{get_processor_count, interrupts};
 use crate::errno::Errno;
 use crate::fd::{Fd, RawFd};
 use crate::scheduler::task::*;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -19,6 +19,7 @@ use riscv::register::sstatus;
 use timer_interrupts::TimerList;
 
 use crate::arch::core_local::*;
+use crate::arch::kernel::scheduler::TaskStacks;
 #[cfg(target_arch = "riscv64")]
 use crate::arch::switch::switch_to_task;
 #[cfg(target_arch = "x86_64")]
@@ -26,7 +27,6 @@ use crate::arch::switch::{switch_to_fpu_owner, switch_to_task};
 use crate::arch::{get_processor_count, interrupts};
 use crate::errno::Errno;
 use crate::fd::{Fd, RawFd};
-use crate::kernel::scheduler::TaskStacks;
 use crate::scheduler::task::*;
 use crate::{arch, io};
 
@@ -136,7 +136,7 @@ impl PerCoreSchedulerExt for &mut PerCoreScheduler {
 		use arm_gic::IntId;
 		use arm_gic::gicv3::{GicCpuInterface, SgiTarget, SgiTargetGroup};
 
-		use crate::interrupts::SGI_RESCHED;
+		use crate::arch::kernel::interrupts::SGI_RESCHED;
 
 		dsb(NSH);
 		isb(SY);

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -19,7 +19,7 @@ use memory_addresses::VirtAddr;
 #[cfg(not(feature = "common-os"))]
 use self::tls::Tls;
 use super::timer_interrupts::{Source, create_timer_abs};
-use crate::arch::core_local::*;
+use crate::arch::kernel::core_local::*;
 use crate::arch::processor::{self, FPUState};
 use crate::arch::scheduler::TaskStacks;
 use crate::fd::{Fd, RawFd, stdio};

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -19,8 +19,8 @@ use memory_addresses::VirtAddr;
 #[cfg(not(feature = "common-os"))]
 use self::tls::Tls;
 use super::timer_interrupts::{Source, create_timer_abs};
-use crate::arch;
 use crate::arch::core_local::*;
+use crate::arch::processor::{self, FPUState};
 use crate::arch::scheduler::TaskStacks;
 use crate::fd::{Fd, RawFd, stdio};
 use crate::scheduler::CoreId;
@@ -373,7 +373,7 @@ pub(crate) struct Task {
 	/// Last stack pointer on the user stack before jumping to kernel space
 	pub user_stack_pointer: VirtAddr,
 	/// Last FPU state before a context switch to another task using the FPU
-	pub last_fpu_state: arch::processor::FPUState,
+	pub last_fpu_state: FPUState,
 	/// ID of the core this task is running on
 	pub core_id: CoreId,
 	/// Stack of the task
@@ -410,14 +410,14 @@ impl Task {
 			prio: task_prio,
 			last_stack_pointer: VirtAddr::zero(),
 			user_stack_pointer: VirtAddr::zero(),
-			last_fpu_state: arch::processor::FPUState::new(),
+			last_fpu_state: FPUState::new(),
 			core_id,
 			stacks,
 			object_map,
 			#[cfg(not(feature = "common-os"))]
 			tls: None,
 			#[cfg(all(target_arch = "x86_64", feature = "common-os"))]
-			root_page_table: arch::create_new_root_page_table(),
+			root_page_table: crate::arch::create_new_root_page_table(),
 		}
 	}
 
@@ -458,7 +458,7 @@ impl Task {
 			prio: IDLE_PRIO,
 			last_stack_pointer: VirtAddr::zero(),
 			user_stack_pointer: VirtAddr::zero(),
-			last_fpu_state: arch::processor::FPUState::new(),
+			last_fpu_state: FPUState::new(),
 			core_id,
 			stacks: TaskStacks::from_boot_stacks(),
 			object_map: OBJECT_MAP.get().unwrap().clone(),
@@ -602,7 +602,7 @@ impl BlockedTaskQueue {
 	/// at least one task has elapsed.
 	pub fn handle_waiting_tasks(&mut self, ready_queue: &mut PriorityTaskQueue) {
 		// Get the current time.
-		let time = arch::processor::get_timer_ticks();
+		let time = processor::get_timer_ticks();
 
 		// Get the wakeup time of this task and check if we have reached the first task
 		// that hasn't elapsed yet or waits indefinitely.

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -21,7 +21,7 @@ use self::tls::Tls;
 use super::timer_interrupts::{Source, create_timer_abs};
 use crate::arch::kernel::core_local::*;
 use crate::arch::kernel::processor::{self, FPUState};
-use crate::arch::scheduler::TaskStacks;
+use crate::arch::kernel::scheduler::TaskStacks;
 use crate::fd::{Fd, RawFd, stdio};
 use crate::scheduler::CoreId;
 

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -20,7 +20,7 @@ use memory_addresses::VirtAddr;
 use self::tls::Tls;
 use super::timer_interrupts::{Source, create_timer_abs};
 use crate::arch::kernel::core_local::*;
-use crate::arch::processor::{self, FPUState};
+use crate::arch::kernel::processor::{self, FPUState};
 use crate::arch::scheduler::TaskStacks;
 use crate::fd::{Fd, RawFd, stdio};
 use crate::scheduler::CoreId;

--- a/src/scheduler/task/mod.rs
+++ b/src/scheduler/task/mod.rs
@@ -417,7 +417,7 @@ impl Task {
 			#[cfg(not(feature = "common-os"))]
 			tls: None,
 			#[cfg(all(target_arch = "x86_64", feature = "common-os"))]
-			root_page_table: crate::arch::create_new_root_page_table(),
+			root_page_table: crate::arch::mm::create_new_root_page_table(),
 		}
 	}
 

--- a/src/scheduler/task/tls.rs
+++ b/src/scheduler/task/tls.rs
@@ -162,7 +162,7 @@ impl Tls {
 				}
 			}
 			target_arch = "x86_64" => {
-				use crate::arch::x86_64::kernel::processor;
+				use crate::arch::kernel::processor;
 
 				let addr = self.thread_ptr().expose_provenance();
 				processor::writefs(addr);

--- a/src/scheduler/timer_interrupts.rs
+++ b/src/scheduler/timer_interrupts.rs
@@ -93,7 +93,7 @@ pub fn create_timer(source: Source, wakeup_micros: u64) {
 	create_timer_abs(
 		source,
 		// get_timer_ticks should always return a nonzero value
-		crate::arch::processor::get_timer_ticks() + wakeup_micros,
+		crate::arch::kernel::processor::get_timer_ticks() + wakeup_micros,
 	);
 }
 
@@ -137,7 +137,7 @@ pub fn clear_active_and_set_next() {
 	// Either way, this means that QEMU *thinks* the time has passed, so it
 	// probably has and knows better than we do.
 	// We can cheat a bit and adjust all timers slightly based on this
-	let timer_ticks = crate::arch::processor::get_timer_ticks();
+	let timer_ticks = crate::arch::kernel::processor::get_timer_ticks();
 	if prev_wakeup_time > timer_ticks {
 		let offset = prev_wakeup_time - timer_ticks;
 		timers.adjust_by(offset);

--- a/src/scheduler/timer_interrupts.rs
+++ b/src/scheduler/timer_interrupts.rs
@@ -1,9 +1,9 @@
 use core::mem;
 
-use crate::core_local::core_scheduler;
+use crate::arch::kernel::core_local::core_scheduler;
+use crate::arch::set_oneshot_timer;
 #[cfg(feature = "net")]
 use crate::executor::network::wake_network_waker;
-use crate::set_oneshot_timer;
 
 /// A possible timer interrupt source (i.e. reason the timer interrupt was set
 /// up).

--- a/src/scheduler/timer_interrupts.rs
+++ b/src/scheduler/timer_interrupts.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use crate::arch::kernel::core_local::core_scheduler;
-use crate::arch::set_oneshot_timer;
+use crate::arch::kernel::set_oneshot_timer;
 #[cfg(feature = "net")]
 use crate::executor::network::wake_network_waker;
 

--- a/src/synch/recmutex.rs
+++ b/src/synch/recmutex.rs
@@ -1,6 +1,6 @@
 use hermit_sync::TicketMutex;
 
-use crate::arch::core_local::*;
+use crate::arch::kernel::core_local::*;
 use crate::scheduler::PerCoreSchedulerExt;
 use crate::scheduler::task::{TaskHandlePriorityQueue, TaskId};
 

--- a/src/synch/semaphore.rs
+++ b/src/synch/semaphore.rs
@@ -2,7 +2,7 @@
 use crossbeam_utils::Backoff;
 use hermit_sync::InterruptTicketMutex;
 
-use crate::arch::core_local::*;
+use crate::arch::kernel::core_local::*;
 use crate::scheduler::PerCoreSchedulerExt;
 use crate::scheduler::task::TaskHandlePriorityQueue;
 

--- a/src/synch/semaphore.rs
+++ b/src/synch/semaphore.rs
@@ -70,7 +70,8 @@ impl Semaphore {
 		let backoff = Backoff::new();
 		let core_scheduler = core_scheduler();
 
-		let wakeup_time = time.map(|ms| crate::arch::processor::get_timer_ticks() + ms * 1000);
+		let wakeup_time =
+			time.map(|ms| crate::arch::kernel::processor::get_timer_ticks() + ms * 1000);
 
 		// Loop until we have acquired the semaphore.
 		loop {
@@ -81,7 +82,7 @@ impl Semaphore {
 				locked_state.count -= 1;
 				return true;
 			} else if let Some(t) = wakeup_time
-				&& t < crate::arch::processor::get_timer_ticks()
+				&& t < crate::arch::kernel::processor::get_timer_ticks()
 			{
 				// We could not acquire the semaphore and we were woken up because the wakeup time has elapsed.
 				// Don't try again and return the failure status.

--- a/src/syscalls/entropy.rs
+++ b/src/syscalls/entropy.rs
@@ -2,7 +2,7 @@ use core::slice;
 
 use hermit_sync::TicketMutex;
 
-use crate::arch;
+use crate::arch::processor;
 use crate::entropy::{self, Flags};
 use crate::errno::Errno;
 
@@ -115,7 +115,7 @@ pub extern "C" fn sys_srand(seed: u32) {
 }
 
 pub(crate) fn init_entropy() {
-	let seed: u32 = arch::processor::get_timestamp() as u32;
+	let seed: u32 = processor::get_timestamp() as u32;
 
 	*PARK_MILLER_LEHMER_SEED.lock() = seed;
 }

--- a/src/syscalls/entropy.rs
+++ b/src/syscalls/entropy.rs
@@ -2,7 +2,7 @@ use core::slice;
 
 use hermit_sync::TicketMutex;
 
-use crate::arch::processor;
+use crate::arch::kernel::processor;
 use crate::entropy::{self, Flags};
 use crate::errno::Errno;
 

--- a/src/syscalls/mman.rs
+++ b/src/syscalls/mman.rs
@@ -13,10 +13,9 @@ use free_list::{FreeList, PageLayout, PageRange};
 use hermit_sync::SpinMutex;
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::arch;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
-use crate::arch::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 
 bitflags! {
@@ -67,7 +66,7 @@ pub extern "C" fn sys_mmap(size: usize, prot_flags: MemoryProtection, ret: &mut 
 		flags.execute_disable();
 	}
 
-	arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+	paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
 
 	*ret = virtual_address.as_mut_ptr();
 
@@ -86,11 +85,8 @@ pub extern "C" fn sys_munmap(ptr: *mut u8, size: usize) -> i32 {
 		return 0;
 	}
 
-	if let Some(physical_address) = arch::mm::paging::virtual_to_physical(virtual_address) {
-		arch::mm::paging::unmap::<BasePageSize>(
-			virtual_address,
-			size / BasePageSize::SIZE as usize,
-		);
+	if let Some(physical_address) = paging::virtual_to_physical(virtual_address) {
+		paging::unmap::<BasePageSize>(virtual_address, size / BasePageSize::SIZE as usize);
 		debug!("Unmapping {virtual_address:X} ({size}) -> {physical_address:X}");
 
 		let frame_range =
@@ -127,14 +123,14 @@ pub extern "C" fn sys_mprotect(ptr: *mut u8, size: usize, prot_flags: MemoryProt
 	let virtual_address = VirtAddr::from_ptr(ptr);
 
 	debug!("Mprotect {virtual_address:X} ({size}) -> {prot_flags:?})");
-	if let Some(physical_address) = arch::mm::paging::virtual_to_physical(virtual_address) {
-		arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+	if let Some(physical_address) = paging::virtual_to_physical(virtual_address) {
+		paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
 		0
 	} else {
 		let frame_layout = PageLayout::from_size(size).unwrap();
 		let frame_range = FrameAlloc::allocate(frame_layout).unwrap();
 		let physical_address = PhysAddr::from(frame_range.start());
-		arch::mm::paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
+		paging::map::<BasePageSize>(virtual_address, physical_address, count, flags);
 		0
 	}
 }

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -272,7 +272,7 @@ pub(crate) fn shutdown(arg: i32) -> ! {
 	// This is a stable message used for detecting exit codes for different hypervisors.
 	panic_println!("exit status {arg}");
 
-	crate::arch::processor::shutdown(arg)
+	crate::arch::kernel::processor::shutdown(arg)
 }
 
 #[hermit_macro::system(errno)]

--- a/src/syscalls/processor.rs
+++ b/src/syscalls/processor.rs
@@ -1,4 +1,4 @@
-use crate::arch::get_processor_count;
+use crate::arch::kernel::get_processor_count;
 
 /// Returns the number of processors currently online.
 #[hermit_macro::system]

--- a/src/syscalls/processor.rs
+++ b/src/syscalls/processor.rs
@@ -17,5 +17,5 @@ pub extern "C" fn sys_available_parallelism() -> usize {
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub extern "C" fn sys_get_processor_frequency() -> u16 {
-	crate::arch::processor::get_frequency()
+	crate::arch::kernel::processor::get_frequency()
 }

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -3,7 +3,7 @@ use alloc::collections::BTreeMap;
 use hermit_sync::InterruptTicketMutex;
 
 use crate::arch::kernel::core_local::*;
-use crate::arch::processor::{get_frequency, get_timestamp};
+use crate::arch::kernel::processor::{get_frequency, get_timestamp};
 use crate::config::USER_STACK_SIZE;
 use crate::errno::Errno;
 use crate::scheduler::PerCoreSchedulerExt;
@@ -69,7 +69,7 @@ pub(super) fn usleep(usecs: u64) {
 	if usecs >= 10_000 {
 		// Enough time to set a wakeup timer and block the current task.
 		debug!("sys_usleep blocking the task for {usecs} microseconds");
-		let wakeup_time = arch::processor::get_timer_ticks() + usecs;
+		let wakeup_time = arch::kernel::processor::get_timer_ticks() + usecs;
 		let core_scheduler = core_scheduler();
 		core_scheduler.block_current_task(Some(wakeup_time));
 
@@ -202,7 +202,7 @@ static BLOCKED_TASKS: InterruptTicketMutex<BTreeMap<TaskId, TaskHandle>> =
 	InterruptTicketMutex::new(BTreeMap::new());
 
 fn block_current_task(timeout: Option<u64>) {
-	let wakeup_time = timeout.map(|t| arch::processor::get_timer_ticks() + t * 1000);
+	let wakeup_time = timeout.map(|t| arch::kernel::processor::get_timer_ticks() + t * 1000);
 	let core_scheduler = core_scheduler();
 	let handle = core_scheduler.get_current_task_handle();
 	let tid = core_scheduler.get_current_task_id();

--- a/src/syscalls/tasks.rs
+++ b/src/syscalls/tasks.rs
@@ -2,7 +2,7 @@ use alloc::collections::BTreeMap;
 
 use hermit_sync::InterruptTicketMutex;
 
-use crate::arch::core_local::*;
+use crate::arch::kernel::core_local::*;
 use crate::arch::processor::{get_frequency, get_timestamp};
 use crate::config::USER_STACK_SIZE;
 use crate::errno::Errno;

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -1,4 +1,5 @@
-use crate::arch;
+use crate::arch::kernel::systemtime;
+use crate::arch::processor;
 use crate::errno::Errno;
 use crate::syscalls::usleep;
 use crate::time::{itimerval, timespec, timeval};
@@ -63,11 +64,11 @@ pub unsafe extern "C" fn sys_clock_gettime(clock_id: clockid_t, tp: *mut timespe
 
 	match clock_id {
 		CLOCK_REALTIME => {
-			*result = timespec::from_usec(arch::kernel::systemtime::now_micros() as i64);
+			*result = timespec::from_usec(systemtime::now_micros() as i64);
 			0
 		}
 		CLOCK_MONOTONIC => {
-			*result = timespec::from_usec(arch::processor::get_timer_ticks() as i64);
+			*result = timespec::from_usec(processor::get_timer_ticks() as i64);
 			0
 		}
 		_ => {
@@ -111,9 +112,9 @@ pub unsafe extern "C" fn sys_clock_nanosleep(
 
 			if flags & TIMER_ABSTIME > 0 {
 				if clock_id == CLOCK_REALTIME {
-					microseconds -= arch::kernel::systemtime::now_micros();
+					microseconds -= systemtime::now_micros();
 				} else {
-					microseconds -= arch::processor::get_timer_ticks();
+					microseconds -= processor::get_timer_ticks();
 				}
 			}
 
@@ -144,7 +145,7 @@ pub unsafe extern "C" fn sys_gettimeofday(tp: *mut timeval, tz: usize) -> i32 {
 	if let Some(result) = unsafe { tp.as_mut() } {
 		// Return the current time based on the wallclock time when we were booted up
 		// plus the current timer ticks.
-		let microseconds = arch::kernel::systemtime::now_micros();
+		let microseconds = systemtime::now_micros();
 		*result = timeval::from_usec(microseconds as i64);
 	}
 

--- a/src/syscalls/timer.rs
+++ b/src/syscalls/timer.rs
@@ -1,5 +1,4 @@
-use crate::arch::kernel::systemtime;
-use crate::arch::processor;
+use crate::arch::kernel::{processor, systemtime};
 use crate::errno::Errno;
 use crate::syscalls::usleep;
 use crate::time::{itimerval, timespec, timeval};

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use crate::arch;
+use crate::arch::kernel::systemtime;
 
 #[allow(non_camel_case_types)]
 pub type time_t = i64;
@@ -80,9 +80,7 @@ impl SystemTime {
 
 	/// Returns the system time corresponding to "now".
 	pub fn now() -> Self {
-		Self(timespec::from_usec(
-			arch::kernel::systemtime::now_micros() as i64
-		))
+		Self(timespec::from_usec(systemtime::now_micros() as i64))
 	}
 
 	/// Returns the amount of time elapsed from an earlier point in time.

--- a/src/uhyve.rs
+++ b/src/uhyve.rs
@@ -5,7 +5,7 @@ use uhyve_interface::GuestPhysAddr;
 use uhyve_interface::v2::parameters::SerialWriteBufferParams;
 use uhyve_interface::v2::{Hypercall, HypercallAddress};
 
-use crate::arch;
+use crate::arch::kernel::processor;
 use crate::arch::mm::paging::virtual_to_physical;
 
 #[cfg(target_os = "none")]
@@ -93,6 +93,6 @@ pub(crate) fn uhyve_hypercall(hypercall: Hypercall<'_>) {
 pub fn shutdown(error_code: i32) -> ! {
 	uhyve_hypercall(Hypercall::Exit(error_code));
 	loop {
-		arch::processor::halt();
+		processor::halt();
 	}
 }


### PR DESCRIPTION
This PR cleans up imports from the arch module. This unifies the way arch-specific items are imported and makes things less confusing. Unfortunately, this creates a lot of churn, but I think this is overdue.

This potentially impacts projects that use the kernel's Rust API:
- `load_application` and `jump_to_user_land` are now exported at `hermit::common_os` instead of `hermit::arch`.
- `DEFAULT_STACK_SIZE` is now exported at `hermit::config` instead of `hermit`.