### PR TITLE
build(deps): patch trapframe dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,8 +1912,7 @@ checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 [[package]]
 name = "trapframe"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1699c0079cb7ff77b57fd429bcfa87b1220898bb303e0e45f75789778a376d"
+source = "git+https://github.com/hermit-os/trapframe-rs?branch=hermit#5fe6f37087a34a7f7c81837047d4bc9ca7194545"
 dependencies = [
  "raw-cpuid",
  "x86_64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 [[package]]
 name = "trapframe"
 version = "0.10.1"
-source = "git+https://github.com/hermit-os/trapframe-rs?branch=hermit#5fe6f37087a34a7f7c81837047d4bc9ca7194545"
+source = "git+https://github.com/rcore-os/trapframe-rs?branch=stable-rust#b4218c3b469f81d1983e590beb4fdb76a6341ef8"
 dependencies = [
  "raw-cpuid",
  "x86_64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,6 +452,9 @@ unreadable_literal = "warn"
 
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
+# FIXME: remove once merged and published:
+# https://github.com/rcore-os/trapframe-rs/pull/18
+trapframe = { git = "https://github.com/hermit-os/trapframe-rs", branch = "hermit" }
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ unreadable_literal = "warn"
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
 # FIXME: remove once merged and published:
 # https://github.com/rcore-os/trapframe-rs/pull/18
-trapframe = { git = "https://github.com/hermit-os/trapframe-rs", branch = "hermit" }
+trapframe = { git = "https://github.com/rcore-os/trapframe-rs", branch = "stable-rust" }
 
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
This PR patches the trapframe dependency to include https://github.com/rcore-os/trapframe-rs/pull/18, which should fix the linker issues I saw in https://github.com/hermit-os/kernel/pull/2425 (CI only, very fragile).

In the long term, we should probably migrate away from this dependency (https://github.com/hermit-os/kernel/issues/2526).