### PR TITLE
fix(mm): don't account for kernel executable memory twice

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -12,7 +12,6 @@ use hashbrown::HashMap;
 use hashbrown::hash_map::Iter;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
-use memory_addresses::PhysAddr;
 use shlex::Shlex;
 
 static BOOT_INFO: OnceCell<BootInfo> = OnceCell::new();
@@ -106,13 +105,6 @@ pub fn fdt() -> Option<Fdt<'static>> {
 		let ptr = ptr::with_exposed_provenance(fdt.get());
 		unsafe { Fdt::from_ptr(ptr).unwrap() }
 	})
-}
-
-pub(crate) fn get_ram_address() -> Option<PhysAddr> {
-	let fdt = fdt()?;
-	let memory = fdt.memory();
-	let ptr = memory.regions().next()?.starting_address;
-	Some(ptr.expose_provenance().into())
 }
 
 /// Returns the RSDP physical address if available.

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -61,11 +61,11 @@ use talc::source::Manual;
 pub use self::page_range_alloc::{PageRangeAllocator, PageRangeBox};
 pub use self::physicalmem::{FrameAlloc, FrameBox};
 pub use self::virtualmem::{PageAlloc, PageBox};
+use crate::arch;
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 use crate::arch::mm::paging::HugePageSize;
 pub use crate::arch::mm::paging::virtual_to_physical;
 use crate::arch::mm::paging::{BasePageSize, LargePageSize, PageSize};
-use crate::{arch, env};
 
 #[cfg(target_os = "none")]
 #[global_allocator]
@@ -135,20 +135,12 @@ pub(crate) fn init() {
 	let npage_3tables = npages / npage_div + 1;
 	let npage_2tables = npage_3tables / npage_div + 1;
 	let npage_1tables = npage_2tables / npage_div + 1;
-	let reserved_space = (npage_3tables + npage_2tables + npage_1tables)
-		* BasePageSize::SIZE as usize
+	let min_mem = (npage_3tables + npage_2tables + npage_1tables) * BasePageSize::SIZE as usize
 		+ 2 * LargePageSize::SIZE as usize;
 	#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 	let has_1gib_pages = arch::kernel::processor::supports_1gib_pages();
 	let has_2mib_pages = arch::kernel::processor::supports_2mib_pages();
 
-	let min_mem = if env::is_uefi() {
-		// On UEFI, the given memory is guaranteed free memory and the kernel is located before the given memory
-		reserved_space
-	} else {
-		(kernel_addr_range.end.as_u64() - env::get_ram_address().unwrap().as_u64()
-			+ reserved_space as u64) as usize
-	};
 	info!("Minimum memory size: {} MiB", min_mem >> 20);
 	let avail_mem = total_mem
 		.checked_sub(min_mem)


### PR DESCRIPTION
`physicalmem::total_memory_size()` already accounts for the kernel executable.

This reduces the minimum QEMU memory amount for x86-64 hello_world from 29M to 19M.

Found this while preparing https://github.com/hermit-os/kernel/pull/2546.