### PR TITLE
fix(aarch64/interrupt): match against the correct exception class

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -178,8 +178,8 @@ pub(crate) extern "C" fn do_sync(state: &State) {
 	let pc = ELR_EL1.get();
 
 	/* data abort from lower or current level */
-	if (ec == ESR_EL1::EC::Value::SoftwareStepCurrentEL)
-		|| (ec == ESR_EL1::EC::Value::SoftwareStepLowerEL)
+	if (ec == ESR_EL1::EC::Value::DataAbortCurrentEL)
+		|| (ec == ESR_EL1::EC::Value::DataAbortLowerEL)
 	{
 		/* check if value in far_el1 is valid */
 		if (iss & (1 << 10)) == 0 {


### PR DESCRIPTION
A mix-up seems to have happened in 341a1bf when replacing hardcoded literals with the enum variants.