### PR TITLE
feat(xtask): run AArch64 QEMU with `max` CPU type instead of Cortex-A72

### DIFF
--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -330,7 +330,7 @@ impl Qemu {
 			Arch::Aarch64 | Arch::Aarch64Be => {
 				if !self.accel {
 					cpu_args.push("-cpu".to_owned());
-					cpu_args.push("cortex-a72".to_owned());
+					cpu_args.push("max,lpa2=off".to_owned());
 				}
 
 				cpu_args.push("-semihosting".to_owned());


### PR DESCRIPTION
This PR works around https://github.com/hermit-os/kernel/issues/2543 by explicitly disabling LPA2 but otherwise enables QEMU's `max` CPU type.

This enables the ARM v8.5 RNG, for example. For details, see https://github.com/hermit-os/kernel/pull/2528.