### PR TITLE
feat(env): drop support for non-FDT-based RAM boot info

### DIFF
--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -43,10 +43,6 @@ pub fn is_uhyve_with_pci() -> bool {
 	false
 }
 
-pub fn get_limit() -> usize {
-	env::boot_info().hardware_info.phys_addr_range.end as usize
-}
-
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
 	let fdt = env::fdt().unwrap();

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -19,8 +19,6 @@ use core::arch::global_asm;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 use core::{ptr, str};
 
-use memory_addresses::PhysAddr;
-
 pub(crate) use self::interrupts::wakeup_core;
 pub(crate) use self::processor::set_oneshot_timer;
 use crate::arch::aarch64::kernel::core_local::*;
@@ -43,10 +41,6 @@ global_asm!(include_str!("start.s"));
 
 pub fn is_uhyve_with_pci() -> bool {
 	false
-}
-
-pub fn get_ram_address() -> PhysAddr {
-	PhysAddr::new(env::boot_info().hardware_info.phys_addr_range.start)
 }
 
 pub fn get_limit() -> usize {

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -8,7 +8,7 @@ use align_address::Align;
 use free_list::PageLayout;
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::env::get_ram_address;
+use crate::env;
 use crate::mm::{FrameAlloc, PageRangeAllocator};
 
 /// Pointer to the root page table (called "Level 0" in ARM terminology).
@@ -708,7 +708,7 @@ pub fn unmap<S: PageSize>(virtual_address: VirtAddr, count: usize) {
 }
 
 pub unsafe fn init() {
-	let ram_start = get_ram_address();
+	let ram_start = env::get_ram_address();
 	info!("RAM starts at physical address {ram_start:p}");
 
 	// determine physical address size

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -8,7 +8,6 @@ use align_address::Align;
 use free_list::PageLayout;
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::env;
 use crate::mm::{FrameAlloc, PageRangeAllocator};
 
 /// Pointer to the root page table (called "Level 0" in ARM terminology).
@@ -708,9 +707,6 @@ pub fn unmap<S: PageSize>(virtual_address: VirtAddr, count: usize) {
 }
 
 pub unsafe fn init() {
-	let ram_start = env::get_ram_address();
-	info!("RAM starts at physical address {ram_start:p}");
-
 	// determine physical address size
 	let id_aa64mmfr0_el1 = ID_AA64MMFR0_EL1.extract();
 

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -16,7 +16,6 @@ use core::ptr;
 use core::sync::atomic::{AtomicPtr, AtomicU32, AtomicU64, Ordering};
 
 use free_list::PageLayout;
-use memory_addresses::PhysAddr;
 use riscv::register::sstatus;
 
 pub(crate) use self::processor::{set_oneshot_timer, wakeup_core};
@@ -43,10 +42,6 @@ static NUM_CPUS: AtomicU32 = AtomicU32::new(0);
 
 pub fn is_uhyve_with_pci() -> bool {
 	false
-}
-
-pub fn get_ram_address() -> PhysAddr {
-	PhysAddr::new(env::boot_info().hardware_info.phys_addr_range.start)
 }
 
 pub fn get_limit() -> usize {

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -44,11 +44,6 @@ pub fn is_uhyve_with_pci() -> bool {
 	false
 }
 
-pub fn get_limit() -> usize {
-	(env::boot_info().hardware_info.phys_addr_range.end
-		- env::boot_info().hardware_info.phys_addr_range.start) as usize
-}
-
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
 	NUM_CPUS.load(Ordering::Relaxed)

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -6,7 +6,6 @@ use core::slice;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
 use hermit_entry::boot_info::{PlatformInfo, RawBootInfo};
-use memory_addresses::PhysAddr;
 use x86_64::registers::control::{Cr0, Cr4};
 
 pub(crate) use self::apic::{set_oneshot_timer, wakeup_core};
@@ -38,10 +37,6 @@ mod syscall;
 pub(crate) mod systemtime;
 #[cfg(feature = "vga")]
 pub mod vga;
-
-pub fn get_ram_address() -> PhysAddr {
-	PhysAddr::new(env::boot_info().hardware_info.phys_addr_range.start)
-}
 
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
@@ -226,7 +221,7 @@ where
 
 	use align_address::Align;
 	use free_list::PageLayout;
-	use memory_addresses::VirtAddr;
+	use memory_addresses::{PhysAddr, VirtAddr};
 	use x86_64::structures::paging::{PageSize, Size4KiB as BasePageSize};
 
 	use crate::arch::x86_64::mm::paging::{self, PageTableEntryFlags, PageTableEntryFlagsExt};

--- a/src/env.rs
+++ b/src/env.rs
@@ -60,8 +60,11 @@ pub fn fdt() -> Option<Fdt<'static>> {
 	})
 }
 
-pub(crate) fn get_ram_address() -> PhysAddr {
-	PhysAddr::new(boot_info().hardware_info.phys_addr_range.start)
+pub(crate) fn get_ram_address() -> Option<PhysAddr> {
+	let fdt = fdt()?;
+	let memory = fdt.memory();
+	let ptr = memory.regions().next()?.starting_address;
+	Some(ptr.expose_provenance().into())
 }
 
 /// Returns the RSDP physical address if available.

--- a/src/env.rs
+++ b/src/env.rs
@@ -11,9 +11,9 @@ use hashbrown::HashMap;
 use hashbrown::hash_map::Iter;
 use hermit_entry::boot_info::{BootInfo, PlatformInfo, RawBootInfo};
 use hermit_sync::OnceCell;
+use memory_addresses::PhysAddr;
 
 use crate::arch::kernel;
-pub(crate) use crate::arch::kernel::get_ram_address;
 
 static BOOT_INFO: OnceCell<BootInfo> = OnceCell::new();
 
@@ -58,6 +58,10 @@ pub fn fdt() -> Option<Fdt<'static>> {
 		let ptr = ptr::with_exposed_provenance(fdt.get().try_into().unwrap());
 		unsafe { Fdt::from_ptr(ptr).unwrap() }
 	})
+}
+
+pub(crate) fn get_ram_address() -> PhysAddr {
+	PhysAddr::new(boot_info().hardware_info.phys_addr_range.start)
 }
 
 /// Returns the RSDP physical address if available.

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -146,8 +146,8 @@ pub(crate) fn init() {
 		// On UEFI, the given memory is guaranteed free memory and the kernel is located before the given memory
 		reserved_space
 	} else {
-		(kernel_addr_range.end.as_u64() - env::get_ram_address().as_u64() + reserved_space as u64)
-			as usize
+		(kernel_addr_range.end.as_u64() - env::get_ram_address().unwrap().as_u64()
+			+ reserved_space as u64) as usize
 	};
 	info!("Minimum memory size: {} MiB", min_mem >> 20);
 	let avail_mem = total_mem

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -201,29 +201,6 @@ impl PageRangeExt for PageRange {
 	}
 }
 
-#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-unsafe fn detect_from_limits() -> Result<(), ()> {
-	let limit = crate::arch::kernel::get_limit();
-	if limit == 0 {
-		return Err(());
-	}
-
-	#[cfg(target_arch = "riscv64")]
-	let ram_address = env::get_ram_address().as_usize();
-	#[cfg(target_arch = "aarch64")]
-	let ram_address = 0;
-
-	let range =
-		PageRange::new(super::kernel_end_address().as_usize(), ram_address + limit).unwrap();
-	unsafe {
-		PHYSICAL_FREE_LIST.lock().deallocate(range).unwrap();
-		map_frame_range(range);
-	}
-	TOTAL_MEMORY.fetch_add(range.len().get(), Ordering::Relaxed);
-
-	Ok(())
-}
-
 unsafe fn init() {
 	if env::is_uefi() && DeviceAlloc.phys_offset() != VirtAddr::zero() {
 		let start = DeviceAlloc.phys_offset();
@@ -232,17 +209,7 @@ unsafe fn init() {
 		paging::unmap::<HugePageSize>(start, count);
 	}
 
-	if unsafe { detect_from_fdt().is_ok() } {
-		return;
-	}
-
-	cfg_select! {
-		any(target_arch = "aarch64", target_arch = "riscv64") => {
-			error!("Could not detect physical memory from FDT");
-			unsafe { detect_from_limits().unwrap(); }
-		}
-		_ => {
-			panic!("Could not detect physical memory from FDT");
-		}
+	unsafe {
+		detect_from_fdt().unwrap();
 	}
 }

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -209,7 +209,7 @@ unsafe fn detect_from_limits() -> Result<(), ()> {
 	}
 
 	#[cfg(target_arch = "riscv64")]
-	let ram_address = crate::arch::kernel::get_ram_address().as_usize();
+	let ram_address = env::get_ram_address().as_usize();
 	#[cfg(target_arch = "aarch64")]
 	let ram_address = 0;
 


### PR DESCRIPTION
Extracted from https://github.com/hermit-os/kernel/pull/2425.