### PR TITLE
fd/eventfd: wake all registered pollers on write, not just one

### DIFF
--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -108,8 +108,15 @@ impl ObjectInterface for EventFd {
 
 						cx.wake_by_ref();
 					}
-				} else if let Some(cx) = guard.read_queue.pop_front() {
-					cx.wake_by_ref();
+				} else {
+					// The eventfd is now readable. Wake *all* registered pollers, not
+					// just one: a readable notification is level-triggered, and the
+					// `poll`-based fd multiplexing re-registers a fresh waker on every
+					// poll, so the queue accumulates stale wakers — waking only the
+					// oldest (`pop_front`) can wake a dead waker and miss the real one.
+					for waker in guard.read_queue.drain(..) {
+						waker.wake();
+					}
 				}
 
 				Poll::Ready(Ok(len))


### PR DESCRIPTION
A write made the eventfd readable but only woke the oldest waiter (`pop_front`). With the poll(2)-based fd multiplexing re-registering a fresh waker on every poll, the read queue accumulates stale wakers, so the single wake could hit a dead waker and miss the real one — a cross-thread wakeup (e.g. tokio's I/O driver) could then be lost. Drain the queue and wake every registered poller, matching level-triggered readiness.