### PR TITLE
 refactor(virtio-console): remove VirtioUART wrapper

### DIFF
--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -4,7 +4,6 @@ use core::ptr::NonNull;
 use align_address::Align;
 use arm_gic::{IntId, Trigger};
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -16,13 +15,7 @@ use volatile::VolatileRef;
 
 use crate::arch::kernel::interrupts::GIC;
 use crate::arch::mm::paging::{self, PageSize};
-#[cfg(feature = "virtio-console")]
-use crate::console::IoDevice;
 use crate::drivers::InterruptHandlerMap;
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioConsoleDriver;
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioUART;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
@@ -48,10 +41,9 @@ use crate::mm::PhysAddr;
 
 pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
+#[non_exhaustive]
 pub(crate) enum MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -61,15 +53,6 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::VirtioConsole(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptTicketMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -99,7 +82,6 @@ impl MmioDriver {
 }
 
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock"
@@ -110,14 +92,6 @@ pub(crate) fn register_driver(drv: MmioDriver) {
 
 #[cfg(feature = "virtio-net")]
 pub(crate) type NetworkDevice = VirtioNetDriver;
-
-#[cfg(feature = "virtio-console")]
-pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
-	MMIO_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_console_driver())
-}
 
 #[cfg(feature = "virtio-fs")]
 pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<VirtioFsDriver>> {
@@ -256,9 +230,7 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 
 					match drv {
 						#[cfg(feature = "virtio-console")]
-						VirtioDriver::Console(drv) => register_driver(MmioDriver::VirtioConsole(
-							InterruptTicketMutex::new(*drv),
-						)),
+						VirtioDriver::Console(drv) => crate::console::switch_to_virtio(*drv),
 						#[cfg(feature = "virtio-fs")]
 						VirtioDriver::Fs(drv) => {
 							register_driver(MmioDriver::VirtioFs(InterruptTicketMutex::new(*drv)));
@@ -280,14 +252,4 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 	});
 
 	MMIO_DRIVERS.finalize();
-
-	#[cfg(feature = "virtio-console")]
-	{
-		if get_console_driver().is_some() {
-			info!("Switch to virtio console");
-			crate::console::CONSOLE
-				.lock()
-				.replace_device(IoDevice::Virtio(VirtioUART::new()));
-		}
-	}
 }

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -12,7 +12,6 @@ use volatile::VolatileRef;
 use crate::arch::kernel::interrupts::init_plic;
 #[cfg(all(
 	any(
-		feature = "virtio-console",
 		feature = "virtio-fs",
 		feature = "virtio-rng",
 		feature = "virtio-vsock",
@@ -22,7 +21,6 @@ use crate::arch::kernel::interrupts::init_plic;
 use crate::arch::kernel::mmio::MmioDriver;
 #[cfg(all(
 	any(
-		feature = "virtio-console",
 		feature = "virtio-fs",
 		feature = "virtio-rng",
 		feature = "virtio-vsock",
@@ -31,17 +29,9 @@ use crate::arch::kernel::mmio::MmioDriver;
 ))]
 use crate::arch::kernel::mmio::register_driver;
 use crate::arch::mm::paging::{self, PageSize};
-#[cfg(feature = "virtio-console")]
-use crate::console::IoDevice;
 use crate::drivers::InterruptHandlerMap;
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioUART;
-#[cfg(all(feature = "virtio-console", not(feature = "pci")))]
-use crate::drivers::mmio::get_console_driver;
 #[cfg(all(feature = "gem-net", not(feature = "pci")))]
 use crate::drivers::net::gem;
-#[cfg(all(feature = "virtio-console", feature = "pci"))]
-use crate::drivers::pci::get_console_driver;
 #[cfg(all(feature = "virtio", not(feature = "pci")))]
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(all(
@@ -262,11 +252,7 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 
 				match mmio_virtio::init_device(mmio, irq.try_into().unwrap(), handlers) {
 					#[cfg(feature = "virtio-console")]
-					Ok(VirtioDriver::Console(drv)) => {
-						register_driver(MmioDriver::VirtioConsole(
-							hermit_sync::InterruptSpinMutex::new(*drv),
-						));
-					}
+					Ok(VirtioDriver::Console(drv)) => crate::console::switch_to_virtio(*drv),
 					#[cfg(feature = "virtio-fs")]
 					Ok(VirtioDriver::Fs(drv)) => {
 						register_driver(MmioDriver::VirtioFs(
@@ -297,14 +283,4 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 
 	#[cfg(all(any(feature = "virtio", feature = "gem-net"), not(feature = "pci")))]
 	super::mmio::MMIO_DRIVERS.finalize();
-
-	#[cfg(feature = "virtio-console")]
-	{
-		if get_console_driver().is_some() {
-			info!("Switch to virtio console");
-			crate::console::CONSOLE
-				.lock()
-				.replace_device(IoDevice::Virtio(VirtioUART::new()));
-		}
-	}
 }

--- a/src/arch/riscv64/kernel/mmio.rs
+++ b/src/arch/riscv64/kernel/mmio.rs
@@ -1,15 +1,12 @@
 use alloc::vec::Vec;
 
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use hermit_sync::InterruptSpinMutex;
 
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioConsoleDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "gem-net")]
@@ -24,10 +21,9 @@ use crate::init_cell::InitCell;
 
 pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
+#[non_exhaustive]
 pub(crate) enum MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	VirtioConsole(InterruptSpinMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptSpinMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -37,15 +33,6 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	fn get_console_driver(&self) -> Option<&InterruptSpinMutex<VirtioConsoleDriver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::VirtioConsole(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptSpinMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -75,7 +62,6 @@ impl MmioDriver {
 }
 
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -89,14 +75,6 @@ pub(crate) type NetworkDevice = GEMDriver;
 
 #[cfg(all(not(feature = "gem-net"), feature = "virtio-net"))]
 pub(crate) type NetworkDevice = VirtioNetDriver;
-
-#[cfg(feature = "virtio-console")]
-pub(crate) fn get_console_driver() -> Option<&'static InterruptSpinMutex<VirtioConsoleDriver>> {
-	MMIO_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_console_driver())
-}
 
 #[cfg(feature = "virtio-fs")]
 pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptSpinMutex<VirtioFsDriver>> {

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -6,7 +6,6 @@ use core::{ptr, str};
 use align_address::Align;
 use free_list::PageRange;
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -19,8 +18,6 @@ use volatile::VolatileRef;
 use crate::arch::mm::paging;
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::drivers::InterruptHandlerMap;
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioConsoleDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
@@ -48,10 +45,9 @@ pub const MAGIC_VALUE: u32 = 0x7472_6976;
 
 static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
+#[non_exhaustive]
 pub(crate) enum MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -61,15 +57,6 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
-	#[cfg(feature = "virtio-console")]
-	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::VirtioConsole(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptTicketMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -180,7 +167,6 @@ fn guess_device() -> impl Iterator<Item = (VolatileRef<'static, DeviceRegisters>
 }
 
 #[cfg(any(
-	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -191,14 +177,6 @@ pub(crate) fn register_driver(drv: MmioDriver) {
 
 #[cfg(feature = "virtio-net")]
 pub(crate) type NetworkDevice = VirtioNetDriver;
-
-#[cfg(feature = "virtio-console")]
-pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
-	MMIO_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_console_driver())
-}
 
 #[cfg(feature = "virtio-fs")]
 pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<VirtioFsDriver>> {
@@ -232,7 +210,7 @@ fn register_mmio(
 	match mmio_virtio::init_device(mmio, irq, handlers) {
 		#[cfg(feature = "virtio-console")]
 		Ok(VirtioDriver::Console(drv)) => {
-			register_driver(MmioDriver::VirtioConsole(InterruptTicketMutex::new(*drv)));
+			crate::console::switch_to_virtio(*drv);
 		}
 		#[cfg(feature = "virtio-fs")]
 		Ok(VirtioDriver::Fs(drv)) => {
@@ -269,16 +247,5 @@ pub(crate) fn init_drivers(handlers: &mut InterruptHandlerMap) {
 		}
 
 		MMIO_DRIVERS.finalize();
-
-		#[cfg(feature = "virtio-console")]
-		if get_console_driver().is_some() {
-			use crate::console::IoDevice;
-			use crate::drivers::console::VirtioUART;
-
-			info!("Switching to virtio console...");
-			crate::console::CONSOLE
-				.lock()
-				.replace_device(IoDevice::Virtio(VirtioUART::new()));
-		}
 	});
 }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "uhyve")]
 mod uhyve;
 
+#[cfg(feature = "virtio-console")]
+use alloc::boxed::Box;
 use core::{fmt, mem};
 
 use embedded_io::{ErrorType, Read, ReadReady, Write};
@@ -9,7 +11,7 @@ use hermit_sync::{InterruptTicketMutex, Lazy};
 
 use crate::arch::kernel::serial::SerialDevice;
 #[cfg(feature = "virtio-console")]
-use crate::drivers::console::VirtioUART;
+use crate::drivers::console::VirtioConsoleDriver;
 use crate::errno::Errno;
 use crate::executor::WakerRegistration;
 
@@ -20,7 +22,7 @@ pub(crate) enum IoDevice {
 	Uhyve(uhyve::UhyveSerial),
 	Uart(SerialDevice),
 	#[cfg(feature = "virtio-console")]
-	Virtio(VirtioUART),
+	Virtio(Box<VirtioConsoleDriver>),
 }
 
 impl ErrorType for IoDevice {
@@ -77,7 +79,7 @@ impl Write for IoDevice {
 }
 
 pub(crate) struct Console {
-	device: IoDevice,
+	pub device: IoDevice,
 	buffer: Vec<u8, SERIAL_BUFFER_SIZE>,
 }
 
@@ -88,11 +90,12 @@ impl Console {
 			buffer: Vec::new(),
 		}
 	}
+}
 
-	#[cfg(feature = "virtio-console")]
-	pub fn replace_device(&mut self, device: IoDevice) {
-		self.device = device;
-	}
+#[cfg(feature = "virtio-console")]
+pub(crate) fn switch_to_virtio(device: VirtioConsoleDriver) {
+	info!("Switch to virtio console");
+	CONSOLE.lock().device = IoDevice::Virtio(Box::new(device));
 }
 
 impl ErrorType for Console {

--- a/src/drivers/console.rs
+++ b/src/drivers/console.rs
@@ -16,11 +16,8 @@ use volatile::VolatileRef;
 use volatile::access::ReadOnly;
 
 use crate::config::{CONSOLE_PACKET_SIZE, VIRTIO_MAX_QUEUE_SIZE};
+use crate::console::{CONSOLE, IoDevice};
 use crate::drivers::error::DriverError;
-#[cfg(not(feature = "pci"))]
-use crate::drivers::mmio::get_console_driver;
-#[cfg(feature = "pci")]
-use crate::drivers::pci::get_console_driver;
 use crate::drivers::virtio::error::{VirtioConsoleError, VirtioError};
 use crate::drivers::virtio::transport::{InterruptCapability, UniCapsColl};
 use crate::drivers::virtio::virtqueue::split::SplitVq;
@@ -57,47 +54,9 @@ fn fill_queue(vq: &mut VirtQueue, num_packets: u16, packet_size: u32) {
 	}
 }
 
-pub(crate) struct VirtioUART;
-
-impl VirtioUART {
-	pub const fn new() -> Self {
-		Self {}
-	}
-}
-
-impl ErrorType for VirtioUART {
-	type Error = Errno;
-}
-
-impl Read for VirtioUART {
-	fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-		let drv = get_console_driver().ok_or(Errno::Io)?;
-
-		drv.lock().read(buf)
-	}
-}
-
-impl ReadReady for VirtioUART {
+impl ReadReady for VirtioConsoleDriver {
 	fn read_ready(&mut self) -> Result<bool, Self::Error> {
-		let Some(drv) = get_console_driver() else {
-			return Ok(false);
-		};
-
-		Ok(drv.lock().has_packet())
-	}
-}
-
-impl Write for VirtioUART {
-	fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-		if let Some(drv) = get_console_driver() {
-			drv.lock().write_all(buf)?;
-		}
-
-		Ok(buf.len())
-	}
-
-	fn flush(&mut self) -> Result<(), Self::Error> {
-		Ok(())
+		Ok(self.has_packet())
 	}
 }
 
@@ -340,9 +299,9 @@ impl super::virtio::VirtioDriver for VirtioConsoleDriver {
 				InterruptCapability::IsrStatus(_) => {
 					let irq = irq.unwrap();
 					handlers.entry(irq).or_default().push_back(|| {
-						if let Some(driver) = get_console_driver() {
-							driver.lock().handle_interrupt();
-						};
+						if let IoDevice::Virtio(driver) = &mut CONSOLE.lock().device {
+							driver.handle_interrupt();
+						}
 					});
 					crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
 					info!("Virtio interrupt handler at line {irq}");
@@ -352,8 +311,8 @@ impl super::virtio::VirtioDriver for VirtioConsoleDriver {
 					msix_table,
 					handlers,
 					|| {
-						if let Some(driver) = get_console_driver() {
-							driver.lock().handle_device_configuration_interrupt();
+						if let IoDevice::Virtio(driver) = &mut CONSOLE.lock().device {
+							driver.handle_device_configuration_interrupt();
 						};
 					},
 					[(0..2u16, Self::handle_queue_interrupt as fn())].into_iter(),

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "virtio-console")]
-pub(crate) use crate::arch::kernel::mmio::get_console_driver;
 #[cfg(feature = "virtio-fs")]
 pub(crate) use crate::arch::kernel::mmio::get_filesystem_driver;
 #[cfg(feature = "virtio-rng")]

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -6,7 +6,6 @@ use core::fmt;
 #[cfg(any(
 	feature = "virtio-fs",
 	feature = "virtio-vsock",
-	feature = "virtio-console",
 	feature = "virtio-rng",
 ))]
 use hermit_sync::InterruptTicketMutex;
@@ -19,13 +18,9 @@ use pci_types::{
 };
 
 use crate::arch::kernel::pci::PciConfigRegion;
-#[cfg(feature = "virtio-console")]
-use crate::console::IoDevice;
 #[allow(unused_imports)]
 use crate::drivers::Driver;
 use crate::drivers::InterruptHandlerMap;
-#[cfg(feature = "virtio-console")]
-use crate::drivers::console::{VirtioConsoleDriver, VirtioUART};
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "rtl8139")]
@@ -334,8 +329,6 @@ pub(crate) fn print_information() {
 pub(crate) enum PciDriver {
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
-	#[cfg(feature = "virtio-console")]
-	VirtioConsole(InterruptTicketMutex<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-rng")]
 	VirtioRng(InterruptTicketMutex<VirtioRngDriver>),
 	#[cfg(feature = "virtio-vsock")]
@@ -343,15 +336,6 @@ pub(crate) enum PciDriver {
 }
 
 impl PciDriver {
-	#[cfg(feature = "virtio-console")]
-	fn get_console_driver(&self) -> Option<&InterruptTicketMutex<VirtioConsoleDriver>> {
-		#[allow(unreachable_patterns)]
-		match self {
-			Self::VirtioConsole(drv) => Some(drv),
-			_ => None,
-		}
-	}
-
 	#[cfg(feature = "virtio-rng")]
 	fn get_rng_driver(&self) -> Option<&InterruptTicketMutex<VirtioRngDriver>> {
 		#[allow(unreachable_patterns)]
@@ -389,14 +373,6 @@ pub(crate) type NetworkDevice = VirtioNetDriver;
 
 #[cfg(feature = "rtl8139")]
 pub(crate) type NetworkDevice = RTL8139Driver;
-
-#[cfg(feature = "virtio-console")]
-pub(crate) fn get_console_driver() -> Option<&'static InterruptTicketMutex<VirtioConsoleDriver>> {
-	PCI_DRIVERS
-		.get()?
-		.iter()
-		.find_map(|drv| drv.get_console_driver())
-}
 
 #[cfg(feature = "virtio-rng")]
 pub(crate) fn get_rng_driver() -> Option<&'static InterruptTicketMutex<VirtioRngDriver>> {
@@ -445,11 +421,7 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 			match pci_virtio::init_device(adapter, handlers) {
 				#[cfg(feature = "virtio-console")]
 				Ok(VirtioDriver::Console(drv)) => {
-					register_driver(PciDriver::VirtioConsole(InterruptTicketMutex::new(*drv)));
-					info!("Switch to virtio console");
-					crate::console::CONSOLE
-						.lock()
-						.replace_device(IoDevice::Virtio(VirtioUART::new()));
+					crate::console::switch_to_virtio(*drv);
 				}
 				#[cfg(feature = "virtio-fs")]
 				Ok(VirtioDriver::Fs(drv)) => {

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -2,8 +2,7 @@
 	not(any(
 		feature = "virtio-vsock",
 		feature = "virtio-fs",
-		feature = "virtio-rng",
-		feature = "virtio-console"
+		feature = "virtio-rng"
 	)),
 	expect(dead_code)
 )]


### PR DESCRIPTION
Rather than accessing the virtio-console driver through the global driver vector, place it into the using struct in a way similar to what was done in b735657.