### PR TITLE
ci: add Pull Request Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,155 @@
+# Meta
+
+cargo:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Cargo.toml"
+          - "**/Cargo.lock"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+
+# Crates
+
+hermit-builtins:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "hermit-builtins/**"
+
+hermit-macro:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "hermit-macro/**"
+
+xtask:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "xtask/**"
+
+# Architectures
+
+aarch64:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/arch/aarch64/**"
+
+riscv64:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/arch/riscv64/**"
+
+x86_64:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/arch/x86_64/**"
+
+# Platforms
+
+uhyve:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/uhyve/**"
+          - "**/uhyve.rs"
+
+# Transports
+
+mmio:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/mmio/**"
+          - "**/mmio.rs*"
+
+pci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/pci/**"
+          - "**/pci.rs"
+
+# Drivers
+
+gem:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/net/gem/**"
+
+loopback:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/net/loopback.rs"
+
+rtl8139:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/net/rtl8139.rs"
+
+virtio-console:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/console/**"
+
+virtio-fs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/fs/**"
+          - "src/fs/virtio_fs.rs"
+
+virtio-net:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/net/virtio/**"
+
+virtio-vsock:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drivers/vsock/**"
+          - "src/executor/vsock.rs"
+
+# Kernel modules
+
+env:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/env/**"
+
+executor:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/executor/**"
+
+fd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/fd/**"
+
+fs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/fs/**"
+
+mm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/mm/**"
+
+scheduler:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/scheduler/**"
+          - "**/scheduler.rs"
+
+synch:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/synch/**"
+
+syscalls:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/syscalls/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/labeler@v7


### PR DESCRIPTION
This PR adds a workflow to run [actions/labeler](https://github.com/actions/labeler) to automatically label PRs based on touched file paths.

This action is already used by Uhyve: [uhyve/.github/labeler.yml](https://github.com/hermit-os/uhyve/blob/09e301297e1a0bc9c083ead81ed017d11932f299/.github/labeler.yml).

The current labels in this PR are just a gut feeling. It would be great to have your feedback on them and on whether we should do this at all.