### PR TITLE
scheduler: add optional preemptive scheduling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,9 @@ virtio-fs = ["virtio", "dep:fuse-abi", "fuse-abi/num_enum"]
 ## Enables the virtio-vsock driver.
 virtio-vsock = ["virtio"]
 
+## Enable preemptive scheduling
+preemptive = []
+
 #! ### Other Drivers
 
 ## Enables the _Video Graphics Array_ (VGA) driver.

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -20,6 +20,8 @@ use timer_interrupts::TimerList;
 
 use crate::arch::kernel;
 use crate::arch::kernel::core_local::*;
+#[cfg(feature = "preemptive")]
+use crate::arch::kernel::processor;
 use crate::arch::kernel::scheduler::TaskStacks;
 #[cfg(target_arch = "riscv64")]
 use crate::arch::kernel::switch::switch_to_task;
@@ -35,6 +37,11 @@ pub mod task;
 pub mod timer_interrupts;
 
 static NO_TASKS: AtomicU32 = AtomicU32::new(0);
+/// Length of a preemptive scheduling time slice, in microseconds (10 ms). With
+/// rhyve's external-interrupt exiting this also bounds the guest VM-exit rate
+/// during contention (one exit per slice).
+#[cfg(feature = "preemptive")]
+const PREEMPTION_SLICE_US: u64 = 10_000;
 /// Map between Core ID and per-core scheduler
 #[cfg(feature = "smp")]
 static SCHEDULER_INPUTS: SpinMutex<Vec<&InterruptTicketMutex<SchedulerInput>>> =
@@ -398,6 +405,14 @@ impl PerCoreScheduler {
 		without_interrupts(|| {
 			let task = self.blocked_tasks.custom_wakeup(task);
 			self.ready_queue.push(task);
+			// The woken task is now ready. Arm the preemption timer so the running
+			// task — which may be CPU-bound and never yield — is preempted soon and
+			// the newcomer gets to run.
+			#[cfg(feature = "preemptive")]
+			{
+				let deadline = processor::get_timer_ticks() + PREEMPTION_SLICE_US;
+				timer_interrupts::create_timer_abs(timer_interrupts::Source::Preemption, deadline);
+			}
 		});
 	}
 
@@ -407,6 +422,16 @@ impl PerCoreScheduler {
 			without_interrupts(|| {
 				let task = self.blocked_tasks.custom_wakeup(task);
 				self.ready_queue.push(task);
+				// The woken task is now ready on this core. Arm the preemption timer
+				// so the running (possibly non-yielding) task is preempted soon.
+				#[cfg(feature = "preemptive")]
+				{
+					let deadline = processor::get_timer_ticks() + PREEMPTION_SLICE_US;
+					timer_interrupts::create_timer_abs(
+						timer_interrupts::Source::Preemption,
+						deadline,
+					);
+				}
 			});
 		} else {
 			get_scheduler_input(task.get_core_id())
@@ -798,6 +823,16 @@ impl PerCoreScheduler {
 
 		if id == new_id {
 			return None;
+		}
+
+		// Preemptive round-robin: arm a one-shot time-slice timer for the task we
+		// are about to run, but only while other tasks are ready — with no
+		// contention the system stays tickless. When the slice expires, the timer
+		// interrupt's `reschedule()` switches to the next ready task.
+		#[cfg(feature = "preemptive")]
+		if !self.ready_queue.is_empty() {
+			let deadline = processor::get_timer_ticks() + PREEMPTION_SLICE_US;
+			timer_interrupts::create_timer_abs(timer_interrupts::Source::Preemption, deadline);
 		}
 
 		// Tell the scheduler about the new task.

--- a/src/scheduler/timer_interrupts.rs
+++ b/src/scheduler/timer_interrupts.rs
@@ -11,6 +11,11 @@ use crate::executor::network::wake_network_waker;
 pub enum Source {
 	Network,
 	Scheduler,
+	/// Preemptive time-slice timer (round-robin between equally prioritized,
+	/// ready tasks). Only armed with the `preemptive` feature and when there is
+	/// contention.
+	#[cfg(feature = "preemptive")]
+	Preemption,
 }
 
 /// A slot in the timer list. Each source is represented once. This is so that
@@ -25,9 +30,15 @@ pub struct Slot {
 	wakeup_time: u64,
 }
 
+#[cfg(feature = "preemptive")]
+const NUMBER_OF_SLOTS: usize = 3;
+
+#[cfg(not(feature = "preemptive"))]
+const NUMBER_OF_SLOTS: usize = 2;
+
 // List of timers with one entry for every possible source.
 #[derive(Debug)]
-pub struct TimerList([Slot; 2]);
+pub struct TimerList([Slot; NUMBER_OF_SLOTS]);
 
 impl TimerList {
 	pub fn new() -> Self {
@@ -38,6 +49,11 @@ impl TimerList {
 			},
 			Slot {
 				source: Source::Scheduler,
+				wakeup_time: u64::MAX,
+			},
+			#[cfg(feature = "preemptive")]
+			Slot {
+				source: Source::Preemption,
 				wakeup_time: u64::MAX,
 			},
 		])


### PR DESCRIPTION
The scheduler is tickless (a TSC-deadline one-shot timer), so a CPU-bound task that never blocks or yields keeps its core indefinitely. Add an optional `preemptive` feature that round-robins between ready tasks via a time slice.

A new `Source::Preemption` timer slot is armed for `now + 10ms` whenever the scheduler switches to a task while others are ready, and whenever `custom_wakeup` makes a task ready (so a freshly woken task preempts a non-yielding runner soon). When the slice expires, the timer handler's existing `reschedule()` switches to the next ready task. With no contention nothing is armed, so the system stays tickless.