### PR TITLE
feat: Add virtio-rng driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,12 @@ jobs:
         if: matrix.arch == 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package stdin --features hermit/virtio-console --no-default-features qemu ${{ matrix.qemu_flags }} --devices virtio-console-mmio
         if: matrix.arch != 'x86_64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package hello_world --features hermit/virtio-rng,hermit/pci --no-default-features qemu ${{ matrix.qemu_flags }} --devices virtio-rng-pci
+        if: matrix.arch != 'riscv64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package hello_world --features hermit/virtio-rng --no-default-features qemu ${{ matrix.qemu_flags }} --devices virtio-rng-mmio --microvm
+        if: matrix.arch == 'x86_64'
+      - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package hello_world --features hermit/virtio-rng --no-default-features qemu ${{ matrix.qemu_flags }} --devices virtio-rng-mmio
+        if: matrix.arch != 'x86_64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package thread_test --smp 4 qemu ${{ matrix.qemu_flags }}
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package rusty_demo --features fs qemu ${{ matrix.qemu_flags }} --devices virtio-fs-pci
         if: matrix.arch == 'x86_64'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,9 @@ virtio-console = ["virtio"]
 ## Enables the virtio-fs driver.
 virtio-fs = ["virtio", "dep:fuse-abi", "fuse-abi/num_enum"]
 
+## Enables the virtio-rng driver.
+virtio-rng = ["virtio"]
+
 ## Enables the virtio-vsock driver.
 virtio-vsock = ["virtio"]
 

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -6,6 +6,7 @@ use arm_gic::{IntId, Trigger};
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use hermit_sync::InterruptTicketMutex;
@@ -26,11 +27,14 @@ use crate::drivers::console::VirtioUART;
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
 use crate::drivers::net::virtio::VirtioNetDriver;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-net",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use crate::drivers::virtio::transport::mmio::VirtioDriver;
@@ -49,6 +53,8 @@ pub(crate) enum MmioDriver {
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
+	#[cfg(feature = "virtio-rng")]
+	VirtioRng(InterruptTicketMutex<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	VirtioVsock(InterruptTicketMutex<VirtioVsockDriver>),
 }
@@ -72,6 +78,15 @@ impl MmioDriver {
 		}
 	}
 
+	#[cfg(feature = "virtio-rng")]
+	fn get_rng_driver(&self) -> Option<&InterruptTicketMutex<VirtioRngDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioRng(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-vsock")]
 	fn get_vsock_driver(&self) -> Option<&InterruptTicketMutex<VirtioVsockDriver>> {
 		#[allow(unreachable_patterns)]
@@ -85,6 +100,7 @@ impl MmioDriver {
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock"
 ))]
 pub(crate) fn register_driver(drv: MmioDriver) {
@@ -108,6 +124,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-rng")]
+pub(crate) fn get_rng_driver() -> Option<&'static InterruptTicketMutex<VirtioRngDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_rng_driver())
 }
 
 #[cfg(feature = "virtio-vsock")]
@@ -240,6 +264,10 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 						}
 						#[cfg(feature = "virtio-net")]
 						VirtioDriver::Net(drv) => *NETWORK_DEVICE.lock() = Some(*drv),
+						#[cfg(feature = "virtio-rng")]
+						VirtioDriver::Rng(drv) => {
+							register_driver(MmioDriver::VirtioRng(InterruptTicketMutex::new(*drv)));
+						}
 						#[cfg(feature = "virtio-vsock")]
 						VirtioDriver::Vsock(drv) => register_driver(MmioDriver::VirtioVsock(
 							InterruptTicketMutex::new(*drv),

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -14,6 +14,7 @@ use crate::arch::kernel::interrupts::init_plic;
 	any(
 		feature = "virtio-console",
 		feature = "virtio-fs",
+		feature = "virtio-rng",
 		feature = "virtio-vsock",
 	),
 	not(feature = "pci"),
@@ -23,6 +24,7 @@ use crate::arch::kernel::mmio::MmioDriver;
 	any(
 		feature = "virtio-console",
 		feature = "virtio-fs",
+		feature = "virtio-rng",
 		feature = "virtio-vsock",
 	),
 	not(feature = "pci")
@@ -47,6 +49,7 @@ use crate::drivers::virtio::transport::mmio as mmio_virtio;
 		feature = "virtio-console",
 		feature = "virtio-fs",
 		feature = "virtio-net",
+		feature = "virtio-rng",
 		feature = "virtio-vsock",
 	),
 	not(feature = "pci"),
@@ -273,6 +276,12 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 					#[cfg(feature = "virtio-net")]
 					Ok(VirtioDriver::Net(drv)) => {
 						*NETWORK_DEVICE.lock() = Some(*drv);
+					}
+					#[cfg(feature = "virtio-rng")]
+					Ok(VirtioDriver::Rng(drv)) => {
+						register_driver(MmioDriver::VirtioRng(
+							hermit_sync::InterruptSpinMutex::new(*drv),
+						));
 					}
 					#[cfg(feature = "virtio-vsock")]
 					Ok(VirtioDriver::Vsock(drv)) => {

--- a/src/arch/riscv64/kernel/mmio.rs
+++ b/src/arch/riscv64/kernel/mmio.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use hermit_sync::InterruptSpinMutex;
@@ -15,6 +16,8 @@ use crate::drivers::fs::VirtioFsDriver;
 use crate::drivers::net::gem::GEMDriver;
 #[cfg(all(not(feature = "gem-net"), feature = "virtio-net"))]
 use crate::drivers::net::virtio::VirtioNetDriver;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 #[cfg(feature = "virtio-vsock")]
 use crate::drivers::vsock::VirtioVsockDriver;
 use crate::init_cell::InitCell;
@@ -27,6 +30,8 @@ pub(crate) enum MmioDriver {
 	VirtioConsole(InterruptSpinMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptSpinMutex<VirtioFsDriver>),
+	#[cfg(feature = "virtio-rng")]
+	VirtioRng(InterruptSpinMutex<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	VirtioVsock(InterruptSpinMutex<VirtioVsockDriver>),
 }
@@ -50,6 +55,15 @@ impl MmioDriver {
 		}
 	}
 
+	#[cfg(feature = "virtio-rng")]
+	fn get_rng_driver(&self) -> Option<&InterruptSpinMutex<VirtioRngDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioRng(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-vsock")]
 	fn get_vsock_driver(&self) -> Option<&InterruptSpinMutex<VirtioVsockDriver>> {
 		#[allow(unreachable_patterns)]
@@ -63,6 +77,7 @@ impl MmioDriver {
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 pub(crate) fn register_driver(drv: MmioDriver) {
@@ -89,6 +104,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptSpinMutex<Virt
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-rng")]
+pub(crate) fn get_rng_driver() -> Option<&'static InterruptSpinMutex<VirtioRngDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_rng_driver())
 }
 
 #[cfg(feature = "virtio-vsock")]

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -8,6 +8,7 @@ use free_list::{PageLayout, PageRange};
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use hermit_sync::InterruptTicketMutex;
@@ -27,11 +28,14 @@ use crate::drivers::console::VirtioConsoleDriver;
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
 use crate::drivers::net::virtio::VirtioNetDriver;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-net",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use crate::drivers::virtio::transport::mmio::VirtioDriver;
@@ -53,6 +57,8 @@ pub(crate) enum MmioDriver {
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
+	#[cfg(feature = "virtio-rng")]
+	VirtioRng(InterruptTicketMutex<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	VirtioVsock(InterruptTicketMutex<VirtioVsockDriver>),
 }
@@ -72,6 +78,15 @@ impl MmioDriver {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioFs(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
+	#[cfg(feature = "virtio-rng")]
+	fn get_rng_driver(&self) -> Option<&InterruptTicketMutex<VirtioRngDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioRng(drv) => Some(drv),
 			_ => None,
 		}
 	}
@@ -185,6 +200,7 @@ fn guess_device(
 #[cfg(any(
 	feature = "virtio-console",
 	feature = "virtio-fs",
+	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 pub(crate) fn register_driver(drv: MmioDriver) {
@@ -208,6 +224,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-rng")]
+pub(crate) fn get_rng_driver() -> Option<&'static InterruptTicketMutex<VirtioRngDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_rng_driver())
 }
 
 #[cfg(feature = "virtio-vsock")]
@@ -235,6 +259,10 @@ fn register_mmio(
 		#[cfg(feature = "virtio-net")]
 		Ok(VirtioDriver::Net(drv)) => {
 			*NETWORK_DEVICE.lock() = Some(*drv);
+		}
+		#[cfg(feature = "virtio-rng")]
+		Ok(VirtioDriver::Rng(drv)) => {
+			register_driver(MmioDriver::VirtioRng(InterruptTicketMutex::new(*drv)));
 		}
 		#[cfg(feature = "virtio-vsock")]
 		Ok(VirtioDriver::Vsock(drv)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,3 +17,6 @@ pub(crate) const VSOCK_PACKET_SIZE: u32 = 8192;
 
 #[cfg(feature = "virtio-console")]
 pub(crate) const CONSOLE_PACKET_SIZE: u32 = 8192;
+
+#[cfg(feature = "virtio-rng")]
+pub(crate) const RNG_PACKET_SIZE: u32 = 32;

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -2,5 +2,7 @@
 pub(crate) use crate::arch::kernel::mmio::get_console_driver;
 #[cfg(feature = "virtio-fs")]
 pub(crate) use crate::arch::kernel::mmio::get_filesystem_driver;
+#[cfg(feature = "virtio-rng")]
+pub(crate) use crate::arch::kernel::mmio::get_rng_driver;
 #[cfg(feature = "virtio-vsock")]
 pub(crate) use crate::arch::kernel::mmio::get_vsock_driver;

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -10,6 +10,8 @@ pub mod mmio;
 pub mod net;
 #[cfg(feature = "pci")]
 pub mod pci;
+#[cfg(feature = "virtio-rng")]
+pub mod rng;
 #[cfg(feature = "virtio")]
 pub mod virtio;
 #[cfg(feature = "virtio-vsock")]

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -6,7 +6,8 @@ use core::fmt;
 #[cfg(any(
 	feature = "virtio-fs",
 	feature = "virtio-vsock",
-	feature = "virtio-console"
+	feature = "virtio-console",
+	feature = "virtio-rng",
 ))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
@@ -31,6 +32,8 @@ use crate::drivers::fs::VirtioFsDriver;
 use crate::drivers::net::rtl8139::{self, RTL8139Driver};
 #[cfg(all(not(feature = "rtl8139"), feature = "virtio-net"))]
 use crate::drivers::net::virtio::VirtioNetDriver;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 #[cfg(feature = "virtio")]
 use crate::drivers::virtio::transport::pci as pci_virtio;
 #[cfg(feature = "virtio")]
@@ -333,6 +336,8 @@ pub(crate) enum PciDriver {
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-console")]
 	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
+	#[cfg(feature = "virtio-rng")]
+	VirtioRng(InterruptTicketMutex<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	VirtioVsock(InterruptTicketMutex<VirtioVsockDriver>),
 }
@@ -343,6 +348,15 @@ impl PciDriver {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioConsole(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
+	#[cfg(feature = "virtio-rng")]
+	fn get_rng_driver(&self) -> Option<&InterruptTicketMutex<VirtioRngDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioRng(drv) => Some(drv),
 			_ => None,
 		}
 	}
@@ -382,6 +396,14 @@ pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<Virti
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_console_driver())
+}
+
+#[cfg(feature = "virtio-rng")]
+pub(crate) fn get_rng_driver() -> Option<&'static InterruptTicketMutex<VirtioRngDriver>> {
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_rng_driver())
 }
 
 #[cfg(feature = "virtio-vsock")]
@@ -432,6 +454,10 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				#[cfg(feature = "virtio-fs")]
 				Ok(VirtioDriver::Fs(drv)) => {
 					register_driver(PciDriver::VirtioFs(InterruptTicketMutex::new(*drv)));
+				}
+				#[cfg(feature = "virtio-rng")]
+				Ok(VirtioDriver::Rng(drv)) => {
+					register_driver(PciDriver::VirtioRng(InterruptTicketMutex::new(*drv)));
 				}
 				#[cfg(all(not(feature = "rtl8139"), feature = "virtio-net"))]
 				Ok(VirtioDriver::Net(drv)) => *NETWORK_DEVICE.lock() = Some(*drv),

--- a/src/drivers/rng.rs
+++ b/src/drivers/rng.rs
@@ -1,0 +1,198 @@
+//! A virtio-rng driver.
+//!
+//! For details on the device, see [Entropy Device].
+//!
+//! [Entropy Device]: https://docs.oasis-open.org/virtio/virtio/v1.4/cs01/virtio-v1.4-cs01.html#x1-4130004
+//!
+
+use alloc::vec::Vec;
+
+use embedded_io::{ErrorType, Read};
+use pci_types::InterruptLine;
+use smallvec::SmallVec;
+use volatile::VolatileRef;
+use volatile::access::ReadOnly;
+
+use crate::config::{RNG_PACKET_SIZE, VIRTIO_MAX_QUEUE_SIZE};
+use crate::drivers::error::DriverError;
+#[cfg(not(feature = "pci"))]
+use crate::drivers::mmio::get_rng_driver;
+#[cfg(feature = "pci")]
+use crate::drivers::pci::get_rng_driver;
+use crate::drivers::virtio::error::VirtioRngError;
+use crate::drivers::virtio::transport::UniCapsColl;
+use crate::drivers::virtio::virtqueue::split::SplitVq;
+use crate::drivers::virtio::virtqueue::{
+	AvailBufferToken, BufferElem, BufferType, UsedBufferToken, VirtQueue, Virtq,
+};
+use crate::drivers::{Driver, InterruptHandlerMap};
+use crate::errno::Errno;
+use crate::mm::device_alloc::DeviceAlloc;
+
+pub fn seed_entropy() -> Option<[u8; 32]> {
+	get_rng_driver().and_then(|drv| {
+		let mut buf = [0u8; 32];
+		if drv.lock().read(&mut buf).ok()? == buf.len() {
+			Some(buf)
+		} else {
+			None
+		}
+	})
+}
+
+fn fill_queue(vq: &mut VirtQueue, num_packets: u16, packet_size: u32) {
+	for _ in 0..num_packets {
+		let buff_tkn = match AvailBufferToken::new(SmallVec::new(), {
+			let mut vec = SmallVec::new();
+			vec.push(BufferElem::Vector(Vec::with_capacity_in(
+				packet_size.try_into().unwrap(),
+				DeviceAlloc,
+			)));
+			vec
+		}) {
+			Ok(tkn) => tkn,
+			Err(_vq_err) => {
+				panic!("Setup of rng queue failed, which should not happen!");
+			}
+		};
+
+		// BufferTokens are directly provided to the queue
+		// TransferTokens are directly dispatched
+		// Transfers will be awaited at the queue
+		if let Err(err) = vq.dispatch(buff_tkn, false, BufferType::Direct) {
+			error!("{err:#?}");
+			break;
+		}
+	}
+}
+
+pub(crate) struct RxQueue {
+	vq: Option<VirtQueue>,
+	packet_size: u32,
+}
+impl RxQueue {
+	pub fn new() -> Self {
+		Self {
+			vq: None,
+			packet_size: RNG_PACKET_SIZE,
+		}
+	}
+
+	pub fn add(&mut self, mut vq: VirtQueue) {
+		const BUFF_PER_PACKET: u16 = 1;
+		let num_packets = vq.size() / BUFF_PER_PACKET;
+		fill_queue(&mut vq, num_packets, self.packet_size);
+
+		self.vq = Some(vq);
+	}
+
+	pub fn disable_notifs(&mut self) {
+		let Some(vq) = &mut self.vq else {
+			return;
+		};
+
+		vq.disable_notifs();
+	}
+
+	fn get_next(&mut self) -> Option<UsedBufferToken> {
+		self.vq.as_mut().unwrap().try_recv().ok()
+	}
+
+	pub fn process_packet<F>(&mut self, mut f: F) -> Result<usize, DriverError>
+	where
+		F: FnMut(&[u8]) -> usize,
+	{
+		let Some(mut buffer_tkn) = self.get_next() else {
+			return Ok(0);
+		};
+
+		let packet = buffer_tkn.used_recv_buff.pop_front_vec().unwrap();
+		let vq = self.vq.as_mut().unwrap();
+		let result = f(&packet[..]);
+
+		fill_queue(vq, 1, self.packet_size);
+
+		Ok(result)
+	}
+}
+pub(crate) struct VirtioRngDriver {
+	pub(super) recv_vq: RxQueue,
+}
+
+impl Driver for VirtioRngDriver {
+	fn get_name() -> &'static str {
+		"virtio-rng"
+	}
+}
+
+impl ErrorType for VirtioRngDriver {
+	type Error = Errno;
+}
+
+impl super::virtio::VirtioDriver for VirtioRngDriver {
+	type Config = ();
+	type Error = VirtioRngError;
+	type DeviceFeatures = virtio::F;
+
+	const MINIMAL_FEATURES: Self::DeviceFeatures = virtio::F::VERSION_1;
+	const OPTIONAL_FEATURES: Self::DeviceFeatures = virtio::F::empty();
+
+	fn init_dev(
+		(mut caps_coll, dev_cfg_raw): (UniCapsColl, VolatileRef<'static, Self::Config, ReadOnly>),
+		_handlers: &mut InterruptHandlerMap,
+		_irq: Option<InterruptLine>,
+	) -> Result<Self, (crate::drivers::virtio::error::VirtioError, UniCapsColl)> {
+		let mut recv_vq = RxQueue::new();
+
+		let _dev_cfg: crate::drivers::virtio::DevCfg<Self> =
+			match caps_coll.init_caps(dev_cfg_raw, |caps_coll, dev_cfg| {
+				recv_vq.add(VirtQueue::Split(
+					SplitVq::new(
+						&mut caps_coll.com_cfg,
+						&caps_coll.notif_cfg,
+						VIRTIO_MAX_QUEUE_SIZE,
+						0,
+						dev_cfg.features,
+					)
+					.unwrap(),
+				));
+				recv_vq.disable_notifs();
+
+				Ok(())
+			}) {
+				Ok(dev_cfg) => dev_cfg,
+				Err(err) => return Err((err, caps_coll)),
+			};
+
+		Ok(Self { recv_vq })
+	}
+
+	#[cfg(feature = "pci")]
+	fn no_dev_cfg_err(dev_id: u16) -> Self::Error {
+		VirtioRngError::NoDevCfg(dev_id)
+	}
+}
+
+impl Read for VirtioRngDriver {
+	fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+		self.recv_vq
+			.process_packet(|src| {
+				buf[..src.len()].copy_from_slice(src);
+				src.len()
+			})
+			.map_err(|_| Errno::Io)
+	}
+}
+
+pub mod error {
+	use thiserror::Error;
+
+	#[derive(Error, Debug, Copy, Clone)]
+	pub enum VirtioRngError {
+		#[cfg(feature = "pci")]
+		#[error(
+			"Virtio rng device driver failed, for device {0:x}, due to a missing or malformed device config!"
+		)]
+		NoDevCfg(u16),
+	}
+}

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -285,6 +285,8 @@ pub mod error {
 	pub use crate::drivers::net::virtio::error::VirtioNetError;
 	#[cfg(feature = "pci")]
 	use crate::drivers::pci::error::PciError;
+	#[cfg(feature = "virtio-rng")]
+	pub use crate::drivers::rng::error::VirtioRngError;
 	#[cfg(feature = "virtio-vsock")]
 	pub use crate::drivers::vsock::error::VirtioVsockError;
 
@@ -337,5 +339,9 @@ pub mod error {
 		#[cfg(feature = "virtio-console")]
 		#[error(transparent)]
 		ConsoleDriver(#[from] VirtioConsoleError),
+
+		#[cfg(feature = "virtio-rng")]
+		#[error(transparent)]
+		RngDriver(#[from] VirtioRngError),
 	}
 }

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -23,6 +23,8 @@ use crate::drivers::error::DriverError;
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
 use crate::drivers::net::virtio::VirtioNetDriver;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::error::VirtioError;
 use crate::drivers::virtio::transport::{InterruptCapability, UniCapsColl};
 use crate::drivers::virtio::{ControlRegisters, VirtioIdExt};
@@ -328,6 +330,8 @@ pub(crate) enum VirtioDriver {
 	Fs(alloc::boxed::Box<VirtioFsDriver>),
 	#[cfg(feature = "virtio-net")]
 	Net(alloc::boxed::Box<VirtioNetDriver>),
+	#[cfg(feature = "virtio-rng")]
+	Rng(alloc::boxed::Box<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	Vsock(alloc::boxed::Box<VirtioVsockDriver>),
 }
@@ -388,6 +392,17 @@ pub(crate) fn init_device(
 			}
 			Err(virtio_error) => {
 				error!("Virtio network driver could not be initialized with device");
+				Err(DriverError::InitVirtioDevFail(virtio_error))
+			}
+		},
+		#[cfg(feature = "virtio-rng")]
+		virtio::Id::Rng => match init::<VirtioRngDriver>(registers, irq_no, handlers) {
+			Ok(virt_rng_drv) => {
+				info!("Virtio rng driver initialized.");
+				Ok(VirtioDriver::Rng(alloc::boxed::Box::new(virt_rng_drv)))
+			}
+			Err(virtio_error) => {
+				error!("Virtio rng driver could not be initialized with device");
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -38,6 +38,8 @@ use crate::drivers::pci::error::PciError;
 use crate::drivers::pci::msix;
 #[cfg(target_arch = "x86_64")]
 use crate::drivers::pci::msix::MsixTableVolatileElementAccess;
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::error::VirtioError;
 use crate::drivers::virtio::transport::pci::PciBar as VirtioPciBar;
 use crate::drivers::virtio::transport::{InterruptCapability, UniCapsColl};
@@ -149,6 +151,10 @@ impl CapCfg for virtio::net::Config {
 }
 
 impl CapCfg for virtio::vsock::Config {
+	const TYPE: CapCfgType = CapCfgType::Device;
+}
+
+impl CapCfg for () {
 	const TYPE: CapCfgType = CapCfgType::Device;
 }
 
@@ -721,6 +727,7 @@ pub(crate) fn map_caps(
 			not(feature = "rtl8139"),
 			feature = "virtio-net",
 		),
+		feature = "virtio-rng",
 		feature = "virtio-vsock"
 	)),
 	expect(unused_variables)
@@ -798,6 +805,17 @@ pub(crate) fn init_device(
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
+		#[cfg(feature = "virtio-rng")]
+		virtio::Id::Rng => match init::<VirtioRngDriver>(device, handlers) {
+			Ok(virt_rng_drv) => {
+				info!("Virtio rng driver initialized.");
+				Ok(VirtioDriver::Rng(alloc::boxed::Box::new(virt_rng_drv)))
+			}
+			Err(virtio_error) => {
+				error!("Virtio rng driver could not be initialized with device: {device_id:x}");
+				Err(DriverError::InitVirtioDevFail(virtio_error))
+			}
+		},
 		#[cfg(feature = "virtio-vsock")]
 		virtio::Id::Vsock => match init::<VirtioVsockDriver>(device, handlers) {
 			Ok(virt_sock_drv) => {
@@ -837,6 +855,8 @@ pub(crate) enum VirtioDriver {
 		feature = "virtio-net",
 	))]
 	Net(alloc::boxed::Box<VirtioNetDriver>),
+	#[cfg(feature = "virtio-rng")]
+	Rng(alloc::boxed::Box<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
 	Vsock(alloc::boxed::Box<VirtioVsockDriver>),
 }

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -7,7 +7,9 @@ use hermit_sync::InterruptTicketMutex;
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::{Rng, SeedableRng};
 
-use crate::arch::kernel::processor::{get_timer_ticks, seed_entropy};
+use crate::arch::kernel::processor::{get_timer_ticks, seed_entropy as processor_seed_entropy};
+#[cfg(feature = "virtio-rng")]
+use crate::drivers::rng::seed_entropy as virtio_seed_entropy;
 use crate::errno::Errno;
 use crate::io;
 
@@ -36,9 +38,7 @@ pub fn read(buf: &mut [u8], _flags: Flags) -> io::Result<usize> {
 	let pool = match pool {
 		Some(pool) if now.saturating_sub(pool.last_reseed) <= RESEED_INTERVAL => pool,
 		pool => {
-			let Some(seed) = seed_entropy() else {
-				return Err(Errno::Nosys);
-			};
+			let seed = seed_entropy().ok_or(Errno::Nosys)?;
 
 			pool.insert(Pool {
 				rng: ChaCha20Rng::from_seed(seed),
@@ -51,4 +51,13 @@ pub fn read(buf: &mut [u8], _flags: Flags) -> io::Result<usize> {
 	// Slice lengths are always <= isize::MAX so this return value cannot conflict
 	// with error numbers.
 	Ok(buf.len())
+}
+
+fn seed_entropy() -> Option<[u8; 32]> {
+	#[cfg(feature = "virtio-rng")]
+	if let Some(entropy) = virtio_seed_entropy() {
+		return Some(entropy);
+	}
+
+	processor_seed_entropy()
 }

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -2,6 +2,7 @@
 	not(any(
 		feature = "virtio-vsock",
 		feature = "virtio-fs",
+		feature = "virtio-rng",
 		feature = "virtio-console"
 	)),
 	expect(dead_code)

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -88,6 +88,12 @@ pub enum Device {
 	/// virtio-net via PCI.
 	VirtioNetPci,
 
+	/// virtio-rng via MMIO.
+	VirtioRngMmio,
+
+	/// virtio-rng via PCI.
+	VirtioRngPci,
+
 	/// virtio-vsock via MMIO.
 	VirtioVsockMmio,
 
@@ -479,6 +485,15 @@ impl Qemu {
 						"-device".to_owned(),
 						"virtconsole,chardev=char0".to_owned(),
 					]
+				}
+				device @ (Device::VirtioRngMmio | Device::VirtioRngPci) => {
+					let device_arg = match device {
+						Device::VirtioRngMmio => "virtio-rng-device",
+						Device::VirtioRngPci => "virtio-rng-pci,disable-legacy=on",
+						_ => unreachable!(),
+					};
+
+					vec!["-device".to_owned(), device_arg.to_owned()]
 				}
 				device @ (Device::VirtioVsockMmio | Device::VirtioVsockPci) => {
 					let device_arg = match device {


### PR DESCRIPTION
In virtualized deployments seed DRNG from entropy provided by host.

Tbh this driver is of limited use, but was good exercise to get started with virtio.

|Arch|mmio|pci|
|---|---|---|
|x86_64|✅|✅|
|aarch64|✅|✅|
|riscv64|✅|❌ - pci will be added with https://github.com/hermit-os/kernel/pull/2550|


Blocked by integration of https://github.com/rust-osdev/virtio-spec-rs/pull/24 and new release of virtio-spec-rs.
