### PR TITLE
feat: Bochs VBE linear framebuffer support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,10 @@ virtio-vsock = ["virtio"]
 ## This is only useful on PCs (x86-64).
 vga = []
 
+## Enables the _Bochs Graphics Adapter_ (BGA) driver.
+##
+## This provides a linear framebuffer for pixel graphics and is primarily useful in QEMU/Bochs environments (x86-64).
+bga = ["pci"]
 #! ### Performance Features
 
 ## Disables putting the CPU to sleep.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,9 @@ vga = []
 ## Enables the _Bochs Graphics Adapter_ (BGA) driver.
 ##
 ## This provides a linear framebuffer for pixel graphics and is primarily useful in QEMU/Bochs environments (x86-64).
+## It does not enable any kernel rendering, applications need to implement their own rendering on top of the framebuffer.
 bga = ["pci"]
+
 #! ### Performance Features
 
 ## Disables putting the CPU to sleep.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ vga = []
 ## Enables the _Bochs Graphics Adapter_ (BGA) driver.
 ##
 ## This provides a linear framebuffer for pixel graphics and is primarily useful in QEMU/Bochs environments (x86-64).
-## It does not enable any kernel rendering, applications need to implement their own rendering on top of the framebuffer.
+## Any rendering has to be done by the application; the kernel itself does not output anything on the framebuffer.
 bga = ["pci"]
 
 #! ### Performance Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,11 @@ vga = []
 ## It allows receiving scancodes from the PS/2 keyboard that can be used to port applications.
 ## This is only useful on PCs (x86-64).
 pc-keyboard = []
+## Enables the _Bochs Graphics Adapter_ (BGA) driver.
+##
+## This provides a linear framebuffer for pixel graphics and is primarily useful in QEMU/Bochs environments (x86-64).
+## Any rendering has to be done by the application; the kernel itself does not output anything on the framebuffer.
+bga = ["pci"]
 
 #! ### Performance Features
 

--- a/src/arch/x86_64/kernel/bga.rs
+++ b/src/arch/x86_64/kernel/bga.rs
@@ -39,7 +39,7 @@ pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
 		let bga_version = data_port.read();
 
 		if bga_version != VBE_DISPI_ID5 {
-			error!("Unsupported BGA version: {:#06x}", bga_version);
+			error!("Unsupported BGA version: {bga_version:#06x}");
 			return;
 		}
 

--- a/src/arch/x86_64/kernel/bga.rs
+++ b/src/arch/x86_64/kernel/bga.rs
@@ -1,0 +1,91 @@
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use memory_addresses::{PhysAddr, VirtAddr};
+use pci_types::{Bar, CommandRegister};
+use x86_64::instructions::port::Port;
+
+use crate::arch::x86_64::mm::paging;
+use crate::arch::x86_64::mm::paging::{BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt};
+use crate::drivers::pci::PciDevice;
+use crate::kernel::pci::PciConfigRegion;
+
+static FRAMEBUFFER_PHYS: AtomicU64 = AtomicU64::new(0);
+
+const VBE_DISPI_IOPORT_INDEX: u16 = 0x01ce;
+const VBE_DISPI_IOPORT_DATA: u16 = 0x01cf;
+
+const VBE_DISPI_INDEX_ID: u16 = 0;
+const VBE_DISPI_INDEX_XRES: u16 = 1;
+const VBE_DISPI_INDEX_YRES: u16 = 2;
+const VBE_DISPI_INDEX_BPP: u16 = 3;
+const VBE_DISPI_INDEX_ENABLE: u16 = 4;
+
+const VBE_DISPI_DISABLED: u16 = 0x00;
+const VBE_DISPI_ENABLED: u16 = 0x01;
+const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
+const VBE_DISPI_ID5: u16 = 0xb0c5;
+
+pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
+	//To Do: Detect Resolution automatically
+	let width: u16 = 640;
+	let height: u16 = 400;
+	let bpp: u16 = 32;
+
+	unsafe {
+		let mut index_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_INDEX);
+		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
+
+		index_port.write(VBE_DISPI_INDEX_ID);
+		let bga_version = data_port.read();
+
+		if bga_version != VBE_DISPI_ID5 {
+			error!("Unsupported BGA version: {:#06x}", bga_version);
+			return;
+		}
+
+		index_port.write(VBE_DISPI_INDEX_ENABLE);
+		data_port.write(VBE_DISPI_DISABLED);
+
+		index_port.write(VBE_DISPI_INDEX_XRES);
+		data_port.write(width);
+
+		index_port.write(VBE_DISPI_INDEX_YRES);
+		data_port.write(height);
+
+		index_port.write(VBE_DISPI_INDEX_BPP);
+		data_port.write(bpp);
+
+		index_port.write(VBE_DISPI_INDEX_ENABLE);
+		data_port.write(VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED);
+	}
+
+	adapter.set_command(CommandRegister::MEMORY_ENABLE);
+
+	let (phys_addr, size) = match adapter.get_bar(0) {
+		Some(Bar::Memory32 { address, size, .. }) => (u64::from(address), size as usize),
+		Some(Bar::Memory64 { address, size, .. }) => (address, size as usize),
+		_ => return,
+	};
+
+	FRAMEBUFFER_PHYS.store(phys_addr, Ordering::Release);
+
+	assert!(
+		size % 4096 == 0,
+		"Framebuffer size must be a multiple of 4096 bytes"
+	);
+	let page_count = size / 4096;
+
+	let mut flags = PageTableEntryFlags::empty();
+	flags.device().writable().execute_disable();
+	flags.insert(PageTableEntryFlags::USER_ACCESSIBLE);
+	paging::map::<BasePageSize>(
+		VirtAddr::new(phys_addr),
+		PhysAddr::new(phys_addr),
+		page_count,
+		flags,
+	);
+}
+
+pub fn get_framebuffer_address() -> u64 {
+	FRAMEBUFFER_PHYS.load(Ordering::Acquire)
+}

--- a/src/arch/x86_64/kernel/bga.rs
+++ b/src/arch/x86_64/kernel/bga.rs
@@ -1,63 +1,131 @@
-use core::sync::atomic::{AtomicU64, Ordering};
+//! This module contains the implementation of the Bochs Graphics Adapter (BGA) driver.
+//!
+//! The driver uses the Bochs VBE Extensions, which use two I/O ports to communicate with the
+//! emulated VGA card instead of relying on a 16-bit VBE BIOS. The driver initializes the BGA
+//! device, sets the desired resolution and bits per pixel (BPP), and maps the framebuffer
+//! into the virtual address space. It also provides a function to retrieve the physical
+//! address of the framebuffer.
 
+use hermit_sync::OnceCell;
 use memory_addresses::{PhysAddr, VirtAddr};
 use pci_types::{Bar, CommandRegister};
-use x86_64::instructions::port::Port;
+use x86_64::instructions::port::{Port, PortWriteOnly};
 
-use crate::arch::x86_64::mm::paging;
-use crate::arch::x86_64::mm::paging::{BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt};
+use crate::arch::x86_64::mm::paging::{
+	self, BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
+};
 use crate::drivers::pci::PciDevice;
 use crate::kernel::pci::PciConfigRegion;
 
-static FRAMEBUFFER_PHYS: AtomicU64 = AtomicU64::new(0);
+pub struct BgaInfo {
+	pub framebuffer: *mut u8,
+	pub width: u16,
+	pub height: u16,
+	pub bpp: u16,
+}
+
+static BGA_INFO: OnceCell<BgaInfo> = OnceCell::new();
+
+unsafe impl Send for BgaInfo {}
+unsafe impl Sync for BgaInfo {}
 
 const VBE_DISPI_IOPORT_INDEX: u16 = 0x01ce;
 const VBE_DISPI_IOPORT_DATA: u16 = 0x01cf;
 
-const VBE_DISPI_INDEX_ID: u16 = 0;
-const VBE_DISPI_INDEX_XRES: u16 = 1;
-const VBE_DISPI_INDEX_YRES: u16 = 2;
-const VBE_DISPI_INDEX_BPP: u16 = 3;
-const VBE_DISPI_INDEX_ENABLE: u16 = 4;
+pub struct VbeDispiIndex;
+
+#[allow(dead_code)]
+impl VbeDispiIndex {
+	#[doc(alias = "VBE_DISPI_INDEX_ID")]
+	pub const ID: u16 = 0;
+	#[doc(alias = "VBE_DISPI_INDEX_XRES")]
+	pub const XRES: u16 = 1;
+	#[doc(alias = "VBE_DISPI_INDEX_YRES")]
+	pub const YRES: u16 = 2;
+	#[doc(alias = "VBE_DISPI_INDEX_BPP")]
+	pub const BPP: u16 = 3;
+	#[doc(alias = "VBE_DISPI_INDEX_ENABLE")]
+	pub const ENABLE: u16 = 4;
+	#[doc(alias = "VBE_DISPI_INDEX_BANK")]
+	pub const BANK: u16 = 5;
+	#[doc(alias = "VBE_DISPI_INDEX_VIRT_WIDTH")]
+	pub const VIRT_WIDTH: u16 = 6;
+	#[doc(alias = "VBE_DISPI_INDEX_VIRT_HEIGHT")]
+	pub const VIRT_HEIGHT: u16 = 7;
+	#[doc(alias = "VBE_DISPI_INDEX_X_OFFSET")]
+	pub const X_OFFSET: u16 = 8;
+	#[doc(alias = "VBE_DISPI_INDEX_Y_OFFSET")]
+	pub const Y_OFFSET: u16 = 9;
+}
 
 const VBE_DISPI_DISABLED: u16 = 0x00;
 const VBE_DISPI_ENABLED: u16 = 0x01;
 const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
-const VBE_DISPI_ID5: u16 = 0xb0c5;
+
+#[allow(dead_code)]
+const VBE_DISPI_NOCLEARMEM: u16 = 0x80;
+
+pub struct VbeDispiId;
+
+#[allow(dead_code)]
+impl VbeDispiId {
+	#[doc(alias = "VBE_DISPI_ID0")]
+	pub const ID0: u16 = 0xb0c0;
+	#[doc(alias = "VBE_DISPI_ID1")]
+	pub const ID1: u16 = 0xb0c1;
+	#[doc(alias = "VBE_DISPI_ID2")]
+	pub const ID2: u16 = 0xb0c2;
+	#[doc(alias = "VBE_DISPI_ID3")]
+	pub const ID3: u16 = 0xb0c3;
+	#[doc(alias = "VBE_DISPI_ID4")]
+	pub const ID4: u16 = 0xb0c4;
+	#[doc(alias = "VBE_DISPI_ID5")]
+	pub const ID5: u16 = 0xb0c5;
+}
+
+struct BgaRegisters;
+
+impl BgaRegisters {
+	pub fn read(index: u16) -> u16 {
+		let mut index_port: PortWriteOnly<u16> = PortWriteOnly::new(VBE_DISPI_IOPORT_INDEX);
+		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
+		unsafe {
+			index_port.write(index);
+			data_port.read()
+		}
+	}
+
+	pub fn write(index: u16, value: u16) {
+		let mut index_port: PortWriteOnly<u16> = PortWriteOnly::new(VBE_DISPI_IOPORT_INDEX);
+		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
+		unsafe {
+			index_port.write(index);
+			data_port.write(value);
+		}
+	}
+}
 
 pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
-	//To Do: Detect Resolution automatically
+	//To Do: Add support for different resolutions and BPP values
 	let width: u16 = 640;
 	let height: u16 = 400;
 	let bpp: u16 = 32;
 
-	unsafe {
-		let mut index_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_INDEX);
-		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
+	let bga_version = BgaRegisters::read(VbeDispiIndex::ID);
 
-		index_port.write(VBE_DISPI_INDEX_ID);
-		let bga_version = data_port.read();
-
-		if bga_version != VBE_DISPI_ID5 {
-			error!("Unsupported BGA version: {bga_version:#06x}");
-			return;
-		}
-
-		index_port.write(VBE_DISPI_INDEX_ENABLE);
-		data_port.write(VBE_DISPI_DISABLED);
-
-		index_port.write(VBE_DISPI_INDEX_XRES);
-		data_port.write(width);
-
-		index_port.write(VBE_DISPI_INDEX_YRES);
-		data_port.write(height);
-
-		index_port.write(VBE_DISPI_INDEX_BPP);
-		data_port.write(bpp);
-
-		index_port.write(VBE_DISPI_INDEX_ENABLE);
-		data_port.write(VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED);
+	if bga_version != VbeDispiId::ID5 {
+		error!("Unsupported BGA version: {bga_version:#06x}");
+		return;
 	}
+
+	BgaRegisters::write(VbeDispiIndex::ENABLE, VBE_DISPI_DISABLED);
+	BgaRegisters::write(VbeDispiIndex::XRES, width);
+	BgaRegisters::write(VbeDispiIndex::YRES, height);
+	BgaRegisters::write(VbeDispiIndex::BPP, bpp);
+	BgaRegisters::write(
+		VbeDispiIndex::ENABLE,
+		VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED,
+	);
 
 	adapter.set_command(CommandRegister::MEMORY_ENABLE);
 
@@ -67,17 +135,23 @@ pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
 		_ => return,
 	};
 
-	FRAMEBUFFER_PHYS.store(phys_addr, Ordering::Release);
+	BGA_INFO
+		.set(BgaInfo {
+			framebuffer: core::ptr::with_exposed_provenance_mut(phys_addr as usize),
+			width,
+			height,
+			bpp,
+		})
+		.ok();
 
 	assert!(
-		size % 4096 == 0,
+		size.is_multiple_of(4096),
 		"Framebuffer size must be a multiple of 4096 bytes"
 	);
 	let page_count = size / 4096;
 
 	let mut flags = PageTableEntryFlags::empty();
 	flags.device().writable().execute_disable();
-	flags.insert(PageTableEntryFlags::USER_ACCESSIBLE);
 	paging::map::<BasePageSize>(
 		VirtAddr::new(phys_addr),
 		PhysAddr::new(phys_addr),
@@ -86,6 +160,6 @@ pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
 	);
 }
 
-pub fn get_framebuffer_address() -> u64 {
-	FRAMEBUFFER_PHYS.load(Ordering::Acquire)
+pub fn get_framebuffer_info() -> Option<&'static BgaInfo> {
+	BGA_INFO.get()
 }

--- a/src/arch/x86_64/kernel/bga.rs
+++ b/src/arch/x86_64/kernel/bga.rs
@@ -1,0 +1,182 @@
+//! This module contains the implementation of the Bochs Graphics Adapter (BGA) driver.
+//!
+//! The driver uses the Bochs VBE Extensions, which use two I/O ports to communicate with the
+//! emulated VGA card instead of relying on a 16-bit VBE BIOS. The driver initializes the BGA
+//! device, sets the desired resolution and bits per pixel (BPP), and maps the framebuffer
+//! into the virtual address space. It also provides a function to retrieve the physical
+//! address of the framebuffer.
+
+use hermit_sync::{Lazy, TicketMutex};
+use memory_addresses::{PhysAddr, VirtAddr};
+use pci_types::{Bar, CommandRegister};
+use x86_64::instructions::port::{Port, PortWriteOnly};
+
+use crate::arch::kernel::pci::PciConfigRegion;
+use crate::arch::x86_64::mm::paging::{
+	self, BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
+};
+use crate::drivers::pci::PciDevice;
+
+#[derive(Debug, Clone, Copy)]
+pub struct BgaInfo {
+	pub framebuffer: PhysAddr,
+	pub width: u16,
+	pub height: u16,
+	pub bpp: u16,
+}
+
+static BGA_INFO: Lazy<TicketMutex<Option<BgaInfo>>> = Lazy::new(|| TicketMutex::new(None));
+
+const VBE_DISPI_IOPORT_INDEX: u16 = 0x01ce;
+const VBE_DISPI_IOPORT_DATA: u16 = 0x01cf;
+
+#[allow(dead_code)]
+#[repr(u16)]
+pub enum VbeDispiIndex {
+	#[doc(alias = "VBE_DISPI_INDEX_ID")]
+	Id = 0,
+	#[doc(alias = "VBE_DISPI_INDEX_XRES")]
+	Xres = 1,
+	#[doc(alias = "VBE_DISPI_INDEX_YRES")]
+	Yres = 2,
+	#[doc(alias = "VBE_DISPI_INDEX_BPP")]
+	Bpp = 3,
+	#[doc(alias = "VBE_DISPI_INDEX_ENABLE")]
+	Enable = 4,
+	#[doc(alias = "VBE_DISPI_INDEX_BANK")]
+	Bank = 5,
+	#[doc(alias = "VBE_DISPI_INDEX_VIRT_WIDTH")]
+	VirtWidth = 6,
+	#[doc(alias = "VBE_DISPI_INDEX_VIRT_HEIGHT")]
+	VirtHeight = 7,
+	#[doc(alias = "VBE_DISPI_INDEX_X_OFFSET")]
+	XOffset = 8,
+	#[doc(alias = "VBE_DISPI_INDEX_Y_OFFSET")]
+	YOffset = 9,
+}
+
+const VBE_DISPI_DISABLED: u16 = 0x00;
+const VBE_DISPI_ENABLED: u16 = 0x01;
+const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
+#[allow(dead_code)]
+const VBE_DISPI_NOCLEARMEM: u16 = 0x80;
+
+#[allow(dead_code)]
+#[repr(u16)]
+pub enum VbeDispiId {
+	#[doc(alias = "VBE_DISPI_ID0")]
+	Id0 = 0xb0c0,
+	#[doc(alias = "VBE_DISPI_ID1")]
+	Id1 = 0xb0c1,
+	#[doc(alias = "VBE_DISPI_ID2")]
+	Id2 = 0xb0c2,
+	#[doc(alias = "VBE_DISPI_ID3")]
+	Id3 = 0xb0c3,
+	#[doc(alias = "VBE_DISPI_ID4")]
+	Id4 = 0xb0c4,
+	#[doc(alias = "VBE_DISPI_ID5")]
+	Id5 = 0xb0c5,
+}
+
+struct BgaRegisters {
+	index_port: PortWriteOnly<u16>,
+	data_port: Port<u16>,
+}
+
+impl BgaRegisters {
+	pub const fn new() -> Self {
+		Self {
+			index_port: PortWriteOnly::new(VBE_DISPI_IOPORT_INDEX),
+			data_port: Port::new(VBE_DISPI_IOPORT_DATA),
+		}
+	}
+
+	pub fn read(&mut self, index: VbeDispiIndex) -> u16 {
+		// SAFETY: Exclusive correct port access without safety related side-effects.
+		unsafe {
+			self.index_port.write(index as u16);
+			self.data_port.read()
+		}
+	}
+
+	pub fn write(&mut self, index: VbeDispiIndex, value: u16) {
+		// SAFETY: Exclusive correct port access without memory safety related side-effects.
+		unsafe {
+			self.index_port.write(index as u16);
+			self.data_port.write(value);
+		}
+	}
+}
+
+static BGA_REGISTERS: Lazy<TicketMutex<BgaRegisters>> =
+	Lazy::new(|| TicketMutex::new(BgaRegisters::new()));
+
+pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
+	// Hardcoded standard values
+	let width: u16 = 640;
+	let height: u16 = 400;
+	let bpp: u16 = 32;
+
+	let bga_version = BGA_REGISTERS.lock().read(VbeDispiIndex::Id);
+
+	if bga_version != VbeDispiId::Id5 as u16 {
+		error!("Unsupported BGA version: {bga_version:#06x}");
+		return;
+	}
+
+	adapter.set_command(CommandRegister::MEMORY_ENABLE);
+
+	let (phys_addr, size) = match adapter.get_bar(0) {
+		Some(Bar::Memory32 { address, size, .. }) => (u64::from(address), size as usize),
+		Some(Bar::Memory64 { address, size, .. }) => (address, size as usize),
+		_ => return,
+	};
+
+	*BGA_INFO.lock() = Some(BgaInfo {
+		framebuffer: PhysAddr::from(phys_addr),
+		width: 0,
+		height: 0,
+		bpp: 0,
+	});
+
+	set_resolution(width, height, bpp);
+
+	assert!(
+		size.is_multiple_of(4096),
+		"Framebuffer size must be a multiple of 4096 bytes"
+	);
+	let page_count = size / 4096;
+
+	let mut flags = PageTableEntryFlags::empty();
+	flags.device().writable().execute_disable();
+	paging::map::<BasePageSize>(
+		VirtAddr::new(phys_addr),
+		PhysAddr::new(phys_addr),
+		page_count,
+		flags,
+	);
+}
+
+pub fn set_resolution(width: u16, height: u16, bpp: u16) {
+	let mut registers = BGA_REGISTERS.lock();
+	registers.write(VbeDispiIndex::Enable, VBE_DISPI_DISABLED);
+	registers.write(VbeDispiIndex::Xres, width);
+	registers.write(VbeDispiIndex::Yres, height);
+	registers.write(VbeDispiIndex::Bpp, bpp);
+	registers.write(
+		VbeDispiIndex::Enable,
+		VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED,
+	);
+	drop(registers);
+	if let Some(ref mut info) = *BGA_INFO.lock() {
+		info.width = width;
+		info.height = height;
+		info.bpp = bpp;
+	} else {
+		error!("BGA is not initialized");
+	}
+}
+
+pub fn get_framebuffer_info() -> Option<BgaInfo> {
+	*BGA_INFO.lock()
+}

--- a/src/arch/x86_64/kernel/bga.rs
+++ b/src/arch/x86_64/kernel/bga.rs
@@ -11,14 +11,15 @@ use memory_addresses::{PhysAddr, VirtAddr};
 use pci_types::{Bar, CommandRegister};
 use x86_64::instructions::port::{Port, PortWriteOnly};
 
+use crate::arch::kernel::pci::PciConfigRegion;
 use crate::arch::x86_64::mm::paging::{
 	self, BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
 use crate::drivers::pci::PciDevice;
-use crate::kernel::pci::PciConfigRegion;
 
+#[derive(Debug)]
 pub struct BgaInfo {
-	pub framebuffer: *mut u8,
+	pub framebuffer: usize,
 	pub width: u16,
 	pub height: u16,
 	pub bpp: u16,
@@ -26,36 +27,32 @@ pub struct BgaInfo {
 
 static BGA_INFO: OnceCell<BgaInfo> = OnceCell::new();
 
-unsafe impl Send for BgaInfo {}
-unsafe impl Sync for BgaInfo {}
-
 const VBE_DISPI_IOPORT_INDEX: u16 = 0x01ce;
 const VBE_DISPI_IOPORT_DATA: u16 = 0x01cf;
 
-pub struct VbeDispiIndex;
-
 #[allow(dead_code)]
-impl VbeDispiIndex {
+#[repr(u16)]
+pub enum VbeDispiIndex {
 	#[doc(alias = "VBE_DISPI_INDEX_ID")]
-	pub const ID: u16 = 0;
+	Id = 0,
 	#[doc(alias = "VBE_DISPI_INDEX_XRES")]
-	pub const XRES: u16 = 1;
+	Xres = 1,
 	#[doc(alias = "VBE_DISPI_INDEX_YRES")]
-	pub const YRES: u16 = 2;
+	Yres = 2,
 	#[doc(alias = "VBE_DISPI_INDEX_BPP")]
-	pub const BPP: u16 = 3;
+	Bpp = 3,
 	#[doc(alias = "VBE_DISPI_INDEX_ENABLE")]
-	pub const ENABLE: u16 = 4;
+	Enable = 4,
 	#[doc(alias = "VBE_DISPI_INDEX_BANK")]
-	pub const BANK: u16 = 5;
+	Bank = 5,
 	#[doc(alias = "VBE_DISPI_INDEX_VIRT_WIDTH")]
-	pub const VIRT_WIDTH: u16 = 6;
+	VirtWidth = 6,
 	#[doc(alias = "VBE_DISPI_INDEX_VIRT_HEIGHT")]
-	pub const VIRT_HEIGHT: u16 = 7;
+	VirtHeight = 7,
 	#[doc(alias = "VBE_DISPI_INDEX_X_OFFSET")]
-	pub const X_OFFSET: u16 = 8;
+	XOffset = 8,
 	#[doc(alias = "VBE_DISPI_INDEX_Y_OFFSET")]
-	pub const Y_OFFSET: u16 = 9;
+	YOffset = 9,
 }
 
 const VBE_DISPI_DISABLED: u16 = 0x00;
@@ -65,41 +62,40 @@ const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
 #[allow(dead_code)]
 const VBE_DISPI_NOCLEARMEM: u16 = 0x80;
 
-pub struct VbeDispiId;
-
 #[allow(dead_code)]
-impl VbeDispiId {
+#[repr(u16)]
+pub enum VbeDispiId {
 	#[doc(alias = "VBE_DISPI_ID0")]
-	pub const ID0: u16 = 0xb0c0;
+	Id0 = 0xb0c0,
 	#[doc(alias = "VBE_DISPI_ID1")]
-	pub const ID1: u16 = 0xb0c1;
+	Id1 = 0xb0c1,
 	#[doc(alias = "VBE_DISPI_ID2")]
-	pub const ID2: u16 = 0xb0c2;
+	Id2 = 0xb0c2,
 	#[doc(alias = "VBE_DISPI_ID3")]
-	pub const ID3: u16 = 0xb0c3;
+	Id3 = 0xb0c3,
 	#[doc(alias = "VBE_DISPI_ID4")]
-	pub const ID4: u16 = 0xb0c4;
+	Id4 = 0xb0c4,
 	#[doc(alias = "VBE_DISPI_ID5")]
-	pub const ID5: u16 = 0xb0c5;
+	Id5 = 0xb0c5,
 }
 
 struct BgaRegisters;
 
 impl BgaRegisters {
-	pub fn read(index: u16) -> u16 {
+	pub fn read(index: VbeDispiIndex) -> u16 {
 		let mut index_port: PortWriteOnly<u16> = PortWriteOnly::new(VBE_DISPI_IOPORT_INDEX);
 		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
 		unsafe {
-			index_port.write(index);
+			index_port.write(index as u16);
 			data_port.read()
 		}
 	}
 
-	pub fn write(index: u16, value: u16) {
+	pub fn write(index: VbeDispiIndex, value: u16) {
 		let mut index_port: PortWriteOnly<u16> = PortWriteOnly::new(VBE_DISPI_IOPORT_INDEX);
 		let mut data_port: Port<u16> = Port::new(VBE_DISPI_IOPORT_DATA);
 		unsafe {
-			index_port.write(index);
+			index_port.write(index as u16);
 			data_port.write(value);
 		}
 	}
@@ -111,19 +107,19 @@ pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
 	let height: u16 = 400;
 	let bpp: u16 = 32;
 
-	let bga_version = BgaRegisters::read(VbeDispiIndex::ID);
+	let bga_version = BgaRegisters::read(VbeDispiIndex::Id);
 
-	if bga_version != VbeDispiId::ID5 {
+	if bga_version != VbeDispiId::Id5 as u16 {
 		error!("Unsupported BGA version: {bga_version:#06x}");
 		return;
 	}
 
-	BgaRegisters::write(VbeDispiIndex::ENABLE, VBE_DISPI_DISABLED);
-	BgaRegisters::write(VbeDispiIndex::XRES, width);
-	BgaRegisters::write(VbeDispiIndex::YRES, height);
-	BgaRegisters::write(VbeDispiIndex::BPP, bpp);
+	BgaRegisters::write(VbeDispiIndex::Enable, VBE_DISPI_DISABLED);
+	BgaRegisters::write(VbeDispiIndex::Xres, width);
+	BgaRegisters::write(VbeDispiIndex::Yres, height);
+	BgaRegisters::write(VbeDispiIndex::Bpp, bpp);
 	BgaRegisters::write(
-		VbeDispiIndex::ENABLE,
+		VbeDispiIndex::Enable,
 		VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED,
 	);
 
@@ -137,12 +133,12 @@ pub fn init_device(adapter: &PciDevice<PciConfigRegion>) {
 
 	BGA_INFO
 		.set(BgaInfo {
-			framebuffer: core::ptr::with_exposed_provenance_mut(phys_addr as usize),
+			framebuffer: phys_addr as usize,
 			width,
 			height,
 			bpp,
 		})
-		.ok();
+		.unwrap();
 
 	assert!(
 		size.is_multiple_of(4096),

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -15,6 +15,8 @@ use crate::env;
 #[cfg(feature = "acpi")]
 pub mod acpi;
 pub mod apic;
+#[cfg(feature = "bga")]
+pub mod bga;
 pub mod core_local;
 pub mod gdt;
 pub mod interrupts;

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -17,6 +17,8 @@ use crate::env::UhyveStartInfo;
 #[cfg(feature = "acpi")]
 mod acpi;
 pub mod apic;
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+pub mod bga;
 pub mod core_local;
 pub mod gdt;
 pub mod interrupts;

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -459,6 +459,20 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				Err(err) => error!("Could not initialize rtl8139 device: {err}"),
 			}
 		}
+
+		#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+		for adapter in PCI_DEVICES.finalize().iter().filter(|x| {
+			let (vendor_id, device_id) = x.id();
+			vendor_id == 0x1234 && device_id == 0x1111
+		}) {
+			info!(
+				"Found Bochs VGA device with device id {:#x}",
+				adapter.device_id()
+			);
+
+			crate::kernel::bga::init_device(adapter);
+		}
+
 		PCI_DRIVERS.finalize();
 	});
 }

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -470,7 +470,7 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				adapter.device_id()
 			);
 
-			crate::kernel::bga::init_device(adapter);
+			crate::arch::kernel::bga::init_device(adapter);
 		}
 
 		PCI_DRIVERS.finalize();

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -492,6 +492,20 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				Err(err) => error!("Could not initialize rtl8139 device: {err}"),
 			}
 		}
+
+		#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+		for adapter in PCI_DEVICES.finalize().iter().filter(|x| {
+			let (vendor_id, device_id) = x.id();
+			vendor_id == 0x1234 && device_id == 0x1111
+		}) {
+			info!(
+				"Found Bochs VGA device with device id {:#x}",
+				adapter.device_id()
+			);
+
+			crate::arch::kernel::bga::init_device(adapter);
+		}
+
 		PCI_DRIVERS.finalize();
 	});
 }

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -6,3 +6,18 @@ use crate::arch::mm::paging::{BasePageSize, PageSize};
 pub extern "C" fn sys_getpagesize() -> i32 {
 	BasePageSize::SIZE.try_into().unwrap()
 }
+
+/// Returns the address of the framebuffer, if available. Returns 0 if no framebuffer is available.
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_get_framebuffer() -> u64 {
+	crate::kernel::bga::get_framebuffer_address()
+}
+
+#[cfg(not(all(target_arch = "x86_64", feature = "bga")))]
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_get_framebuffer() -> u64 {
+	0
+}

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -1,4 +1,14 @@
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+use core::ffi::c_int;
+
 use crate::arch::mm::paging::{BasePageSize, PageSize};
+#[repr(C)]
+pub struct FramebufferInfo {
+	pub framebuffer: *mut u8,
+	pub width: u32,
+	pub height: u32,
+	pub bpp: u32,
+}
 
 /// Returns the base page size, in bytes, of the current system.
 #[hermit_macro::system]
@@ -7,17 +17,30 @@ pub extern "C" fn sys_getpagesize() -> i32 {
 	BasePageSize::SIZE.try_into().unwrap()
 }
 
-/// Returns the address of the framebuffer, if available. Returns 0 if no framebuffer is available.
+/// Returns the framebuffer information for the BGA device, if it has been initialized. Returns 0
+/// on success, or -1 if the BGA device has not been initialized.
 #[cfg(all(target_arch = "x86_64", feature = "bga"))]
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub extern "C" fn sys_get_framebuffer() -> u64 {
-	crate::kernel::bga::get_framebuffer_address()
-}
+pub unsafe extern "C" fn sys_framebuffer(info: *mut FramebufferInfo) -> c_int {
+	if info.is_null() {
+		return -1;
+	};
 
-#[cfg(not(all(target_arch = "x86_64", feature = "bga")))]
-#[hermit_macro::system]
-#[unsafe(no_mangle)]
-pub extern "C" fn sys_get_framebuffer() -> u64 {
-	0
+	let bga_info = crate::arch::kernel::bga::get_framebuffer_info();
+	match bga_info {
+		Some(bga_info) => {
+			let info_c = FramebufferInfo {
+				framebuffer: bga_info.framebuffer,
+				width: u32::from(bga_info.width),
+				height: u32::from(bga_info.height),
+				bpp: u32::from(bga_info.bpp),
+			};
+			unsafe {
+				info.write(info_c);
+			}
+			0
+		}
+		None => -1,
+	}
 }

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -1,3 +1,6 @@
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+use core::ffi::c_int;
+
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 
 /// Returns the base page size, in bytes, of the current system.
@@ -31,4 +34,50 @@ pub unsafe extern "C" fn sys_read_keyboard(buffer: *mut u8, size: usize, nonbloc
 	} else {
 		result as isize
 	}
+}
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+#[repr(C)]
+pub struct FramebufferInfo {
+	pub framebuffer: *mut u8,
+	pub width: u32,
+	pub height: u32,
+	pub bpp: u32,
+}
+
+/// Returns the framebuffer information for the video output device.
+/// Returns 0 on success, or -1 if the BGA device has not yet been initialized.
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_get_framebuffer_info(info: *mut FramebufferInfo) -> c_int {
+	if info.is_null() {
+		return -1;
+	};
+
+	let bga_info = crate::arch::kernel::bga::get_framebuffer_info();
+	match bga_info {
+		Some(bga_info) => {
+			let info_c = FramebufferInfo {
+				framebuffer: core::ptr::with_exposed_provenance_mut(
+					bga_info.framebuffer.as_usize(),
+				),
+				width: u32::from(bga_info.width),
+				height: u32::from(bga_info.height),
+				bpp: u32::from(bga_info.bpp),
+			};
+			unsafe {
+				info.write(info_c);
+			}
+			0
+		}
+		None => -1,
+	}
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+#[hermit_macro::system]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_set_resolution(width: u16, height: u16, bpp: u16) -> c_int {
+	crate::arch::kernel::bga::set_resolution(width, height, bpp);
+	0
 }

--- a/src/syscalls/system.rs
+++ b/src/syscalls/system.rs
@@ -2,13 +2,6 @@
 use core::ffi::c_int;
 
 use crate::arch::mm::paging::{BasePageSize, PageSize};
-#[repr(C)]
-pub struct FramebufferInfo {
-	pub framebuffer: *mut u8,
-	pub width: u32,
-	pub height: u32,
-	pub bpp: u32,
-}
 
 /// Returns the base page size, in bytes, of the current system.
 #[hermit_macro::system]
@@ -17,12 +10,21 @@ pub extern "C" fn sys_getpagesize() -> i32 {
 	BasePageSize::SIZE.try_into().unwrap()
 }
 
+#[cfg(all(target_arch = "x86_64", feature = "bga"))]
+#[repr(C)]
+pub struct FramebufferInfo {
+	pub framebuffer: *mut u8,
+	pub width: u32,
+	pub height: u32,
+	pub bpp: u32,
+}
+
 /// Returns the framebuffer information for the BGA device, if it has been initialized. Returns 0
 /// on success, or -1 if the BGA device has not been initialized.
 #[cfg(all(target_arch = "x86_64", feature = "bga"))]
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sys_framebuffer(info: *mut FramebufferInfo) -> c_int {
+pub unsafe extern "C" fn sys_get_framebuffer_info(info: *mut FramebufferInfo) -> c_int {
 	if info.is_null() {
 		return -1;
 	};
@@ -31,7 +33,7 @@ pub unsafe extern "C" fn sys_framebuffer(info: *mut FramebufferInfo) -> c_int {
 	match bga_info {
 		Some(bga_info) => {
 			let info_c = FramebufferInfo {
-				framebuffer: bga_info.framebuffer,
+				framebuffer: core::ptr::with_exposed_provenance_mut(bga_info.framebuffer),
 				width: u32::from(bga_info.width),
 				height: u32::from(bga_info.height),
 				bpp: u32::from(bga_info.bpp),


### PR DESCRIPTION
I'm currently working on porting Doom to Hermit and needed a feature to directly write pixel data into the Bochs Graphics Adaptor as Hermit currently only has support for VGA in textmode. 

The feature currently adds standard BGA preparation [(Link to OSDev)](https://wiki.osdev.org/Bochs_VBE_Extensions#Programming_the_BGA) with a hardcoded resolution (640x400), bpp (32) and a systemcall (sys_get_framebuffer) to receive the address of the framebuffer.
The systemcall falls back to 0 if there was a failure in initializing the framebuffer (e.g. if pci is missing, or the bga feature is not enabled).

I have currently only tested this feature with c programs on a mac using Qemu. The feature is also only available on the x86_64 architecture. 