### PR TITLE
fix: don't special-case Uhyve without PCI

### DIFF
--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -40,10 +40,6 @@ pub(crate) static CURRENT_STACK_ADDRESS: AtomicPtr<u8> = AtomicPtr::new(ptr::nul
 #[cfg(target_os = "none")]
 global_asm!(include_str!("start.s"));
 
-pub fn is_uhyve_with_pci() -> bool {
-	false
-}
-
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
 	let fdt = env::fdt().unwrap();

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -40,10 +40,6 @@ static NUM_CPUS: AtomicU32 = AtomicU32::new(0);
 
 // FUNCTIONS
 
-pub fn is_uhyve_with_pci() -> bool {
-	false
-}
-
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
 	NUM_CPUS.load(Ordering::Relaxed)

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -5,7 +5,7 @@ use core::ptr;
 use core::slice;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
-use hermit_entry::boot_info::{PlatformInfo, RawBootInfo};
+use hermit_entry::boot_info::RawBootInfo;
 use x86_64::registers::control::{Cr0, Cr4};
 
 pub(crate) use self::apic::{set_oneshot_timer, wakeup_core};
@@ -40,6 +40,8 @@ pub mod vga;
 
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
+	use hermit_entry::boot_info::PlatformInfo;
+
 	match env::boot_info().platform_info {
 		PlatformInfo::Uhyve { num_cpus, .. } => u32::try_from(num_cpus.get()).unwrap(),
 		_ => apic::local_apic_id_count(),
@@ -54,13 +56,6 @@ pub fn get_processor_count() -> u32 {
 #[cfg(not(feature = "smp"))]
 pub fn get_processor_count() -> u32 {
 	1
-}
-
-pub fn is_uhyve_with_pci() -> bool {
-	matches!(
-		env::boot_info().platform_info,
-		PlatformInfo::Uhyve { has_pci: true, .. }
-	)
 }
 
 /// Real Boot Processor initialization as soon as we have put the first Welcome message on the screen.
@@ -93,10 +88,9 @@ pub fn boot_processor_init() {
 		#[cfg(feature = "acpi")]
 		acpi::init();
 	}
-	if is_uhyve_with_pci() || !is_uhyve() {
-		#[cfg(feature = "pci")]
-		pci::init();
-	}
+
+	#[cfg(feature = "pci")]
+	pci::init();
 
 	apic::init();
 	scheduler::install_timer_handler();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,10 +284,8 @@ fn boot_processor_main() -> ! {
 	#[cfg(feature = "smp")]
 	synch_all_cores();
 
-	if kernel::is_uhyve_with_pci() || !env::is_uhyve() {
-		#[cfg(feature = "pci")]
-		drivers::pci::print_information();
-	}
+	#[cfg(feature = "pci")]
+	drivers::pci::print_information();
 
 	// Start the initd task.
 	unsafe { PerCoreScheduler::spawn(initd, 0, scheduler::task::NORMAL_PRIO, 0, USER_STACK_SIZE) };


### PR DESCRIPTION
This PR removes any special casing for Uhyve without PCI. Since before hermit-entry, Uhyve advertises PCI support exactly when it is running on Linux. I tested this on the last good AArch64 macOS Uhyve commit (see https://github.com/hermit-os/uhyve/issues/1408).