### PR TITLE
fix(getdents): return `EINVAL` when buffer too small

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -397,7 +397,11 @@ impl ObjectInterface for MemDirectoryInterface {
 			let next_dirent = (buf_offset + dirent_len).align_up(align_of::<Dirent64>());
 
 			if next_dirent > buf.len() {
-				// target buffer full -> we return the nr. of bytes written (like linux does)
+				if ret == 0 {
+					// Buffer too small to hold even one entry
+					return Err(Errno::Inval);
+				}
+				// Buffer full -> return bytes written so far; caller retries from rsp_offset
 				break;
 			}
 

--- a/src/fs/virtio_fs.rs
+++ b/src/fs/virtio_fs.rs
@@ -1041,7 +1041,11 @@ impl ObjectInterface for VirtioFsDirectoryHandle {
 			let next_dirent = (buf_offset + dirent_len).align_up(align_of::<Dirent64>());
 
 			if next_dirent > buf.len() {
-				// target buffer full -> we return the nr. of bytes written (like linux does)
+				if ret == 0 {
+					// Buffer too small to hold even one entry
+					return Err(Errno::Inval);
+				}
+				// Buffer full -> return bytes written so far; caller retries from rsp_offset
 				break;
 			}
 


### PR DESCRIPTION
Currently, Hermit behaves like so:

```
> ls testdir
file_aaaaaaaaa_0.txt
file_aaaaaaaaa_10.txt
file_aaaaaaaaa_11.txt
file_aaaaaaaaa_12_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt
file_aaaaaaaaa_12.txt
file_aaaaaaaaa_13.txt

> run.sh
...
[    0.442456][0][INFO ] Jumping into application
READDIR
- .
- ..
- file_aaaaaaaaa_0.txt
- file_aaaaaaaaa_10.txt
- file_aaaaaaaaa_11.txt
- file_aaaaaaaaa_12.txt
- file_aaaaaaaaa_13.txt
```