### PR TITLE
feat(aarch64): Seed entropy using ARM RNG

### DIFF
--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -1,6 +1,7 @@
 use core::arch::asm;
 use core::{fmt, mem};
 
+use aarch64_cpu::asm::random::ArmRng;
 use aarch64_cpu::registers::*;
 use hermit_sync::{Lazy, OnceCell, without_interrupts};
 
@@ -197,7 +198,13 @@ impl fmt::Display for CpuFrequency {
 }
 
 pub fn seed_entropy() -> Option<[u8; 32]> {
-	None
+	let rng = ArmRng::new()?;
+	let mut buf = [0u8; 32];
+	for word in buf.chunks_mut(8) {
+		let value = rng.rndr()?.to_ne_bytes();
+		word.copy_from_slice(&value);
+	}
+	Some(buf)
 }
 
 /// The halt function stops the processor until the next interrupt arrives


### PR DESCRIPTION
Implement missing entropy seeding on ARM.
[ArmRng Implentation](https://github.com/rust-embedded/aarch64-cpu/blob/ee779cbf9e082f026037623e5ba372d4da053ca6/packages/aarch64-cpu/src/asm/random.rs#L18)
[ARM Doc](https://developer.arm.com/documentation/111107/2026-03/AArch64-Registers/RNDR--Random-Number)

For RISC-V we could leverage the optional Zkr extension.
[RISC-V Doc](https://docs.riscv.org/reference/isa/v20260120/unpriv/scalar-crypto.html#zkr)
Changes follow in separate PR.