### PR TITLE
refactor(virtio-net): use the checksum functions provided by smoltcp

### DIFF
--- a/src/drivers/net/virtio.rs
+++ b/src/drivers/net/virtio.rs
@@ -684,16 +684,19 @@ impl VirtioNetDriver {
 		let ip_header_len: u16;
 		let ip_packet_len: usize;
 		let protocol;
-		let pseudo_header_checksum;
 		let mut ethernet_frame = EthernetFrame::new_unchecked(frame);
-		match ethernet_frame.ethertype() {
+		let pseudo_header_checksum = match ethernet_frame.ethertype() {
 			smoltcp::wire::EthernetProtocol::Ipv4 => {
 				let ip_packet = Ipv4Packet::new_unchecked(&*ethernet_frame.payload_mut());
 				ip_header_len = ip_packet.header_len().into();
 				ip_packet_len = ip_packet.total_len().into();
 				protocol = ip_packet.next_header();
-				pseudo_header_checksum =
-					partial_checksum::ipv4_pseudo_header_partial_checksum(&ip_packet);
+				smoltcp::wire::checksum::pseudo_header_v4(
+					&ip_packet.src_addr(),
+					&ip_packet.dst_addr(),
+					protocol,
+					(ip_packet.total_len() - ip_header_len).into(),
+				)
 			}
 			smoltcp::wire::EthernetProtocol::Ipv6 => {
 				let ip_packet = Ipv6Packet::new_unchecked(&*ethernet_frame.payload_mut());
@@ -702,8 +705,12 @@ impl VirtioNetDriver {
 				);
 				ip_packet_len = ip_packet.total_len();
 				protocol = ip_packet.next_header();
-				pseudo_header_checksum =
-					partial_checksum::ipv6_pseudo_header_partial_checksum(&ip_packet);
+				smoltcp::wire::checksum::pseudo_header_v6(
+					&ip_packet.src_addr(),
+					&ip_packet.dst_addr(),
+					protocol,
+					ip_packet.payload_len().into(),
+				)
 			}
 			// If the Ethernet protocol is not one of these two above, for which we know there may be a checksum field,
 			// we default to not asking for checksum, as otherwise the frame will be corrupted by the device trying
@@ -1038,61 +1045,5 @@ pub mod error {
 			"Virtio network driver failed, for device {0:x}, due to a missing or malformed device config!"
 		)]
 		NoDevCfg(u16),
-	}
-}
-
-/// The checksum functions in this module only calculate the one's complement sum for the pseudo-header
-/// and their results are meant to be combined with the TCP payload to calculate the real checksum.
-/// They are only useful for the VIRTIO driver with the checksum offloading feature.
-///
-/// The calculations here can theoretically be made faster by exploiting the properties described in
-/// [RFC 1071 section 2](https://www.rfc-editor.org/rfc/rfc1071).
-mod partial_checksum {
-	use smoltcp::wire::{Ipv4Packet, Ipv6Packet};
-
-	fn addr_sum<const N: usize>(addr: &[u8; N]) -> u16 {
-		let mut sum = 0;
-		const CHUNK_SIZE: usize = size_of::<u16>();
-		for i in 0..(N / CHUNK_SIZE) {
-			sum = ones_complement_add(
-				sum,
-				(u16::from(addr[CHUNK_SIZE * i]) << 8) | u16::from(addr[CHUNK_SIZE * i + 1]),
-			);
-		}
-		sum
-	}
-
-	/// Calculates the checksum for the IPv4 pseudo-header as described in
-	/// [RFC 9293 subsection 3.1](https://www.rfc-editor.org/rfc/rfc9293.html#section-3.1-6.18.1) WITHOUT the final inversion.
-	pub(super) fn ipv4_pseudo_header_partial_checksum<T: AsRef<[u8]>>(
-		packet: &Ipv4Packet<T>,
-	) -> u16 {
-		let padded_protocol = u16::from(u8::from(packet.next_header()));
-		let payload_len = packet.total_len() - u16::from(packet.header_len());
-
-		let mut sum = addr_sum(&packet.src_addr().octets());
-		sum = ones_complement_add(sum, addr_sum(&packet.dst_addr().octets()));
-		sum = ones_complement_add(sum, padded_protocol);
-		ones_complement_add(sum, payload_len)
-	}
-
-	/// Calculates the checksum for the IPv6 pseudo-header as described in
-	/// [RFC 8200 subsection 8.1](https://www.rfc-editor.org/rfc/rfc8200.html#section-8.1) WITHOUT the final inversion.
-	pub(super) fn ipv6_pseudo_header_partial_checksum<T: AsRef<[u8]>>(
-		packet: &Ipv6Packet<T>,
-	) -> u16 {
-		warn!("The IPv6 partial checksum implementation is untested!");
-		let padded_protocol = u16::from(u8::from(packet.next_header()));
-
-		let mut sum = addr_sum(&packet.src_addr().octets());
-		sum = ones_complement_add(sum, addr_sum(&packet.dst_addr().octets()));
-		sum = ones_complement_add(sum, packet.payload_len());
-		ones_complement_add(sum, padded_protocol)
-	}
-
-	/// Implements one's complement checksum as described in [RFC 1071 section 1](https://www.rfc-editor.org/rfc/rfc1071#section-1).
-	fn ones_complement_add(lhs: u16, rhs: u16) -> u16 {
-		let (sum, overflow) = u16::overflowing_add(lhs, rhs);
-		sum + u16::from(overflow)
 	}
 }


### PR DESCRIPTION
This will need to wait until a smoltcp version with the newly exposed functions is released.