### PR TITLE
chore: remove `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-. text !filter !merge !diff


### PR DESCRIPTION
This line exists since the beginning (https://github.com/hermit-os/kernel/commit/1ade5b08960ad0d01e78d41544a744eca63a9b38).

The reason for this line is not clear to me:

```
. text !filter !merge !diff
```

`.` matches the current directory, so the repository root, but not any files inside it. `text` marks the directory as a text file to enable end-of-line conversion. Then, `filter`, `merge` and `diff` are set to `Unspecified`, which does not seem useful for directories.