### PR TITLE
fix(x86_64/uefi): unmap stack on drop

### DIFF
--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -13,7 +13,6 @@ use crate::arch::x86_64::mm::paging::{
 	BasePageSize, PageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
 use crate::config::*;
-use crate::env;
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 use crate::scheduler::task::{Task, TaskFrame};
 use crate::scheduler::{PerCoreSchedulerExt, timer_interrupts};
@@ -220,12 +219,10 @@ impl Drop for TaskStacks {
 					stacks.total_size >> 10,
 				);
 
-				if !env::is_uefi() {
-					crate::arch::mm::paging::unmap::<BasePageSize>(
-						stacks.virt_addr,
-						stacks.total_size / BasePageSize::SIZE as usize + 4,
-					);
-				}
+				crate::arch::mm::paging::unmap::<BasePageSize>(
+					stacks.virt_addr,
+					stacks.total_size / BasePageSize::SIZE as usize + 4,
+				);
 				let range = PageRange::from_start_len(
 					stacks.virt_addr.as_usize(),
 					stacks.total_size + 4 * BasePageSize::SIZE as usize,


### PR DESCRIPTION
This PR makes the kernel unmap user stacks on drop. In early UEFI times, this was not necessary, since we would never touch the page tables for stacks. This changed in https://github.com/hermit-os/kernel/commit/a68db87d56e34cb5c8245b6e84366fa391ff35d2, but forgot to enable unmapping.

This PR makes the following UB program throw a page fault as expected on UEFI:

```rust
use std::thread;

struct Ptr(*mut ());

unsafe impl Send for Ptr {}

fn main() {
	let thread = thread::spawn(move || {
		let rsp: *mut ();
		unsafe {
			core::arch::asm!("mov {}, rsp", out(reg) rsp);
		}
		Ptr(rsp)
	});
	let ptr = thread.join().unwrap().0;
	dbg!(ptr);

	// Yield to drop thread.
	thread::yield_now();

	unsafe {
		ptr.cast::<u8>().write(0);
	}
}
```

I noticed this while working on https://github.com/hermit-os/kernel/pull/2546.