### PR TITLE
Fix aarch64 timer interrupt configuration

### DIFF
--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -330,7 +330,7 @@ fn __set_oneshot_timer(wakeup_time: Option<u64>) {
 
 	// wt is the absolute wakeup time in microseconds based on processor::get_timer_ticks.
 	let freq: u64 = CPU_FREQUENCY.get().into(); // frequency in KHz
-	let deadline = (wt / 1000) * freq;
+	let deadline = wt * freq / 1000;
 
 	CNTP_CVAL_EL0.set(deadline);
 	CNTP_CTL_EL0.write(CNTP_CTL_EL0::ENABLE::SET);

--- a/src/arch/aarch64/kernel/processor.rs
+++ b/src/arch/aarch64/kernel/processor.rs
@@ -330,7 +330,7 @@ fn __set_oneshot_timer(wakeup_time: Option<u64>) {
 
 	// wt is the absolute wakeup time in microseconds based on processor::get_timer_ticks.
 	let freq: u64 = CPU_FREQUENCY.get().into(); // frequency in KHz
-	let deadline = wt * freq / 1000;
+	let deadline = BOOT_COUNTER.get().unwrap() + wt * freq / 1000;
 
 	CNTP_CVAL_EL0.set(deadline);
 	CNTP_CTL_EL0.write(CNTP_CTL_EL0::ENABLE::SET);


### PR DESCRIPTION
We currently misconfigure the timer interrupt on aarch64, which results in it constantly firing if we have a `BOOT_COUNTER` that is not zero. We were also losing precision in some hypothetical edge cases. After fixing both, I see around 7 Gbit/s of throughput in the networking benchmarks rather than 5 Mbit/s and no more constant timer interrupts firing.