### PR TITLE
refactor(x86_64/paging): extract UEFI check out of `make_p4_writable()`

### DIFF
--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -312,15 +312,14 @@ pub fn init() {
 	unsafe {
 		log_page_tables();
 	}
-	make_p4_writable();
+
+	if env::is_uefi() {
+		make_p4_writable();
+	}
 }
 
 fn make_p4_writable() {
 	debug!("Making P4 table writable");
-
-	if !env::is_uefi() {
-		return;
-	}
 
 	let mut pt = unsafe { identity_mapped_page_table() };
 


### PR DESCRIPTION
This makes gating the function easier.

Extracted from https://github.com/hermit-os/kernel/pull/2546.