### PR TITLE
refactor: move runtime code to `crate::rt`

### DIFF
--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -14,10 +14,10 @@ use hashbrown::HashMap;
 use hermit_sync::{InterruptSpinMutex, InterruptTicketMutex, OnceCell, SpinMutex};
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::arch::aarch64::kernel::core_local::{core_id, core_scheduler, increment_irq_counter};
-use crate::arch::aarch64::kernel::scheduler::State;
-use crate::arch::aarch64::kernel::serial::handle_uart_interrupt;
-use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::kernel::core_local::{core_id, core_scheduler, increment_irq_counter};
+use crate::arch::kernel::scheduler::State;
+use crate::arch::kernel::serial::handle_uart_interrupt;
+use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::drivers::InterruptHandlerMap;
 use crate::env;
 use crate::mm::{PageAlloc, PageRangeAllocator};

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -13,8 +13,8 @@ use hermit_sync::without_interrupts;
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 use volatile::VolatileRef;
 
-use crate::arch::aarch64::kernel::interrupts::GIC;
-use crate::arch::aarch64::mm::paging::{self, PageSize};
+use crate::arch::kernel::interrupts::GIC;
+use crate::arch::mm::paging::{self, PageSize};
 #[cfg(feature = "virtio-console")]
 use crate::console::IoDevice;
 use crate::drivers::InterruptHandlerMap;

--- a/src/arch/aarch64/kernel/mod.rs
+++ b/src/arch/aarch64/kernel/mod.rs
@@ -20,8 +20,8 @@ use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
 pub(crate) use self::interrupts::wakeup_core;
 pub(crate) use self::processor::set_oneshot_timer;
-use crate::arch::aarch64::kernel::core_local::*;
-use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize};
+use crate::arch::kernel::core_local::*;
+use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::config::*;
 
 #[repr(align(8))]
@@ -110,7 +110,7 @@ pub fn boot_next_processor() {
 
 		use memory_addresses::VirtAddr;
 
-		use crate::arch::aarch64::start::smp::{TTBR0, smp_start};
+		use crate::arch::start::smp::{TTBR0, smp_start};
 		use crate::mm::virtual_to_physical;
 
 		if cpu_online == 0 {

--- a/src/arch/aarch64/kernel/pci.rs
+++ b/src/arch/aarch64/kernel/pci.rs
@@ -11,9 +11,9 @@ use pci_types::{
 	PciHeader,
 };
 
-use crate::arch::aarch64::kernel::core_local::core_id;
-use crate::arch::aarch64::kernel::interrupts::GIC;
-use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::kernel::core_local::core_id;
+use crate::arch::kernel::interrupts::GIC;
+use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::drivers::pci::{PCI_DEVICES, PciDevice};
 use crate::env;
 use crate::mm::{PageAlloc, PageRangeAllocator};

--- a/src/arch/aarch64/kernel/scheduler.rs
+++ b/src/arch/aarch64/kernel/scheduler.rs
@@ -9,9 +9,9 @@ use align_address::Align;
 use free_list::{PageLayout, PageRange};
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::arch::aarch64::kernel::CURRENT_STACK_ADDRESS;
-use crate::arch::aarch64::kernel::core_local::core_scheduler;
-use crate::arch::aarch64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::kernel::CURRENT_STACK_ADDRESS;
+use crate::arch::kernel::core_local::core_scheduler;
+use crate::arch::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
 use crate::config::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 use crate::scheduler::PerCoreSchedulerExt;

--- a/src/arch/aarch64/kernel/systemtime.rs
+++ b/src/arch/aarch64/kernel/systemtime.rs
@@ -5,7 +5,7 @@ use hermit_sync::OnceCell;
 use memory_addresses::{PhysAddr, VirtAddr};
 use time::OffsetDateTime;
 
-use crate::arch::aarch64::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::mm::paging::{self, BasePageSize, PageSize, PageTableEntryFlags};
 use crate::env;
 use crate::mm::{PageAlloc, PageRangeAllocator};
 

--- a/src/arch/aarch64/start/hermit_entry.rs
+++ b/src/arch/aarch64/start/hermit_entry.rs
@@ -4,10 +4,10 @@ use aarch64_cpu::asm::barrier::{SY, dsb};
 use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
+use crate::arch::kernel::scheduler::TaskStacks;
+use crate::arch::kernel::{CPU_ONLINE, CURRENT_STACK_ADDRESS};
 use crate::config::KERNEL_STACK_SIZE;
 use crate::env;
-use crate::kernel::scheduler::TaskStacks;
-use crate::kernel::{CPU_ONLINE, CURRENT_STACK_ADDRESS};
 
 /// Entrypoint - Initialize Stack pointer and Exception Table
 #[unsafe(no_mangle)]

--- a/src/arch/aarch64/start/hermit_entry.rs
+++ b/src/arch/aarch64/start/hermit_entry.rs
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_i
 
 	if cpu_id == 0 {
 		env::set_boot_info(*boot_info.unwrap());
-		crate::boot_processor_main()
+		crate::rt::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
@@ -106,6 +106,6 @@ pub unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_i
 			}
 		}
 		#[cfg(feature = "smp")]
-		crate::application_processor_main()
+		crate::rt::application_processor_main()
 	}
 }

--- a/src/arch/aarch64/start/smp.rs
+++ b/src/arch/aarch64/start/smp.rs
@@ -189,5 +189,5 @@ unsafe extern "C" fn smp_start_rust() -> ! {
 	// Memory barrier
 	dsb(SY);
 
-	crate::application_processor_main()
+	crate::rt::application_processor_main()
 }

--- a/src/arch/aarch64/start/smp.rs
+++ b/src/arch/aarch64/start/smp.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::AtomicPtr;
 
 use aarch64_cpu::asm::barrier::{SY, dsb};
 
-use crate::kernel::CURRENT_STACK_ADDRESS;
+use crate::arch::kernel::CURRENT_STACK_ADDRESS;
 
 /*
  * Memory types available.
@@ -48,8 +48,8 @@ pub(crate) static TTBR0: AtomicPtr<u8> = AtomicPtr::new(ptr::null_mut());
 
 #[unsafe(naked)]
 pub(crate) unsafe extern "C" fn smp_start() -> ! {
+	use crate::arch::kernel::scheduler::TaskStacks;
 	use crate::config::KERNEL_STACK_SIZE;
-	use crate::kernel::scheduler::TaskStacks;
 
 	// Prepare system control register (SCTRL)
 	//

--- a/src/arch/riscv64/kernel/core_local.rs
+++ b/src/arch/riscv64/kernel/core_local.rs
@@ -9,7 +9,7 @@ use async_executor::StaticLocalExecutor;
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::{RawRwSpinLock, RawSpinMutex};
 
-use crate::arch::riscv64::kernel::CPU_ONLINE;
+use crate::arch::kernel::CPU_ONLINE;
 #[cfg(feature = "smp")]
 use crate::scheduler::SchedulerInput;
 use crate::scheduler::{CoreId, PerCoreScheduler};

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -9,6 +9,16 @@ use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 #[cfg(all(feature = "virtio", not(feature = "pci")))]
 use volatile::VolatileRef;
 
+use crate::arch::kernel::interrupts::init_plic;
+#[cfg(all(
+	any(
+		feature = "virtio-console",
+		feature = "virtio-fs",
+		feature = "virtio-vsock",
+	),
+	not(feature = "pci"),
+))]
+use crate::arch::kernel::mmio::MmioDriver;
 #[cfg(all(
 	any(
 		feature = "virtio-console",
@@ -18,17 +28,7 @@ use volatile::VolatileRef;
 	not(feature = "pci")
 ))]
 use crate::arch::kernel::mmio::register_driver;
-use crate::arch::riscv64::kernel::interrupts::init_plic;
-#[cfg(all(
-	any(
-		feature = "virtio-console",
-		feature = "virtio-fs",
-		feature = "virtio-vsock",
-	),
-	not(feature = "pci"),
-))]
-use crate::arch::riscv64::kernel::mmio::MmioDriver;
-use crate::arch::riscv64::mm::paging::{self, PageSize};
+use crate::arch::mm::paging::{self, PageSize};
 #[cfg(feature = "virtio-console")]
 use crate::console::IoDevice;
 use crate::drivers::InterruptHandlerMap;

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -9,6 +9,15 @@ use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 #[cfg(all(feature = "virtio", not(feature = "pci")))]
 use volatile::VolatileRef;
 
+#[cfg(all(
+	any(
+		feature = "virtio-console",
+		feature = "virtio-fs",
+		feature = "virtio-vsock",
+	),
+	not(feature = "pci")
+))]
+use crate::arch::kernel::mmio::register_driver;
 use crate::arch::riscv64::kernel::interrupts::init_plic;
 #[cfg(all(
 	any(
@@ -46,15 +55,6 @@ use crate::drivers::virtio::transport::mmio::VirtioDriver;
 use crate::env;
 #[cfg(all(any(feature = "gem-net", feature = "virtio-net"), not(feature = "pci")))]
 use crate::executor::device::NETWORK_DEVICE;
-#[cfg(all(
-	any(
-		feature = "virtio-console",
-		feature = "virtio-fs",
-		feature = "virtio-vsock",
-	),
-	not(feature = "pci")
-))]
-use crate::kernel::mmio::register_driver;
 
 static mut PLATFORM_MODEL: Model = Model::Unknown;
 

--- a/src/arch/riscv64/kernel/interrupts.rs
+++ b/src/arch/riscv64/kernel/interrupts.rs
@@ -171,7 +171,7 @@ pub(crate) fn enable_and_wait() {
 				trace!("SOFT");
 				//Disable Supervisor-level software interrupt
 				sie::clear_ssoft();
-				crate::arch::riscv64::kernel::scheduler::wakeup_handler();
+				crate::arch::kernel::scheduler::wakeup_handler();
 				break;
 			}
 
@@ -187,7 +187,7 @@ pub(crate) fn enable_and_wait() {
 
 				debug!("sip: {pending_interrupts:x?}");
 				trace!("TIMER");
-				crate::arch::riscv64::kernel::scheduler::timer_handler();
+				crate::arch::kernel::scheduler::timer_handler();
 				break;
 			}
 		}
@@ -243,10 +243,10 @@ pub extern "C" fn trap_handler(tf: &mut TrapFrame) {
 		Trap::Interrupt(Interrupt::SupervisorExternal) => external_handler(),
 		#[cfg(feature = "smp")]
 		Trap::Interrupt(Interrupt::SupervisorSoft) => {
-			crate::arch::riscv64::kernel::scheduler::wakeup_handler();
+			crate::arch::kernel::scheduler::wakeup_handler();
 		}
 		Trap::Interrupt(Interrupt::SupervisorTimer) => {
-			crate::arch::riscv64::kernel::scheduler::timer_handler();
+			crate::arch::kernel::scheduler::timer_handler();
 		}
 		cause => {
 			error!("Interrupt: {cause:?}");

--- a/src/arch/riscv64/kernel/mod.rs
+++ b/src/arch/riscv64/kernel/mod.rs
@@ -18,9 +18,9 @@ use free_list::PageLayout;
 use riscv::register::sstatus;
 
 pub(crate) use self::processor::{set_oneshot_timer, wakeup_core};
-use crate::arch::riscv64::kernel::core_local::core_id;
-pub use crate::arch::riscv64::kernel::devicetree::init_drivers;
-use crate::arch::riscv64::kernel::processor::lsb;
+use crate::arch::kernel::core_local::core_id;
+pub use crate::arch::kernel::devicetree::init_drivers;
+use crate::arch::kernel::processor::lsb;
 use crate::config::KERNEL_STACK_SIZE;
 use crate::env;
 use crate::init_cell::InitCell;

--- a/src/arch/riscv64/kernel/processor.rs
+++ b/src/arch/riscv64/kernel/processor.rs
@@ -3,7 +3,7 @@ use core::num::NonZeroU64;
 
 use riscv::register::{sie, sstatus, time};
 
-use crate::arch::riscv64::kernel::{HARTS_AVAILABLE, get_timebase_freq};
+use crate::arch::kernel::{HARTS_AVAILABLE, get_timebase_freq};
 use crate::scheduler::CoreId;
 
 /// Current FPU state. Saved at context switch when changed

--- a/src/arch/riscv64/kernel/scheduler.rs
+++ b/src/arch/riscv64/kernel/scheduler.rs
@@ -2,8 +2,8 @@ use align_address::Align;
 use free_list::{PageLayout, PageRange};
 use memory_addresses::{PhysAddr, VirtAddr};
 
-use crate::arch::riscv64::kernel::core_local::core_scheduler;
-use crate::arch::riscv64::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::kernel::core_local::core_scheduler;
+use crate::arch::mm::paging::{BasePageSize, PageSize, PageTableEntryFlags};
 use crate::config::{DEFAULT_STACK_SIZE, KERNEL_STACK_SIZE};
 use crate::mm::{FrameAlloc, PageAlloc, PageRangeAllocator};
 use crate::scheduler::task::{Task, TaskFrame};

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -4,12 +4,12 @@ use core::sync::atomic::Ordering;
 use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
+use crate::arch::kernel::{CPU_ONLINE, CURRENT_BOOT_ID, HART_MASK, NUM_CPUS};
 use crate::arch::riscv64::kernel::CURRENT_STACK_ADDRESS;
 #[cfg(not(feature = "smp"))]
 use crate::arch::riscv64::kernel::processor;
 use crate::config::KERNEL_STACK_SIZE;
 use crate::env;
-use crate::kernel::{CPU_ONLINE, CURRENT_BOOT_ID, HART_MASK, NUM_CPUS};
 
 //static mut BOOT_STACK: [u8; KERNEL_STACK_SIZE] = [0; KERNEL_STACK_SIZE];
 

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -4,10 +4,11 @@ use core::sync::atomic::Ordering;
 use hermit_entry::Entry;
 use hermit_entry::boot_info::RawBootInfo;
 
-use crate::arch::kernel::{CPU_ONLINE, CURRENT_BOOT_ID, HART_MASK, NUM_CPUS};
-use crate::arch::riscv64::kernel::CURRENT_STACK_ADDRESS;
 #[cfg(not(feature = "smp"))]
-use crate::arch::riscv64::kernel::processor;
+use crate::arch::kernel::processor;
+use crate::arch::kernel::{
+	CPU_ONLINE, CURRENT_BOOT_ID, CURRENT_STACK_ADDRESS, HART_MASK, NUM_CPUS,
+};
 use crate::config::KERNEL_STACK_SIZE;
 use crate::env;
 

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -67,7 +67,7 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 		}
 		NUM_CPUS.store(fdt.cpus().count().try_into().unwrap(), Ordering::Relaxed);
 		HART_MASK.store(hart_mask, Ordering::Relaxed);
-		crate::boot_processor_main()
+		crate::rt::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
@@ -81,6 +81,6 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 			}
 		}
 		#[cfg(feature = "smp")]
-		crate::application_processor_main();
+		crate::rt::application_processor_main();
 	}
 }

--- a/src/arch/riscv64/start/smp.rs
+++ b/src/arch/riscv64/start/smp.rs
@@ -25,5 +25,5 @@ pub unsafe extern "C" fn smp_start(hart_id: usize) -> ! {
 unsafe extern "C" fn smp_start_rust(hart_id: usize) -> ! {
 	CURRENT_BOOT_ID.store(hart_id as u32, Ordering::Relaxed);
 
-	crate::application_processor_main();
+	crate::rt::application_processor_main();
 }

--- a/src/arch/riscv64/start/smp.rs
+++ b/src/arch/riscv64/start/smp.rs
@@ -1,9 +1,9 @@
 use core::arch::naked_asm;
 use core::sync::atomic::Ordering;
 
+use crate::arch::kernel::CURRENT_BOOT_ID;
 use crate::arch::riscv64::kernel::CURRENT_STACK_ADDRESS;
 use crate::config::KERNEL_STACK_SIZE;
-use crate::kernel::CURRENT_BOOT_ID;
 
 #[unsafe(naked)]
 pub unsafe extern "C" fn smp_start(hart_id: usize) -> ! {

--- a/src/arch/riscv64/start/smp.rs
+++ b/src/arch/riscv64/start/smp.rs
@@ -1,8 +1,7 @@
 use core::arch::naked_asm;
 use core::sync::atomic::Ordering;
 
-use crate::arch::kernel::CURRENT_BOOT_ID;
-use crate::arch::riscv64::kernel::CURRENT_STACK_ADDRESS;
+use crate::arch::kernel::{CURRENT_BOOT_ID, CURRENT_STACK_ADDRESS};
 use crate::config::KERNEL_STACK_SIZE;
 
 #[unsafe(naked)]

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -7,8 +7,8 @@ use memory_addresses::{PhysAddr, VirtAddr};
 use x86_64::instructions::port::Port;
 use x86_64::structures::paging::PhysFrame;
 
-use crate::arch::x86_64::mm::paging;
-use crate::arch::x86_64::mm::paging::{
+use crate::arch::mm::paging;
+use crate::arch::mm::paging::{
 	BasePageSize, PageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
 use crate::env;

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -7,9 +7,6 @@ use core::hint::spin_loop;
 use core::{cmp, ptr};
 
 use align_address::Align;
-#[cfg(feature = "smp")]
-use arch::x86_64::kernel::core_local::*;
-use arch::x86_64::kernel::{interrupts, processor};
 use free_list::PageLayout;
 use hermit_sync::{OnceCell, SpinMutex, without_interrupts};
 use memory_addresses::{AddrRange, PhysAddr, VirtAddr};
@@ -19,12 +16,15 @@ use x86_64::registers::model_specific::Msr;
 
 use super::interrupts::IDT;
 #[cfg(feature = "acpi")]
-use crate::arch::x86_64::kernel::acpi;
-use crate::arch::x86_64::mm::paging;
-use crate::arch::x86_64::mm::paging::{
+use crate::arch::kernel::acpi;
+#[cfg(feature = "smp")]
+use crate::arch::kernel::core_local::*;
+use crate::arch::kernel::{interrupts, processor};
+use crate::arch::mm::paging;
+use crate::arch::mm::paging::{
 	BasePageSize, PageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
-use crate::arch::x86_64::swapgs;
+use crate::arch::swapgs;
 use crate::mm::{PageAlloc, PageBox, PageRangeAllocator};
 use crate::scheduler::CoreId;
 use crate::{arch, env, scheduler};
@@ -735,7 +735,7 @@ pub fn init_next_processor_variables() {
 	use core::alloc::Layout;
 	use core::sync::atomic::Ordering;
 
-	use crate::arch::x86_64::kernel::CURRENT_STACK_ADDRESS;
+	use crate::arch::kernel::CURRENT_STACK_ADDRESS;
 	use crate::config::KERNEL_STACK_SIZE;
 
 	// Allocate stack for the CPU and pass the addresses.

--- a/src/arch/x86_64/kernel/gdt.rs
+++ b/src/arch/x86_64/kernel/gdt.rs
@@ -14,8 +14,8 @@ use x86_64::structures::tss::TaskStateSegment;
 use super::CURRENT_STACK_ADDRESS;
 use super::interrupts::{IST_ENTRIES, IST_SIZE};
 use super::scheduler::TaskStacks;
-use crate::arch::x86_64::kernel::core_local::{CoreLocal, core_scheduler};
-use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize};
+use crate::arch::kernel::core_local::{CoreLocal, core_scheduler};
+use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::config::KERNEL_STACK_SIZE;
 
 pub fn add_current_core() {

--- a/src/arch/x86_64/kernel/interrupts.rs
+++ b/src/arch/x86_64/kernel/interrupts.rs
@@ -12,10 +12,10 @@ use x86_64::set_general_handler;
 use x86_64::structures::idt::InterruptDescriptorTable;
 pub use x86_64::structures::idt::InterruptStackFrame as ExceptionStackFrame;
 
-use crate::arch::x86_64::kernel::core_local::{core_scheduler, increment_irq_counter};
-use crate::arch::x86_64::kernel::{apic, processor};
-use crate::arch::x86_64::mm::paging::{BasePageSize, PageSize, page_fault_handler};
-use crate::arch::x86_64::swapgs;
+use crate::arch::kernel::core_local::{core_scheduler, increment_irq_counter};
+use crate::arch::kernel::{apic, processor};
+use crate::arch::mm::paging::{BasePageSize, PageSize, page_fault_handler};
+use crate::arch::swapgs;
 use crate::drivers::InterruptHandlerMap;
 use crate::scheduler::{self, CoreId};
 

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -16,8 +16,8 @@ use memory_addresses::{PhysAddr, VirtAddr};
 use virtio::mmio::{DeviceRegisters, DeviceRegistersVolatileFieldAccess};
 use volatile::VolatileRef;
 
-use crate::arch::x86_64::mm::paging;
-use crate::arch::x86_64::mm::paging::{
+use crate::arch::mm::paging;
+use crate::arch::mm::paging::{
 	BasePageSize, PageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
 use crate::drivers::InterruptHandlerMap;

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -8,7 +8,7 @@ use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 use x86_64::registers::control::{Cr0, Cr4};
 
 pub(crate) use self::apic::{set_oneshot_timer, wakeup_core};
-use crate::arch::x86_64::kernel::core_local::*;
+use crate::arch::kernel::core_local::*;
 
 #[cfg(feature = "acpi")]
 pub mod acpi;
@@ -167,7 +167,7 @@ where
 	use memory_addresses::{PhysAddr, VirtAddr};
 	use x86_64::structures::paging::{PageSize, Size4KiB as BasePageSize};
 
-	use crate::arch::x86_64::mm::paging::{self, PageTableEntryFlags, PageTableEntryFlagsExt};
+	use crate::arch::mm::paging::{self, PageTableEntryFlags, PageTableEntryFlagsExt};
 	use crate::mm::{FrameAlloc, PageRangeAllocator};
 
 	let code_size = (code_size as usize + LOADER_STACK_SIZE).align_up(BasePageSize::SIZE as usize);
@@ -235,7 +235,7 @@ pub unsafe fn jump_to_user_land(entry_point: usize, code_size: usize, arg: &[&st
 	use align_address::Align;
 	use x86_64::structures::paging::{PageSize, Size4KiB as BasePageSize};
 
-	use crate::arch::x86_64::kernel::scheduler::TaskStacks;
+	use crate::arch::kernel::scheduler::TaskStacks;
 
 	info!("Create new file descriptor table");
 	core_scheduler().recreate_objmap().unwrap();

--- a/src/arch/x86_64/kernel/pic.rs
+++ b/src/arch/x86_64/kernel/pic.rs
@@ -1,8 +1,8 @@
 use x86_64::instructions::port::Port;
 
 use super::interrupts::IDT;
-use crate::arch::x86_64::kernel::interrupts::ExceptionStackFrame;
-use crate::arch::x86_64::swapgs;
+use crate::arch::kernel::interrupts::ExceptionStackFrame;
+use crate::arch::swapgs;
 use crate::scheduler;
 
 const PIC1_COMMAND: Port<u8> = Port::new(0x20);

--- a/src/arch/x86_64/kernel/pit.rs
+++ b/src/arch/x86_64/kernel/pit.rs
@@ -2,7 +2,7 @@
 
 use x86_64::instructions::port::Port;
 
-use crate::arch::x86_64::kernel::pic;
+use crate::arch::kernel::pic;
 
 const PIT_CLOCK: u64 = 1_193_182;
 pub const PIT_INTERRUPT_NUMBER: u8 = pic::PIC1_OFFSET;

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -24,8 +24,8 @@ use x86_64::structures::DescriptorTablePointer;
 use x86_64::{VirtAddr, instructions};
 
 #[cfg(feature = "acpi")]
-use crate::arch::x86_64::kernel::acpi;
-use crate::arch::x86_64::kernel::{interrupts, pic, pit};
+use crate::arch::kernel::acpi;
+use crate::arch::kernel::{interrupts, pic, pit};
 use crate::env;
 
 /// See <http://biosbits.org>.
@@ -390,7 +390,7 @@ impl CpuFrequency {
 
 	#[cfg(target_os = "none")]
 	fn measure_frequency(&mut self) -> Result<(), ()> {
-		use crate::arch::x86_64::kernel::interrupts::IDT;
+		use crate::arch::kernel::interrupts::IDT;
 
 		// Measure the CPU frequency by counting 3 ticks of a 100Hz timer.
 		let tick_count = 3;
@@ -879,7 +879,7 @@ pub fn configure() {
 		use x86_64::registers::rflags::RFlags;
 		use x86_64::structures::gdt::SegmentSelector;
 
-		use crate::arch::x86_64::kernel::syscall;
+		use crate::arch::kernel::syscall;
 
 		let has_syscall = match cpuid.get_extended_processor_and_feature_identifiers() {
 			Some(finfo) => finfo.has_syscall_sysret(),

--- a/src/arch/x86_64/kernel/scheduler.rs
+++ b/src/arch/x86_64/kernel/scheduler.rs
@@ -7,9 +7,9 @@ use free_list::{PageLayout, PageRange};
 use memory_addresses::{PhysAddr, VirtAddr};
 
 use super::interrupts::{IDT, IST_SIZE};
-use crate::arch::x86_64::kernel::core_local::*;
-use crate::arch::x86_64::kernel::{apic, interrupts};
-use crate::arch::x86_64::mm::paging::{
+use crate::arch::kernel::core_local::*;
+use crate::arch::kernel::{apic, interrupts};
+use crate::arch::mm::paging::{
 	BasePageSize, PageSize, PageTableEntryFlags, PageTableEntryFlagsExt,
 };
 use crate::config::*;

--- a/src/arch/x86_64/kernel/systemtime.rs
+++ b/src/arch/x86_64/kernel/systemtime.rs
@@ -4,7 +4,7 @@ use hermit_sync::{OnceCell, without_interrupts};
 use time::OffsetDateTime;
 use x86_64::instructions::port::Port;
 
-use crate::arch::x86_64::kernel::processor;
+use crate::arch::kernel::processor;
 
 const CMOS_COMMAND: Port<u8> = Port::new(0x70);
 const CMOS_DATA: Port<u8> = Port::new(0x71);

--- a/src/arch/x86_64/kernel/vga.rs
+++ b/src/arch/x86_64/kernel/vga.rs
@@ -4,8 +4,8 @@ use hermit_sync::SpinMutex;
 use memory_addresses::{PhysAddr, VirtAddr};
 use x86_64::instructions::port::Port;
 
-use crate::arch::x86_64::mm::paging;
-use crate::arch::x86_64::mm::paging::{BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt};
+use crate::arch::mm::paging;
+use crate::arch::mm::paging::{BasePageSize, PageTableEntryFlags, PageTableEntryFlagsExt};
 
 const CRT_CONTROLLER_ADDRESS: Port<u8> = Port::new(0x3d4);
 const CRT_CONTROLLER_DATA: Port<u8> = Port::new(0x3d5);

--- a/src/arch/x86_64/mm/paging.rs
+++ b/src/arch/x86_64/mm/paging.rs
@@ -14,8 +14,8 @@ use x86_64::structures::paging::{
 	FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PhysFrame, Size4KiB, Translate,
 };
 
-use crate::arch::x86_64::kernel::processor;
-use crate::arch::x86_64::mm::{PhysAddr, VirtAddr};
+use crate::arch::kernel::processor;
+use crate::arch::mm::{PhysAddr, VirtAddr};
 use crate::mm::{FrameAlloc, PageRangeAllocator};
 use crate::{env, scheduler};
 
@@ -196,7 +196,7 @@ pub fn map<S>(
 
 	if unmapped {
 		#[cfg(feature = "smp")]
-		crate::arch::x86_64::kernel::apic::ipi_tlb_flush();
+		crate::arch::kernel::apic::ipi_tlb_flush();
 	}
 }
 

--- a/src/arch/x86_64/start/hermit_entry.rs
+++ b/src/arch/x86_64/start/hermit_entry.rs
@@ -78,7 +78,7 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 	if cpu_id == 0 {
 		env::set_boot_info(*boot_info.unwrap());
 
-		crate::boot_processor_main()
+		crate::rt::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]
 		{
@@ -92,6 +92,6 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 			}
 		}
 		#[cfg(feature = "smp")]
-		crate::application_processor_main();
+		crate::rt::application_processor_main();
 	}
 }

--- a/src/arch/x86_64/start/smp.rs
+++ b/src/arch/x86_64/start/smp.rs
@@ -29,5 +29,5 @@ unsafe extern "C" fn smp_start_rust() -> ! {
 		Cr0::update(|flags| flags.remove(Cr0Flags::CACHE_DISABLE | Cr0Flags::NOT_WRITE_THROUGH));
 	}
 
-	crate::application_processor_main();
+	crate::rt::application_processor_main();
 }

--- a/src/arch/x86_64/start/smp.rs
+++ b/src/arch/x86_64/start/smp.rs
@@ -1,8 +1,8 @@
 use x86_64::registers::control::{Cr0, Cr0Flags};
 
+use crate::arch::kernel::CURRENT_STACK_ADDRESS;
 use crate::arch::kernel::scheduler::TaskStacks;
 use crate::config::KERNEL_STACK_SIZE;
-use crate::kernel::CURRENT_STACK_ADDRESS;
 
 #[unsafe(naked)]
 pub unsafe extern "C" fn smp_start() -> ! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 )]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(custom_test_frameworks))]
-#![cfg_attr(all(target_os = "none", test), test_runner(crate::test_runner))]
+#![cfg_attr(all(target_os = "none", test), test_runner(crate::rt::test_runner))]
 #![cfg_attr(
 	all(target_os = "none", test),
 	reexport_test_harness_main = "test_main"
@@ -88,16 +88,6 @@ extern crate log;
 #[cfg(not(target_os = "none"))]
 #[macro_use]
 extern crate std;
-
-#[cfg(feature = "smp")]
-use core::hint::spin_loop;
-#[cfg(feature = "smp")]
-use core::sync::atomic::{AtomicU32, Ordering};
-
-use self::arch::kernel;
-use self::arch::kernel::core_local::{core_id, core_scheduler};
-use self::arch::kernel::interrupts;
-use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 
 #[macro_use]
 mod macros;
@@ -121,6 +111,7 @@ mod init_buf;
 mod init_cell;
 pub mod io;
 pub mod mm;
+pub mod rt;
 pub mod scheduler;
 #[cfg(feature = "shell")]
 mod shell;
@@ -129,192 +120,3 @@ pub mod syscalls;
 pub mod time;
 #[cfg(feature = "uhyve")]
 mod uhyve;
-
-#[cfg(target_os = "none")]
-mod built_info {
-	include!(concat!(env!("OUT_DIR"), "/built.rs"));
-}
-
-#[cfg(target_os = "none")]
-hermit_entry::define_abi_tag!();
-
-#[cfg(target_os = "none")]
-hermit_entry::define_entry_version!();
-
-#[cfg(test)]
-#[cfg(target_os = "none")]
-#[unsafe(no_mangle)]
-extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
-	println!("Executing hermit unittests. Any arguments are dropped");
-	test_main();
-	core_scheduler().exit(0)
-}
-
-//https://github.com/rust-lang/rust/issues/50297#issuecomment-524180479
-#[cfg(target_os = "none")]
-#[cfg(test)]
-pub fn test_runner(tests: &[&dyn Fn()]) {
-	println!("Running {} tests", tests.len());
-	for test in tests {
-		test();
-	}
-	core_scheduler().exit(0)
-}
-
-#[cfg(target_os = "none")]
-#[test_case]
-fn trivial_test() {
-	println!("Test test test");
-	panic!("Test called");
-}
-
-/// Entry point of a kernel thread, which initialize the libos
-#[cfg(target_os = "none")]
-extern "C" fn initd(_arg: usize) {
-	unsafe extern "C" {
-		#[cfg(all(not(test), not(any(feature = "nostd", feature = "common-os"))))]
-		fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> !;
-		#[cfg(all(not(test), any(feature = "nostd", feature = "common-os")))]
-		fn main(argc: i32, argv: *const *const u8, env: *const *const u8);
-	}
-
-	// Initialize Drivers
-	drivers::init();
-	// The filesystem needs to be initialized before network to allow writing packet captures to a file.
-	fs::init();
-	executor::init();
-
-	syscalls::init();
-	#[cfg(feature = "shell")]
-	shell::init();
-
-	// Get the application arguments and environment variables.
-	#[cfg(not(test))]
-	let (argc, argv, environ) = syscalls::get_application_parameters();
-
-	// give the IP thread time to initialize the network interface
-	core_scheduler().reschedule();
-
-	if cfg!(feature = "warn-prebuilt") {
-		warn!("This is a prebuilt Hermit kernel.");
-		warn!("For non-default device drivers and features, consider building a custom kernel.");
-	}
-
-	info!("Jumping into application");
-
-	#[cfg(not(test))]
-	unsafe {
-		// And finally start the application.
-		#[cfg(all(not(test), not(any(feature = "nostd", feature = "common-os"))))]
-		runtime_entry(argc, argv, environ);
-		#[cfg(all(not(test), any(feature = "nostd", feature = "common-os")))]
-		main(argc, argv, environ);
-	}
-	#[cfg(test)]
-	test_main();
-}
-
-#[cfg(target_os = "none")]
-#[cfg(feature = "smp")]
-fn synch_all_cores() {
-	static CORE_COUNTER: AtomicU32 = AtomicU32::new(0);
-
-	CORE_COUNTER.fetch_add(1, Ordering::SeqCst);
-
-	let possible_cpus = kernel::get_possible_cpus();
-	while CORE_COUNTER.load(Ordering::SeqCst) != possible_cpus {
-		spin_loop();
-	}
-}
-
-/// Entry Point of Hermit for the Boot Processor
-#[cfg(target_os = "none")]
-fn boot_processor_main() -> ! {
-	use crate::config::USER_STACK_SIZE;
-
-	// Initialize the kernel and hardware.
-	mm::claim_initial_heap();
-	hermit_sync::Lazy::force(&console::CONSOLE);
-	env::init();
-	unsafe {
-		logging::init();
-	}
-
-	info!("Welcome to Hermit {}", env!("CARGO_PKG_VERSION"));
-	if let Some(git_version) = built_info::GIT_VERSION {
-		let dirty = if built_info::GIT_DIRTY == Some(true) {
-			" (dirty)"
-		} else {
-			""
-		};
-
-		let opt_level = if built_info::OPT_LEVEL == "3" {
-			format_args!("")
-		} else {
-			format_args!(" (opt-level={})", built_info::OPT_LEVEL)
-		};
-
-		info!("Git version: {git_version}{dirty}{opt_level}");
-	}
-	let arch = built_info::TARGET.split_once('-').unwrap().0;
-	info!("Architecture: {arch}");
-	info!("Enabled features: {}", built_info::FEATURES_LOWERCASE_STR);
-	info!("Built on {}", built_info::BUILT_TIME_UTC);
-
-	info!("Executable start: {:p}", elf_symbols::executable_start());
-	info!("ELF header:       {:p}", elf_symbols::elf_header());
-	info!("Text segment end: {:p}", elf_symbols::text_end());
-	info!("Data segment end: {:p}", elf_symbols::data_end());
-	info!("Executable end:   {:p}", elf_symbols::executable_end());
-
-	if let Some(fdt) = env::fdt() {
-		info!("FDT:\n{fdt:#?}");
-	}
-
-	kernel::boot_processor_init();
-
-	#[cfg(not(target_arch = "riscv64"))]
-	scheduler::add_current_core();
-	interrupts::enable();
-
-	kernel::boot_next_processor();
-
-	#[cfg(feature = "smp")]
-	synch_all_cores();
-
-	#[cfg(feature = "pci")]
-	drivers::pci::print_information();
-
-	// Start the initd task.
-	unsafe { PerCoreScheduler::spawn(initd, 0, scheduler::task::NORMAL_PRIO, 0, USER_STACK_SIZE) };
-
-	// Run the scheduler loop.
-	PerCoreScheduler::run();
-}
-
-/// Entry Point of Hermit for an Application Processor
-#[cfg(all(target_os = "none", feature = "smp"))]
-fn application_processor_main() -> ! {
-	kernel::application_processor_init();
-	#[cfg(not(target_arch = "riscv64"))]
-	scheduler::add_current_core();
-	interrupts::enable();
-	kernel::boot_next_processor();
-
-	debug!("Entering idle loop for application processor");
-
-	synch_all_cores();
-	executor::init();
-
-	// Run the scheduler loop.
-	PerCoreScheduler::run();
-}
-
-#[cfg(target_os = "none")]
-#[panic_handler]
-fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
-	let core_id = core_id();
-	panic_println!("[{core_id}][PANIC] {info}\n");
-
-	scheduler::shutdown(1);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ mod init_buf;
 mod init_cell;
 pub mod io;
 pub mod mm;
+#[cfg(target_os = "none")]
 pub mod rt;
 pub mod scheduler;
 #[cfg(feature = "shell")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,12 @@ pub mod time;
 #[cfg(feature = "uhyve")]
 mod uhyve;
 
+#[cfg(target_os = "none")]
 mod built_info {
 	include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
+#[cfg(target_os = "none")]
 hermit_entry::define_abi_tag!();
 
 #[cfg(target_os = "none")]
@@ -149,6 +151,7 @@ extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *c
 }
 
 //https://github.com/rust-lang/rust/issues/50297#issuecomment-524180479
+#[cfg(target_os = "none")]
 #[cfg(test)]
 pub fn test_runner(tests: &[&dyn Fn()]) {
 	println!("Running {} tests", tests.len());
@@ -211,6 +214,7 @@ extern "C" fn initd(_arg: usize) {
 	test_main();
 }
 
+#[cfg(target_os = "none")]
 #[cfg(feature = "smp")]
 fn synch_all_cores() {
 	static CORE_COUNTER: AtomicU32 = AtomicU32::new(0);

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,0 +1,199 @@
+#[cfg(feature = "smp")]
+use core::hint::spin_loop;
+#[cfg(feature = "smp")]
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use crate::arch::kernel;
+use crate::arch::kernel::core_local::{core_id, core_scheduler};
+use crate::arch::kernel::interrupts;
+use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
+use crate::{console, drivers, env, executor, fs, logging, mm, scheduler, syscalls};
+
+#[cfg(target_os = "none")]
+mod built_info {
+	include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+#[cfg(target_os = "none")]
+hermit_entry::define_abi_tag!();
+
+#[cfg(target_os = "none")]
+hermit_entry::define_entry_version!();
+
+#[cfg(test)]
+#[cfg(target_os = "none")]
+#[unsafe(no_mangle)]
+extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
+	println!("Executing hermit unittests. Any arguments are dropped");
+	crate::test_main();
+	core_scheduler().exit(0)
+}
+
+//https://github.com/rust-lang/rust/issues/50297#issuecomment-524180479
+#[cfg(target_os = "none")]
+#[cfg(test)]
+pub fn test_runner(tests: &[&dyn Fn()]) {
+	println!("Running {} tests", tests.len());
+	for test in tests {
+		test();
+	}
+	core_scheduler().exit(0)
+}
+
+#[cfg(target_os = "none")]
+#[test_case]
+fn trivial_test() {
+	println!("Test test test");
+	panic!("Test called");
+}
+
+/// Entry point of a kernel thread, which initialize the libos
+#[cfg(target_os = "none")]
+extern "C" fn initd(_arg: usize) {
+	unsafe extern "C" {
+		#[cfg(all(not(test), not(any(feature = "nostd", feature = "common-os"))))]
+		fn runtime_entry(argc: i32, argv: *const *const u8, env: *const *const u8) -> !;
+		#[cfg(all(not(test), any(feature = "nostd", feature = "common-os")))]
+		fn main(argc: i32, argv: *const *const u8, env: *const *const u8);
+	}
+
+	// Initialize Drivers
+	drivers::init();
+	// The filesystem needs to be initialized before network to allow writing packet captures to a file.
+	fs::init();
+	executor::init();
+
+	syscalls::init();
+	#[cfg(feature = "shell")]
+	crate::shell::init();
+
+	// Get the application arguments and environment variables.
+	#[cfg(not(test))]
+	let (argc, argv, environ) = syscalls::get_application_parameters();
+
+	// give the IP thread time to initialize the network interface
+	core_scheduler().reschedule();
+
+	if cfg!(feature = "warn-prebuilt") {
+		warn!("This is a prebuilt Hermit kernel.");
+		warn!("For non-default device drivers and features, consider building a custom kernel.");
+	}
+
+	info!("Jumping into application");
+
+	#[cfg(not(test))]
+	unsafe {
+		// And finally start the application.
+		#[cfg(all(not(test), not(any(feature = "nostd", feature = "common-os"))))]
+		runtime_entry(argc, argv, environ);
+		#[cfg(all(not(test), any(feature = "nostd", feature = "common-os")))]
+		main(argc, argv, environ);
+	}
+	#[cfg(test)]
+	crate::test_main();
+}
+
+#[cfg(target_os = "none")]
+#[cfg(feature = "smp")]
+fn synch_all_cores() {
+	static CORE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+	CORE_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+	let possible_cpus = kernel::get_possible_cpus();
+	while CORE_COUNTER.load(Ordering::SeqCst) != possible_cpus {
+		spin_loop();
+	}
+}
+
+/// Entry Point of Hermit for the Boot Processor
+#[cfg(target_os = "none")]
+pub fn boot_processor_main() -> ! {
+	use crate::config::USER_STACK_SIZE;
+
+	// Initialize the kernel and hardware.
+	mm::claim_initial_heap();
+	hermit_sync::Lazy::force(&console::CONSOLE);
+	env::init();
+	unsafe {
+		logging::init();
+	}
+
+	info!("Welcome to Hermit {}", env!("CARGO_PKG_VERSION"));
+	if let Some(git_version) = built_info::GIT_VERSION {
+		let dirty = if built_info::GIT_DIRTY == Some(true) {
+			" (dirty)"
+		} else {
+			""
+		};
+
+		let opt_level = if built_info::OPT_LEVEL == "3" {
+			format_args!("")
+		} else {
+			format_args!(" (opt-level={})", built_info::OPT_LEVEL)
+		};
+
+		info!("Git version: {git_version}{dirty}{opt_level}");
+	}
+	let arch = built_info::TARGET.split_once('-').unwrap().0;
+	info!("Architecture: {arch}");
+	info!("Enabled features: {}", built_info::FEATURES_LOWERCASE_STR);
+	info!("Built on {}", built_info::BUILT_TIME_UTC);
+
+	info!("Executable start: {:p}", elf_symbols::executable_start());
+	info!("ELF header:       {:p}", elf_symbols::elf_header());
+	info!("Text segment end: {:p}", elf_symbols::text_end());
+	info!("Data segment end: {:p}", elf_symbols::data_end());
+	info!("Executable end:   {:p}", elf_symbols::executable_end());
+
+	if let Some(fdt) = env::fdt() {
+		info!("FDT:\n{fdt:#?}");
+	}
+
+	kernel::boot_processor_init();
+
+	#[cfg(not(target_arch = "riscv64"))]
+	scheduler::add_current_core();
+	interrupts::enable();
+
+	kernel::boot_next_processor();
+
+	#[cfg(feature = "smp")]
+	synch_all_cores();
+
+	#[cfg(feature = "pci")]
+	drivers::pci::print_information();
+
+	// Start the initd task.
+	unsafe { PerCoreScheduler::spawn(initd, 0, scheduler::task::NORMAL_PRIO, 0, USER_STACK_SIZE) };
+
+	// Run the scheduler loop.
+	PerCoreScheduler::run();
+}
+
+/// Entry Point of Hermit for an Application Processor
+#[cfg(all(target_os = "none", feature = "smp"))]
+pub fn application_processor_main() -> ! {
+	kernel::application_processor_init();
+	#[cfg(not(target_arch = "riscv64"))]
+	scheduler::add_current_core();
+	interrupts::enable();
+	kernel::boot_next_processor();
+
+	debug!("Entering idle loop for application processor");
+
+	synch_all_cores();
+	executor::init();
+
+	// Run the scheduler loop.
+	PerCoreScheduler::run();
+}
+
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+	let core_id = core_id();
+	panic_println!("[{core_id}][PANIC] {info}\n");
+
+	scheduler::shutdown(1);
+}

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -9,19 +9,15 @@ use crate::arch::kernel::interrupts;
 use crate::scheduler::{PerCoreScheduler, PerCoreSchedulerExt};
 use crate::{console, drivers, env, executor, fs, logging, mm, scheduler, syscalls};
 
-#[cfg(target_os = "none")]
 mod built_info {
 	include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-#[cfg(target_os = "none")]
 hermit_entry::define_abi_tag!();
 
-#[cfg(target_os = "none")]
 hermit_entry::define_entry_version!();
 
 #[cfg(test)]
-#[cfg(target_os = "none")]
 #[unsafe(no_mangle)]
 extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
 	println!("Executing hermit unittests. Any arguments are dropped");
@@ -30,7 +26,6 @@ extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *c
 }
 
 //https://github.com/rust-lang/rust/issues/50297#issuecomment-524180479
-#[cfg(target_os = "none")]
 #[cfg(test)]
 pub fn test_runner(tests: &[&dyn Fn()]) {
 	println!("Running {} tests", tests.len());
@@ -40,7 +35,6 @@ pub fn test_runner(tests: &[&dyn Fn()]) {
 	core_scheduler().exit(0)
 }
 
-#[cfg(target_os = "none")]
 #[test_case]
 fn trivial_test() {
 	println!("Test test test");
@@ -48,7 +42,6 @@ fn trivial_test() {
 }
 
 /// Entry point of a kernel thread, which initialize the libos
-#[cfg(target_os = "none")]
 extern "C" fn initd(_arg: usize) {
 	unsafe extern "C" {
 		#[cfg(all(not(test), not(any(feature = "nostd", feature = "common-os"))))]
@@ -93,7 +86,6 @@ extern "C" fn initd(_arg: usize) {
 	crate::test_main();
 }
 
-#[cfg(target_os = "none")]
 #[cfg(feature = "smp")]
 fn synch_all_cores() {
 	static CORE_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -107,7 +99,6 @@ fn synch_all_cores() {
 }
 
 /// Entry Point of Hermit for the Boot Processor
-#[cfg(target_os = "none")]
 pub fn boot_processor_main() -> ! {
 	use crate::config::USER_STACK_SIZE;
 
@@ -172,7 +163,7 @@ pub fn boot_processor_main() -> ! {
 }
 
 /// Entry Point of Hermit for an Application Processor
-#[cfg(all(target_os = "none", feature = "smp"))]
+#[cfg(feature = "smp")]
 pub fn application_processor_main() -> ! {
 	kernel::application_processor_init();
 	#[cfg(not(target_arch = "riscv64"))]
@@ -189,7 +180,6 @@ pub fn application_processor_main() -> ! {
 	PerCoreScheduler::run();
 }
 
-#[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
 	let core_id = core_id();

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "smp")]
-use core::hint::spin_loop;
-#[cfg(feature = "smp")]
-use core::sync::atomic::{AtomicU32, Ordering};
-
 use crate::arch::kernel;
 use crate::arch::kernel::core_local::{core_id, core_scheduler};
 use crate::arch::kernel::interrupts;
@@ -88,13 +83,16 @@ extern "C" fn initd(_arg: usize) {
 
 #[cfg(feature = "smp")]
 fn synch_all_cores() {
+	use core::hint;
+	use core::sync::atomic::{AtomicU32, Ordering};
+
 	static CORE_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 	CORE_COUNTER.fetch_add(1, Ordering::SeqCst);
 
 	let possible_cpus = kernel::get_possible_cpus();
 	while CORE_COUNTER.load(Ordering::SeqCst) != possible_cpus {
-		spin_loop();
+		hint::spin_loop();
 	}
 }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,7 +1,7 @@
 use embedded_io::{Read, Write};
 use simple_shell::*;
 
-use crate::interrupts::print_statistics;
+use crate::arch::kernel::interrupts::print_statistics;
 
 fn read() -> Option<u8> {
 	let mut buf = [0; 1];


### PR DESCRIPTION
Private imports at the crate root are visible to any children. This leads rust-analyzer to import `crate::arch::kernel` from `crate::kernel` by default.

This PR moves all functions from `crate` (lib.rs) to `crate::rt` (rt.rs) to avoid any unwanted private reexports from the crate root.