### PR TITLE
fix: migrate from shell-words to shlex for shell parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -881,7 +881,7 @@ dependencies = [
  "riscv",
  "sbi-rt",
  "semihosting",
- "shell-words",
+ "shlex 2.0.1",
  "simple-shell",
  "smallvec",
  "smoltcp",
@@ -1726,16 +1726,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simple-shell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,7 +341,7 @@ num_enum = { version = "0.7", default-features = false }
 pci-ids = { version = "0.2", optional = true }
 pci_types = { version = "0.10" }
 rand_chacha = { version = "0.10", default-features = false }
-shell-words = { version = "1.1", default-features = false }
+shlex = { version = "2", default-features = false }
 simple-shell = { version = "0.0.1", optional = true }
 smallvec = { version = "1", features = ["const_new"] }
 take-static = "0.1"

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,6 +13,7 @@ use hashbrown::hash_map::Iter;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 use memory_addresses::PhysAddr;
+use shlex::Shlex;
 
 static BOOT_INFO: OnceCell<BootInfo> = OnceCell::new();
 
@@ -141,9 +142,8 @@ impl Default for Cli {
 
 		let args = fdt_args().unwrap_or_default();
 		info!("bootargs = {args}");
-		let words = shell_words::split(args).unwrap();
+		let mut words = Shlex::new(args);
 
-		let mut words = words.into_iter();
 		let expect_arg = |arg: Option<String>, name: &str| {
 			arg.unwrap_or_else(|| {
 				panic!("The argument '{name}' requires a value but none was supplied")


### PR DESCRIPTION
This PR migrates our shell parsing logic for kernel arguments from [shell-words](https://crates.io/crates/shell-words) to [shlex](https://crates.io/crates/shlex).
Both crates are hugely popular, but shlex is a bit more essential to the ecosystem.
This aligns the parsing crate with the quoting crate introduced in https://github.com/hermit-os/kernel/pull/2540.

I don't remember why I chose shell-words in https://github.com/hermit-os/kernel/pull/357.

This does allow avoiding allocating a vector, which is nice, but not that important.