### PR TITLE
fix(scheduler): drop the global TASKS entry on exit

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -194,6 +194,8 @@ impl PerCoreSchedulerExt for &mut PerCoreScheduler {
 					self.custom_wakeup(task);
 				}
 			}
+
+			TASKS.lock().remove(&current_id);
 		});
 
 		self.reschedule();


### PR DESCRIPTION
The global TASKS BTreeMap got a new TaskHandle on every fork/spawn but was never cleaned up. This made join()'s
TASKS.contains_key(&id) always return true for any tid that ever existed, and slowly leaked TaskHandles. exit() already removes the WAITING_TASKS queue — remove the TASKS entry symmetrically.