### PR TITLE
feat: add `loader` feature and make `hermit-entry` optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,16 +175,18 @@ jobs:
           - arch: x86_64
             packages: qemu-system-x86-hwe uftrace
             qemu_flags: --accel --sudo
+            rs_flags: --features hermit/loader
           - arch: aarch64
             packages: qemu-system-arm-hwe ipxe-qemu
-            rs_flags: --features hermit/semihosting
+            rs_flags: --features hermit/loader,hermit/semihosting
           # FIXME: enable semihosting once it works with QEMU
           # See https://github.com/taiki-e/semihosting/issues/18.
           - arch: aarch64_be
             packages: qemu-system-arm-hwe ipxe-qemu
+            rs_flags: --features hermit/loader
           - arch: riscv64
             packages: qemu-system-riscv-hwe
-            rs_flags: --features hermit/semihosting
+            rs_flags: --features hermit/loader,hermit/semihosting
 
     steps:
       - name: Checkout hermit-rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ default = [
 	"dhcpv4",
 	"fsgsbase",
 	"kernel-stack",
+	"loader",
 	"pci-ids",
 	"pci",
 	"smp",
@@ -81,12 +82,19 @@ newlib = []
 
 #! ### Platform Features
 
+## Enables [Hermit loader] support.
+##
+## The Hermit loader is a bootloader that adapts to multiple platforms.
+##
+## [Hermit loader]: https://github.com/hermit-os/loader
+loader = ["hermit-entry"]
+
 ## Enables [Uhyve] support.
 ##
 ## Uhyve is a Hermit-specific _virtual machine monitor_ (VMM).
 ##
 ## [Uhyve]: https://github.com/hermit-os/uhyve
-uhyve = ["dep:uhyve-interface"]
+uhyve = ["hermit-entry", "dep:uhyve-interface"]
 
 #! ### Hardware Features
 #!
@@ -267,6 +275,11 @@ strace = []
 ## Documents the Cargo features in the crate docs.
 document-features = ["dep:document-features"]
 
+## Enables support for hermit-entry boot info.
+##
+## This is automatically enabled by the `loader` and `uhyve` features.
+hermit-entry = ["dep:hermit-entry"]
+
 ## Enables the network backend.
 ##
 ## This is automatically enabled by any network feature.
@@ -333,7 +346,7 @@ free-list = "0.3"
 fuse-abi = { version = "0.2", optional = true, features = ["linux"] }
 hashbrown = { version = "0.17", default-features = false }
 heapless = "0.9"
-hermit-entry = { version = "0.10.10", features = ["kernel"] }
+hermit-entry = { version = "0.10", features = ["kernel"], optional = true }
 hermit-sync = "0.1"
 log = { version = "0.4", default-features = false }
 mem-barrier = { version = "0.1.0", optional = true, features = ["nightly"] }

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -19,7 +19,7 @@ use crate::arch::kernel::scheduler::State;
 use crate::arch::kernel::serial::handle_uart_interrupt;
 use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::drivers::InterruptHandlerMap;
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 use crate::mm::{PageAlloc, PageRangeAllocator};
 use crate::scheduler::{self, CoreId, timer_interrupts};
 
@@ -266,7 +266,7 @@ pub fn wakeup_core(core_id: CoreId) {
 pub(crate) fn init() {
 	info!("Initialize generic interrupt controller");
 
-	let fdt = env::fdt().unwrap();
+	let fdt = env::start_info().fdt().unwrap();
 
 	let intc_node = fdt.find_node("/intc").unwrap();
 	let mut reg_iter = intc_node.reg().unwrap();
@@ -445,7 +445,7 @@ pub fn init_cpu() {
 	GicCpuInterface::enable_group1(true);
 	GicCpuInterface::set_priority_mask(0xff);
 
-	let fdt = env::fdt().unwrap();
+	let fdt = env::start_info().fdt().unwrap();
 
 	if let Some(timer_node) = fdt.find_compatible(&["arm,armv8-timer", "arm,armv7-timer"]) {
 		let irq_slice = timer_node.property("interrupts").unwrap().value;

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -36,6 +36,7 @@ use crate::drivers::virtio::transport::mmio as mmio_virtio;
 use crate::drivers::virtio::transport::mmio::VirtioDriver;
 #[cfg(feature = "virtio-vsock")]
 use crate::drivers::vsock::VirtioVsockDriver;
+use crate::env::FdtStartInfo;
 #[cfg(feature = "virtio-net")]
 use crate::executor::device::NETWORK_DEVICE;
 use crate::init_cell::InitCell;
@@ -120,7 +121,7 @@ pub(crate) fn get_vsock_driver() -> Option<&'static InterruptTicketMutex<VirtioV
 
 pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 	without_interrupts(|| {
-		let Some(fdt) = crate::env::fdt() else {
+		let Some(fdt) = crate::env::start_info().fdt() else {
 			error!("No device tree found, cannot initialize MMIO drivers");
 			return;
 		};

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use self::processor::set_oneshot_timer;
 use crate::arch::kernel::core_local::*;
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::config::*;
+#[cfg(feature = "smp")]
+use crate::env::FdtStartInfo;
 
 #[repr(align(8))]
 pub(crate) struct AlignedAtomicU32(AtomicU32);
@@ -39,7 +41,7 @@ global_asm!(include_str!("exceptions.s"));
 
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
-	let fdt = crate::env::fdt().unwrap();
+	let fdt = crate::env::start_info().fdt().unwrap();
 	let cpu_count = fdt.cpus().count();
 	u32::try_from(cpu_count).unwrap()
 }
@@ -97,9 +99,12 @@ pub fn boot_next_processor() {
 	#[allow(unused_variables)]
 	let cpu_online = CPU_ONLINE.0.fetch_add(1, Ordering::Release);
 
+	#[cfg(feature = "uhyve")]
+	use crate::env::UhyveStartInfo;
+
 	#[allow(clippy::needless_return)]
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	if crate::env::start_info().is_uhyve() {
 		return;
 	}
 
@@ -123,7 +128,7 @@ pub fn boot_next_processor() {
 			trace!("Virtual address of smp_start 0x{virt_start:x}");
 			trace!("Physical address of smp_start 0x{phys_start:x}");
 
-			let fdt = crate::env::fdt().unwrap();
+			let fdt = crate::env::start_info().fdt().unwrap();
 			let psci_node = fdt.find_node("/psci").unwrap();
 
 			let cpu_on = psci_node.property("cpu_on").unwrap().as_usize().unwrap();

--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -15,7 +15,7 @@ use crate::arch::kernel::core_local::core_id;
 use crate::arch::kernel::interrupts::GIC;
 use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::drivers::pci::{PCI_DEVICES, PciDevice};
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 use crate::mm::{PageAlloc, PageRangeAllocator};
 
 const PCI_MAX_DEVICE_NUMBER: u8 = 32;
@@ -222,7 +222,7 @@ fn detect_interrupt(
 }
 
 pub fn init() {
-	let fdt = env::fdt().unwrap();
+	let fdt = env::start_info().fdt().unwrap();
 
 	if let Some(pci_node) = fdt.find_compatible(&["pci-host-ecam-generic"]) {
 		let reg = pci_node.reg().unwrap().next().unwrap();

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -268,7 +268,10 @@ pub fn supports_2mib_pages() -> bool {
 
 pub fn configure() {
 	#[cfg(feature = "uhyve")]
-	if env::is_uhyve() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		return;
 	}
 

--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -6,7 +6,7 @@ use memory_addresses::{PhysAddr, VirtAddr};
 use time::OffsetDateTime;
 
 use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 use crate::mm::{PageAlloc, PageRangeAllocator};
 
 static PL031_ADDRESS: OnceCell<VirtAddr> = OnceCell::new();
@@ -46,11 +46,14 @@ fn rtc_read(off: usize) -> u32 {
 
 fn boot_time() -> OffsetDateTime {
 	#[cfg(feature = "uhyve")]
-	if let Some(boot_time) = env::uhyve_boot_time() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if let Some(boot_time) = env::start_info().uhyve_boot_time() {
 		return boot_time;
 	}
 
-	let fdt = env::fdt().unwrap();
+	let fdt = env::start_info().fdt().unwrap();
 	let Some(pl031_node) = fdt.find_compatible(&["arm,pl031"]) else {
 		error!("Could not find PL031 Real Time Clock to determine the boot time.");
 		return OffsetDateTime::UNIX_EPOCH;

--- a/src/arch/aarch64/mm/paging.rs
+++ b/src/arch/aarch64/mm/paging.rs
@@ -687,6 +687,7 @@ pub fn map_heap<S: PageSize>(virt_addr: VirtAddr, nr_pages: usize) -> Result<(),
 	Ok(())
 }
 
+#[allow(dead_code)]
 pub fn identity_map<S: PageSize>(phys_addr: PhysAddr) {
 	let virt_addr = VirtAddr::new(phys_addr.as_u64());
 	let flags = {

--- a/src/arch/aarch64/start/mod.rs
+++ b/src/arch/aarch64/start/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "hermit-entry")]
 pub mod hermit_entry;
 #[cfg(feature = "smp")]
 pub mod smp;

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -52,7 +52,7 @@ use crate::drivers::virtio::transport::mmio as mmio_virtio;
 	not(feature = "pci"),
 ))]
 use crate::drivers::virtio::transport::mmio::VirtioDriver;
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 #[cfg(all(any(feature = "gem-net", feature = "virtio-net"), not(feature = "pci")))]
 use crate::executor::device::NETWORK_DEVICE;
 
@@ -68,7 +68,7 @@ enum Model {
 /// This function should only be called once
 pub fn init() {
 	debug!("Init devicetree");
-	let Some(fdt) = env::fdt() else {
+	let Some(fdt) = env::start_info().fdt() else {
 		return;
 	};
 
@@ -106,7 +106,7 @@ pub fn init() {
 /// This function should only be called once
 pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 	// TODO: Implement devicetree correctly
-	if let Some(fdt) = env::fdt() {
+	if let Some(fdt) = env::start_info().fdt() {
 		debug!("Init drivers using devicetree");
 
 		unsafe {

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -22,7 +22,7 @@ use crate::arch::kernel::core_local::core_id;
 pub use crate::arch::kernel::devicetree::init_drivers;
 use crate::arch::kernel::processor::lsb;
 use crate::config::KERNEL_STACK_SIZE;
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 use crate::init_cell::InitCell;
 use crate::mm::{FrameAlloc, PageRangeAllocator};
 
@@ -59,7 +59,7 @@ pub fn get_hart_mask() -> u64 {
 }
 
 pub fn get_timebase_freq() -> u64 {
-	let fdt = env::fdt().unwrap();
+	let fdt = env::start_info().fdt().unwrap();
 
 	// Get timebase-freq
 	let cpus_node = fdt
@@ -148,9 +148,12 @@ pub fn boot_next_processor() {
 	// TODO: Old: Changing cpu_online will cause uhyve to start the next processor
 	CPU_ONLINE.fetch_add(1, Ordering::Release);
 
+	#[cfg(feature = "uhyve")]
+	use env::UhyveStartInfo;
+
 	#[allow(clippy::needless_return)]
 	#[cfg(feature = "uhyve")]
-	if env::is_uhyve() {
+	if env::start_info().is_uhyve() {
 		return;
 	}
 

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -35,6 +35,7 @@ pub(crate) static CPU_ONLINE: AtomicU32 = AtomicU32::new(0);
 pub(crate) static CURRENT_BOOT_ID: AtomicU32 = AtomicU32::new(0);
 pub(crate) static CURRENT_STACK_ADDRESS: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 pub(crate) static HART_MASK: AtomicU64 = AtomicU64::new(0);
+#[cfg_attr(not(any(feature = "hermit-entry", feature = "smp")), expect(dead_code))]
 pub(crate) static NUM_CPUS: AtomicU32 = AtomicU32::new(0);
 
 // FUNCTIONS

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -10,7 +10,7 @@ use crate::arch::kernel::{
 	CPU_ONLINE, CURRENT_BOOT_ID, CURRENT_STACK_ADDRESS, HART_MASK, NUM_CPUS,
 };
 use crate::config::KERNEL_STACK_SIZE;
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 
 //static mut BOOT_STACK: [u8; KERNEL_STACK_SIZE] = [0; KERNEL_STACK_SIZE];
 
@@ -54,7 +54,7 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 		crate::logging::KERNEL_LOGGER.set_time(true);
 
 		env::set_start_info(*boot_info.unwrap());
-		let fdt = env::fdt().unwrap();
+		let fdt = env::start_info().fdt().unwrap();
 		// Init HART_MASK
 		let mut hart_mask = 0;
 		for cpu in fdt.cpus() {

--- a/src/arch/riscv64/start/mod.rs
+++ b/src/arch/riscv64/start/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "hermit-entry")]
 pub mod hermit_entry;
 #[cfg(feature = "smp")]
 pub mod smp;

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -8,7 +8,7 @@ use x86_64::structures::paging::{PageTableFlags, PhysFrame};
 
 use crate::arch::mm::paging;
 use crate::arch::mm::paging::{BasePageSize, LargePageSize, PageSize};
-use crate::env;
+use crate::env::{self, StartInfo};
 
 /// Memory at this physical address is supposed to contain a pointer to the Extended BIOS Data Area (EBDA).
 const EBDA_PTR_LOCATION: PhysAddr = PhysAddr::new(0x0000_040e);
@@ -291,7 +291,7 @@ fn detect_rsdp(start_address: PhysAddr, end_address: PhysAddr) -> Result<&'stati
 /// Detects ACPI support of the computer system.
 /// Returns a reference to the ACPI RSDP within the Ok() if successful or an empty Err() on failure.
 fn detect_acpi() -> Result<&'static AcpiRsdp, ()> {
-	if let Some(rsdp_addr) = env::rsdp_addr() {
+	if let Some(rsdp_addr) = env::start_info().rsdp_addr() {
 		trace!("RSDP detected successfully at {rsdp_addr:#x?}");
 		let rsdp = unsafe {
 			ptr::with_exposed_provenance::<AcpiRsdp>(rsdp_addr.get())
@@ -461,7 +461,10 @@ pub fn poweroff() {
 
 pub fn init() {
 	#[cfg(feature = "uhyve")]
-	if env::is_uhyve() {
+	use env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		return;
 	}
 

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -497,7 +497,10 @@ fn default_apic() -> PhysAddr {
 
 fn apic_addr() -> PhysAddr {
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	use crate::env::{self, UhyveStartInfo};
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		return default_apic();
 	}
 

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -9,6 +9,8 @@ use x86_64::registers::control::{Cr0, Cr4};
 
 pub(crate) use self::apic::{set_oneshot_timer, wakeup_core};
 use crate::arch::kernel::core_local::*;
+#[cfg(feature = "uhyve")]
+use crate::env::{self, UhyveStartInfo};
 
 #[cfg(feature = "acpi")]
 pub mod acpi;
@@ -37,7 +39,7 @@ pub mod vga;
 #[cfg(feature = "smp")]
 pub fn get_possible_cpus() -> u32 {
 	#[cfg(feature = "uhyve")]
-	if let Some(num_cpus) = crate::env::uhyve_num_cpus() {
+	if let Some(num_cpus) = env::start_info().uhyve_num_cpus() {
 		return num_cpus.get().try_into().unwrap();
 	}
 
@@ -107,7 +109,7 @@ pub fn application_processor_init() {
 
 fn finish_processor_init() {
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	if env::start_info().is_uhyve() {
 		// uhyve does not use apic::detect_from_acpi and therefore does not know the number of processors and
 		// their APIC IDs in advance.
 		// Therefore, we have to add each booted processor into the CPU_LOCAL_APIC_IDS vector ourselves.
@@ -127,7 +129,7 @@ pub fn boot_next_processor() {
 	let cpu_online = CPU_ONLINE.fetch_add(1, Ordering::Release);
 
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	if env::start_info().is_uhyve() {
 		return;
 	}
 

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -354,8 +354,11 @@ impl CpuFrequency {
 		{
 			use core::num::NonZero;
 
+			use crate::env::FdtStartInfo;
+
 			fn mhz_from_fdt() -> Option<NonZero<u16>> {
-				let khz = env::fdt()?
+				let khz = env::start_info()
+					.fdt()?
 					.find_node("/hermit,tsc")?
 					.property("khz")?
 					.as_usize()?;

--- a/src/arch/x86_64/kernel/systemtime.rs
+++ b/src/arch/x86_64/kernel/systemtime.rs
@@ -175,7 +175,10 @@ static BOOT_TIME: OnceCell<u64> = OnceCell::new();
 
 fn boot_time() -> OffsetDateTime {
 	#[cfg(feature = "uhyve")]
-	if let Some(boot_time) = crate::env::uhyve_boot_time() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if let Some(boot_time) = crate::env::start_info().uhyve_boot_time() {
 		return boot_time;
 	}
 

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -11,8 +11,7 @@ use x86_64::structures::paging::frame::PhysFrameRange;
 use x86_64::structures::paging::mapper::{MapToError, MappedFrame, TranslateResult, UnmapError};
 use x86_64::structures::paging::page::PageRange;
 use x86_64::structures::paging::{
-	FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableIndex, PhysFrame, Size4KiB,
-	Translate,
+	FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PhysFrame, Size4KiB, Translate,
 };
 
 use crate::arch::kernel::processor;
@@ -120,7 +119,10 @@ pub unsafe fn identity_mapped_page_table() -> OffsetPageTable<'static> {
 ///
 /// This is useful for compatibility with the Hermit loader version 0.5.6.
 // FIXME: Remove once we drop support for loader 0.5.6
+#[cfg(feature = "hermit-entry")]
 pub fn is_recursive() -> bool {
+	use x86_64::structures::paging::PageTableIndex;
+
 	let identity_mapped_page_table = unsafe { identity_mapped_page_table() };
 	let level_4_table = identity_mapped_page_table.level_4_table();
 

--- a/src/arch/x86_64/start/mod.rs
+++ b/src/arch/x86_64/start/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "hermit-entry")]
 pub mod hermit_entry;
 #[cfg(feature = "smp")]
 pub mod smp;

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -157,7 +157,10 @@ pub(crate) static CONSOLE: Lazy<InterruptTicketMutex<Console>> = Lazy::new(|| {
 	CoreLocal::install();
 
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	use crate::env::{self, UhyveStartInfo};
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		return InterruptTicketMutex::new(Console::new(IoDevice::Uhyve(uhyve::UhyveSerial::new())));
 	}
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -42,7 +42,7 @@ impl Default for Cli {
 			RandomState::with_seeds(0, 0, 0, 0),
 		);
 
-		let args = bootargs().unwrap_or_default();
+		let args = start_info().bootargs().unwrap_or_default();
 		info!("bootargs = {args}");
 		let mut words = Shlex::new(args);
 

--- a/src/env/start_info.rs
+++ b/src/env/start_info.rs
@@ -1,5 +1,5 @@
 use core::num::NonZero;
-use core::ptr;
+use core::{fmt, ptr};
 
 use fdt::Fdt;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
@@ -7,7 +7,13 @@ use hermit_sync::OnceCell;
 
 static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
-pub fn start_info() -> &'static BootInfo {
+#[cfg(not(feature = "uhyve"))]
+pub fn start_info() -> &'static impl FdtStartInfo {
+	START_INFO.get().unwrap()
+}
+
+#[cfg(feature = "uhyve")]
+pub fn start_info() -> &'static impl UhyveStartInfo {
 	START_INFO.get().unwrap()
 }
 
@@ -16,74 +22,116 @@ pub fn set_start_info(raw_boot_info: RawBootInfo) {
 	START_INFO.set(start_info).unwrap();
 }
 
-/// Whether Hermit is running under the "uhyve" hypervisor.
-#[cfg(feature = "uhyve")]
-pub fn is_uhyve() -> bool {
-	use hermit_entry::boot_info::PlatformInfo;
+pub trait StartInfo {
+	fn display(&self) -> impl fmt::Display {
+		fmt::from_fn(|f| f.write_str("StartInfo::display not implemented"))
+	}
 
-	matches!(start_info().platform_info, PlatformInfo::Uhyve { .. })
-}
+	fn bootargs(&self) -> Option<&str> {
+		None
+	}
 
-#[cfg_attr(target_arch = "riscv64", expect(dead_code))]
-#[cfg(feature = "uhyve")]
-pub fn uhyve_boot_time() -> Option<time::OffsetDateTime> {
-	use hermit_entry::boot_info::PlatformInfo;
-
-	match start_info().platform_info {
-		PlatformInfo::Uhyve { boot_time, .. } => Some(boot_time),
-		_ => None,
+	#[cfg_attr(
+		any(
+			not(feature = "acpi"),
+			target_arch = "aarch64",
+			target_arch = "riscv64"
+		),
+		expect(dead_code)
+	)]
+	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
+		None
 	}
 }
 
-#[cfg_attr(
-	any(not(target_arch = "x86_64"), not(feature = "smp")),
-	expect(dead_code)
-)]
-#[cfg(feature = "uhyve")]
-pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
-	use hermit_entry::boot_info::PlatformInfo;
+pub trait FdtStartInfo: StartInfo {
+	fn fdt(&self) -> Option<Fdt<'_>> {
+		None
+	}
 
-	match start_info().platform_info {
-		PlatformInfo::Uhyve { num_cpus, .. } => {
-			Some(NonZero::new(num_cpus.get() as usize).unwrap())
+	fn fdt_addr(&self) -> Option<NonZero<usize>> {
+		None
+	}
+}
+
+#[cfg(feature = "uhyve")]
+pub trait UhyveStartInfo: FdtStartInfo {
+	fn is_uhyve(&self) -> bool;
+
+	#[cfg_attr(target_arch = "riscv64", expect(unused))]
+	fn uhyve_boot_time(&self) -> Option<time::OffsetDateTime>;
+
+	#[cfg_attr(not(all(target_arch = "x86_64", feature = "smp")), expect(unused))]
+	fn uhyve_num_cpus(&self) -> Option<NonZero<usize>>;
+}
+
+impl StartInfo for BootInfo {
+	fn display(&self) -> impl fmt::Display {
+		fmt::from_fn(|f| {
+			if let Some(fdt) = self.fdt() {
+				write!(f, "FDT:\n{fdt:#?}")
+			} else {
+				f.write_str("No FDT.")
+			}
+		})
+	}
+
+	fn bootargs(&self) -> Option<&str> {
+		self.fdt()?.chosen().bootargs()
+	}
+
+	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
+		let rsdp = self
+			.fdt()?
+			.find_node("/hermit,rsdp")?
+			.reg()?
+			.next()?
+			.starting_address
+			.addr();
+		NonZero::new(rsdp)
+	}
+}
+
+impl FdtStartInfo for BootInfo {
+	fn fdt(&self) -> Option<Fdt<'_>> {
+		let fdt_addr = self.fdt_addr()?;
+		let ptr = ptr::with_exposed_provenance(fdt_addr.get());
+		let fdt = unsafe { Fdt::from_ptr(ptr).unwrap() };
+		Some(fdt)
+	}
+
+	fn fdt_addr(&self) -> Option<NonZero<usize>> {
+		let fdt_addr = self.hardware_info.device_tree?;
+		let fdt_addr = NonZero::new(fdt_addr.get() as usize).unwrap();
+		Some(fdt_addr)
+	}
+}
+
+#[cfg(feature = "uhyve")]
+impl UhyveStartInfo for BootInfo {
+	fn is_uhyve(&self) -> bool {
+		use hermit_entry::boot_info::PlatformInfo;
+
+		matches!(self.platform_info, PlatformInfo::Uhyve { .. })
+	}
+
+	fn uhyve_boot_time(&self) -> Option<time::OffsetDateTime> {
+		use hermit_entry::boot_info::PlatformInfo;
+
+		match self.platform_info {
+			PlatformInfo::Uhyve { boot_time, .. } => Some(boot_time),
+			_ => None,
 		}
-		_ => None,
 	}
-}
 
-pub fn fdt_addr() -> Option<NonZero<usize>> {
-	start_info()
-		.hardware_info
-		.device_tree
-		.map(|fdt| NonZero::new(fdt.get() as usize).unwrap())
-}
+	fn uhyve_num_cpus(&self) -> Option<NonZero<usize>> {
+		use hermit_entry::boot_info::PlatformInfo;
 
-pub fn fdt() -> Option<Fdt<'static>> {
-	fdt_addr().map(|fdt| {
-		let ptr = ptr::with_exposed_provenance(fdt.get());
-		unsafe { Fdt::from_ptr(ptr).unwrap() }
-	})
-}
-
-/// Returns the RSDP physical address if available.
-#[cfg_attr(
-	any(
-		not(feature = "acpi"),
-		target_arch = "aarch64",
-		target_arch = "riscv64"
-	),
-	expect(dead_code)
-)]
-pub fn rsdp_addr() -> Option<NonZero<usize>> {
-	let rsdp_addr = fdt()?
-		.find_node("/hermit,rsdp")?
-		.reg()?
-		.next()?
-		.starting_address
-		.addr();
-	NonZero::new(rsdp_addr)
-}
-
-pub fn bootargs() -> Option<&'static str> {
-	fdt().and_then(|fdt| fdt.chosen().bootargs())
+		match self.platform_info {
+			PlatformInfo::Uhyve { num_cpus, .. } => {
+				Some(NonZero::new(num_cpus.get() as usize).unwrap())
+			}
+			_ => None,
+		}
+	}
 }

--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -5,6 +5,8 @@ use fdt::Fdt;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 
+use super::{FdtStartInfo, StartInfo};
+
 static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
 #[cfg(not(feature = "uhyve"))]
@@ -13,56 +15,13 @@ pub fn start_info() -> &'static impl FdtStartInfo {
 }
 
 #[cfg(feature = "uhyve")]
-pub fn start_info() -> &'static impl UhyveStartInfo {
+pub fn start_info() -> &'static impl super::UhyveStartInfo {
 	START_INFO.get().unwrap()
 }
 
 pub fn set_start_info(raw_boot_info: RawBootInfo) {
 	let start_info = BootInfo::from(raw_boot_info);
 	START_INFO.set(start_info).unwrap();
-}
-
-pub trait StartInfo {
-	fn display(&self) -> impl fmt::Display {
-		fmt::from_fn(|f| f.write_str("StartInfo::display not implemented"))
-	}
-
-	fn bootargs(&self) -> Option<&str> {
-		None
-	}
-
-	#[cfg_attr(
-		any(
-			not(feature = "acpi"),
-			target_arch = "aarch64",
-			target_arch = "riscv64"
-		),
-		expect(dead_code)
-	)]
-	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
-		None
-	}
-}
-
-pub trait FdtStartInfo: StartInfo {
-	fn fdt(&self) -> Option<Fdt<'_>> {
-		None
-	}
-
-	fn fdt_addr(&self) -> Option<NonZero<usize>> {
-		None
-	}
-}
-
-#[cfg(feature = "uhyve")]
-pub trait UhyveStartInfo: FdtStartInfo {
-	fn is_uhyve(&self) -> bool;
-
-	#[cfg_attr(target_arch = "riscv64", expect(unused))]
-	fn uhyve_boot_time(&self) -> Option<time::OffsetDateTime>;
-
-	#[cfg_attr(not(all(target_arch = "x86_64", feature = "smp")), expect(unused))]
-	fn uhyve_num_cpus(&self) -> Option<NonZero<usize>>;
 }
 
 impl StartInfo for BootInfo {
@@ -108,7 +67,7 @@ impl FdtStartInfo for BootInfo {
 }
 
 #[cfg(feature = "uhyve")]
-impl UhyveStartInfo for BootInfo {
+impl super::UhyveStartInfo for BootInfo {
 	fn is_uhyve(&self) -> bool {
 		use hermit_entry::boot_info::PlatformInfo;
 

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -1,9 +1,17 @@
+#[cfg(feature = "hermit-entry")]
 mod hermit_entry;
+
+#[cfg(feature = "hermit-entry")]
+pub use hermit_entry::*;
+
+#[cfg(not(feature = "hermit-entry"))]
+mod unsupported;
 
 use core::fmt;
 use core::num::NonZero;
 
-pub use hermit_entry::*;
+#[cfg(not(feature = "hermit-entry"))]
+pub use unsupported::*;
 
 pub trait StartInfo {
 	fn display(&self) -> impl fmt::Display {
@@ -27,11 +35,17 @@ pub trait StartInfo {
 	}
 }
 
+#[cfg(any(
+	feature = "hermit-entry",
+	target_arch = "aarch64",
+	target_arch = "riscv64"
+))]
 pub trait FdtStartInfo: StartInfo {
 	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
 		None
 	}
 
+	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
 	fn fdt_addr(&self) -> Option<NonZero<usize>> {
 		None
 	}

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -1,0 +1,49 @@
+mod hermit_entry;
+
+use core::fmt;
+use core::num::NonZero;
+
+pub use hermit_entry::*;
+
+pub trait StartInfo {
+	fn display(&self) -> impl fmt::Display {
+		fmt::from_fn(|f| f.write_str("StartInfo::display not implemented"))
+	}
+
+	fn bootargs(&self) -> Option<&str> {
+		None
+	}
+
+	#[cfg_attr(
+		any(
+			not(feature = "acpi"),
+			target_arch = "aarch64",
+			target_arch = "riscv64"
+		),
+		expect(dead_code)
+	)]
+	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
+		None
+	}
+}
+
+pub trait FdtStartInfo: StartInfo {
+	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
+		None
+	}
+
+	fn fdt_addr(&self) -> Option<NonZero<usize>> {
+		None
+	}
+}
+
+#[cfg(feature = "uhyve")]
+pub trait UhyveStartInfo: FdtStartInfo {
+	fn is_uhyve(&self) -> bool;
+
+	#[cfg_attr(target_arch = "riscv64", expect(unused))]
+	fn uhyve_boot_time(&self) -> Option<time::OffsetDateTime>;
+
+	#[cfg_attr(not(all(target_arch = "x86_64", feature = "smp")), expect(unused))]
+	fn uhyve_num_cpus(&self) -> Option<NonZero<usize>>;
+}

--- a/src/env/start_info/unsupported.rs
+++ b/src/env/start_info/unsupported.rs
@@ -1,0 +1,34 @@
+use core::num::NonZero;
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+pub fn start_info() -> &'static impl super::StartInfo {
+	#[expect(unreachable_code)]
+	&panic!()
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+pub fn start_info() -> &'static impl super::FdtStartInfo {
+	#[expect(unreachable_code)]
+	&panic!()
+}
+
+impl super::StartInfo for ! {
+	fn bootargs(&self) -> Option<&str> {
+		*self
+	}
+
+	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
+		*self
+	}
+}
+
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+impl super::FdtStartInfo for ! {
+	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
+		*self
+	}
+
+	fn fdt_addr(&self) -> Option<NonZero<usize>> {
+		*self
+	}
+}

--- a/src/fd/stdio/mod.rs
+++ b/src/fd/stdio/mod.rs
@@ -18,7 +18,10 @@ use crate::fd::{Fd, RawFd, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 
 pub(crate) fn setup(fds: &mut HashMap<RawFd, Arc<async_lock::RwLock<Fd>>, RandomState>) {
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if crate::env::start_info().is_uhyve() {
 		let stdin = Arc::new(async_lock::RwLock::new(UhyveStdin::new().into()));
 		let stdout = Arc::new(async_lock::RwLock::new(UhyveStdout::new().into()));
 		let stderr = Arc::new(async_lock::RwLock::new(UhyveStderr::new().into()));

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -332,7 +332,10 @@ pub(crate) fn init() {
 	virtio_fs::init();
 
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if crate::env::start_info().is_uhyve() {
 		uhyve::init();
 	}
 

--- a/src/fs/uhyve.rs
+++ b/src/fs/uhyve.rs
@@ -14,6 +14,7 @@ use uhyve_interface::v2::parameters::{
 };
 
 use crate::arch::mm::paging;
+use crate::env::FdtStartInfo;
 use crate::errno::Errno;
 use crate::fd::{Fd, RawFd};
 use crate::fs::{
@@ -241,7 +242,7 @@ impl VfsNode for UhyveDirectory {
 pub(crate) fn init() {
 	info!("Try to initialize uhyve filesystem");
 
-	let mount_str = env::fdt().and_then(|fdt| {
+	let mount_str = env::start_info().fdt().and_then(|fdt| {
 		fdt.find_node("/uhyve,mounts")
 			.and_then(|node| node.property("mounts"))
 			.and_then(|property| property.as_str())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -30,6 +30,10 @@ impl KernelLogger {
 		self.time.load(Ordering::Relaxed)
 	}
 
+	#[cfg_attr(
+		all(target_arch = "riscv64", not(feature = "hermit-entry")),
+		expect(dead_code)
+	)]
 	pub fn set_time(&self, time: bool) {
 		self.time.store(time, Ordering::Relaxed);
 	}

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -10,7 +10,7 @@ use memory_addresses::{PhysAddr, VirtAddr};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
 use crate::arch::mm::paging::{self, HugePageSize, PageSize, PageTableEntryFlags};
-use crate::env;
+use crate::env::{self, FdtStartInfo};
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
 
@@ -104,7 +104,7 @@ pub unsafe fn map_frame_range(frame_range: PageRange) {
 }
 
 unsafe fn detect_from_fdt() -> Result<(), ()> {
-	let fdt = env::fdt().ok_or(())?;
+	let fdt = env::start_info().fdt().ok_or(())?;
 
 	let all_regions = fdt
 		.find_all_nodes("/memory")
@@ -172,7 +172,7 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 	let kernel_region = PageRange::containing(kernel_start, kernel_end).unwrap();
 	reserve(kernel_region);
 
-	let fdt_start = env::fdt_addr().unwrap().get();
+	let fdt_start = env::start_info().fdt_addr().unwrap().get();
 	let fdt_end = fdt_start + fdt.total_size();
 	let fdt_region = PageRange::containing(fdt_start, fdt_end).unwrap();
 	reserve(fdt_region);

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -2,14 +2,20 @@ use core::alloc::AllocError;
 use core::fmt;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(feature = "hermit-entry")]
 use align_address::Align;
-use free_list::{FreeList, PageLayout, PageRange, PageRangeError};
+#[cfg(feature = "hermit-entry")]
+use free_list::PageRangeError;
+use free_list::{FreeList, PageLayout, PageRange};
 use hermit_sync::InterruptTicketMutex;
-use memory_addresses::{PhysAddr, VirtAddr};
+use memory_addresses::VirtAddr;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(feature = "hermit-entry")]
+use crate::arch::mm::paging::PageTableEntryFlags;
+#[cfg(all(target_arch = "x86_64", feature = "hermit-entry"))]
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
-use crate::arch::mm::paging::{self, HugePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::mm::paging::{self, HugePageSize, PageSize};
+#[cfg(feature = "hermit-entry")]
 use crate::env::{self, FdtStartInfo};
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
@@ -61,7 +67,10 @@ pub fn total_memory_size() -> usize {
 	TOTAL_MEMORY.load(Ordering::Relaxed)
 }
 
+#[cfg(feature = "hermit-entry")]
 pub unsafe fn map_frame_range(frame_range: PageRange) {
+	use memory_addresses::PhysAddr;
+
 	cfg_select! {
 		target_arch = "aarch64" => {
 			type IdentityPageSize = paging::BasePageSize;
@@ -103,6 +112,7 @@ pub unsafe fn map_frame_range(frame_range: PageRange) {
 	}
 }
 
+#[cfg(feature = "hermit-entry")]
 unsafe fn detect_from_fdt() -> Result<(), ()> {
 	let fdt = env::start_info().fdt().ok_or(())?;
 
@@ -181,12 +191,14 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 }
 
 // FIXME: upstream these
+#[cfg(feature = "hermit-entry")]
 trait PageRangeExt: Sized {
 	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError>;
 
 	fn and(self, rhs: Self) -> Option<Self>;
 }
 
+#[cfg(feature = "hermit-entry")]
 impl PageRangeExt for PageRange {
 	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError> {
 		let start = start.align_down(free_list::PAGE_SIZE);
@@ -209,6 +221,7 @@ unsafe fn init() {
 		paging::unmap::<HugePageSize>(start, count);
 	}
 
+	#[cfg(feature = "hermit-entry")]
 	unsafe {
 		detect_from_fdt().unwrap();
 	}

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -9,8 +9,10 @@ mod built_info {
 	include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
+#[cfg(feature = "hermit-entry")]
 hermit_entry::define_abi_tag!();
 
+#[cfg(feature = "hermit-entry")]
 hermit_entry::define_entry_version!();
 
 #[cfg(test)]

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,8 +1,9 @@
 use crate::arch::kernel;
 use crate::arch::kernel::core_local::{core_id, core_scheduler};
 use crate::arch::kernel::interrupts;
+use crate::env::{self, StartInfo};
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
-use crate::{console, drivers, env, executor, fs, logging, mm, scheduler, syscalls};
+use crate::{console, drivers, executor, fs, logging, mm, scheduler, syscalls};
 
 mod built_info {
 	include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -135,9 +136,7 @@ pub fn boot_processor_main() -> ! {
 	info!("Data segment end: {:p}", elf_symbols::data_end());
 	info!("Executable end:   {:p}", elf_symbols::executable_end());
 
-	if let Some(fdt) = env::fdt() {
-		info!("FDT:\n{fdt:#?}");
-	}
+	info!("{}", env::start_info().display());
 
 	kernel::boot_processor_init();
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -267,7 +267,10 @@ pub(crate) fn shutdown(arg: i32) -> ! {
 	crate::arch::kernel::print_statistics();
 
 	#[cfg(feature = "uhyve")]
-	if env::is_uhyve() {
+	use crate::env::UhyveStartInfo;
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		crate::uhyve::shutdown(arg);
 	}
 


### PR DESCRIPTION
This PR adds a `loader` features and makes `hermit-entry` optional in preparation for https://github.com/hermit-os/kernel/pull/2366.

Depends on:
- https://github.com/hermit-os/kernel/pull/2591
- https://github.com/hermit-os/kernel/pull/2592
- https://github.com/hermit-os/kernel/pull/2593
- https://github.com/hermit-os/kernel/pull/2594
- https://github.com/hermit-os/kernel/pull/2595
- https://github.com/hermit-os/kernel/pull/2596
- https://github.com/hermit-os/kernel/pull/2597
- https://github.com/hermit-os/kernel/pull/2602
- https://github.com/hermit-os/kernel/pull/2615
- https://github.com/hermit-os/kernel/pull/2620
- https://github.com/hermit-os/kernel/pull/2621

This is needed for:
- https://github.com/hermit-os/kernel/pull/2366