### PR TITLE
build(deps): only enable used nightly features for the x86_64 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,7 +369,7 @@ features = [
 free-list = { version = "0.3", features = ["x86_64"] }
 raw-cpuid = "11"
 uart_16550 = { version = "0.6", features = ["embedded-io"] }
-x86_64 = "0.15"
+x86_64 = { version = "0.15", default-features = false, features = ["instructions", "abi_x86_interrupt"] }
 memory_addresses = { version = "0.4", default-features = false, features = [
 	"x86_64",
 	"conv-x86_64",


### PR DESCRIPTION
The x86_64 crate provides a `nightly` feature, which enables the `const_fn`, `step_trait`, `abi_x86_interrupt`, and `asm_const` features. The `step_trait` was changed backwards-incompatibly in a recent nightly Rust version.

This PR disables unused nightly features of the x86_64 crate to reduce the number of nightly changes breaking compilation for us.

This PR should unblock the following two PRs:
- https://github.com/hermit-os/kernel/pull/2551
- https://github.com/hermit-os/kernel/pull/2553