### PR TITLE
syscalls/socket: return 0 for unimplemented SOL_SOCKET options in sys_setsockopt

### DIFF
--- a/src/syscalls/socket/mod.rs
+++ b/src/syscalls/socket/mod.rs
@@ -920,7 +920,13 @@ pub unsafe extern "C" fn sys_setsockopt(
 	optval: *const c_void,
 	optlen: socklen_t,
 ) -> i32 {
-	if level == SOL_SOCKET && optname == SO_REUSEADDR {
+	if level == SOL_SOCKET {
+		// SOL_SOCKET = 4095 cannot be represented as Ipproto (u8), so the
+		// conversion below would always return EINVAL for any SOL_SOCKET option.
+		// Return 0 for SO_REUSEADDR (no-op, already the default) and silently
+		// succeed for other common options (SO_RCVTIMEO, SO_SNDTIMEO, SO_KEEPALIVE,
+		// SO_LINGER, SO_SNDBUF, SO_RCVBUF) so that Rust std's TCP socket setup
+		// does not fail during connect/accept.
 		return 0;
 	}
 


### PR DESCRIPTION
## Problem

`SOL_SOCKET` is defined as `4095` in hermit-abi. This value cannot be represented as `u8`, so the `Ipproto::try_from` conversion that follows the existing `SOL_SOCKET` check always fails and returns `EINVAL` for every `SOL_SOCKET` option **except** `SO_REUSEADDR`.

This causes Rust std's TCP socket setup to fail on hermit: during `connect()` and `accept()`, std internally calls `setsockopt` with `SOL_SOCKET` level (e.g. `SO_RCVTIMEO`, `SO_SNDTIMEO`, `SO_KEEPALIVE`) and the resulting `EINVAL` (os error 22) surfaces to userspace, making plain HTTP connections impossible.

Reproduced while running a Rust HTTP client (ureq 2.x) inside a hermit unikernel on uhyve with virtio-net. Every `connect()` returned `os error 22` before this fix.

## Fix

Match on `SOL_SOCKET` **before** the `Ipproto` conversion and return `0` for all options at that level. Unimplemented options are silently treated as no-ops — consistent with Linux behaviour for unsupported socket options on a given socket type.

`SO_REUSEADDR` continues to work as before (it was already returning `0`).

## Testing

Verified with a ureq-based HTTP client compiled for `x86_64-unknown-hermit` making GET/POST requests over virtio-net to a LAN server. Before this fix: every call failed with `os error 22`. After: connections succeed normally.