### PR TITLE
feat(x86_64/uhyve): drop support for non-FDT TSC frequencies

### DIFF
--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -374,22 +374,6 @@ impl CpuFrequency {
 		Err(())
 	}
 
-	fn detect_from_hypervisor(&mut self) -> Result<(), ()> {
-		#[cfg(feature = "uhyve")]
-		{
-			let cpu_freq = env::uhyve_cpu_freq().ok_or(())?.get();
-			let mhz = cpu_freq / 1000;
-
-			self.set_detected_cpu_frequency(
-				mhz.try_into().unwrap(),
-				CpuFrequencySources::Hypervisor,
-			)
-		}
-
-		#[cfg(not(feature = "uhyve"))]
-		Err(())
-	}
-
 	extern "x86-interrupt" fn measure_frequency_timer_handler(
 		_stack_frame: interrupts::ExceptionStackFrame,
 	) {
@@ -484,7 +468,6 @@ impl CpuFrequency {
 				.or_else(|_e| self.detect_from_cpuid(&cpuid))
 				.or_else(|_e| self.detect_from_cpuid_tsc_info(&cpuid))
 				.or_else(|_e| self.detect_from_cpuid_hypervisor_info(&cpuid))
-				.or_else(|_e| self.detect_from_hypervisor())
 				.or_else(|_e| self.detect_from_cmdline())
 				.or_else(|_e| self.detect_from_cpuid_brand_string(&cpuid))
 				.or_else(|_e| self.measure_frequency())

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -8,7 +8,6 @@ use core::arch::x86_64::{
 };
 use core::fmt;
 use core::hint::spin_loop;
-use core::num::NonZero;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use hermit_sync::Lazy;
@@ -351,20 +350,28 @@ impl CpuFrequency {
 	}
 
 	fn detect_from_fdt(&mut self) -> Result<(), ()> {
-		fn mhz_from_fdt() -> Option<NonZero<u16>> {
-			let khz = env::fdt()?
-				.find_node("/hermit,tsc")?
-				.property("khz")?
-				.as_usize()?;
-			let khz = u32::try_from(khz).ok()?;
-			let mhz = u16::try_from(khz / 1000).ok()?;
-			NonZero::new(mhz)
+		#[cfg(feature = "uhyve")]
+		{
+			use core::num::NonZero;
+
+			fn mhz_from_fdt() -> Option<NonZero<u16>> {
+				let khz = env::fdt()?
+					.find_node("/hermit,tsc")?
+					.property("khz")?
+					.as_usize()?;
+				let khz = u32::try_from(khz).ok()?;
+				let mhz = u16::try_from(khz / 1000).ok()?;
+				NonZero::new(mhz)
+			}
+
+			let mhz = mhz_from_fdt().ok_or(())?;
+			self.set_detected_cpu_frequency(mhz.get(), CpuFrequencySources::Fdt)?;
+
+			Ok(())
 		}
 
-		let mhz = mhz_from_fdt().ok_or(())?;
-		self.set_detected_cpu_frequency(mhz.get(), CpuFrequencySources::Fdt)?;
-
-		Ok(())
+		#[cfg(not(feature = "uhyve"))]
+		Err(())
 	}
 
 	fn detect_from_hypervisor(&mut self) -> Result<(), ()> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -79,17 +79,6 @@ pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
 	}
 }
 
-#[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
-#[cfg(feature = "uhyve")]
-pub fn uhyve_cpu_freq() -> Option<NonZero<u32>> {
-	use hermit_entry::boot_info::PlatformInfo;
-
-	match boot_info().platform_info {
-		PlatformInfo::Uhyve { cpu_freq, .. } => Some(NonZero::new(cpu_freq?.get()).unwrap()),
-		_ => None,
-	}
-}
-
 pub fn is_uefi() -> bool {
 	fdt().is_some_and(|fdt| fdt.root().compatible().first() == "hermit,uefi")
 }


### PR DESCRIPTION
This PR

1. tries to read the TSC frequency from the FDT on Uhyve and
2. drops support for non-FDT Uhyve TSC frequencies.

The second commit makes the kernel guess a wrong frequency on pre-https://github.com/hermit-os/uhyve/commit/e4fb46f2c5a77f7dca92f659ab29be0ed961a8f5 builds of Uhyve. Uhyve 0.5.0 (Feb 2025) or newer are unaffected.

This PR is a step towards https://github.com/hermit-os/kernel/pull/2546.