### PR TITLE
fix(pci): disable decoding while sizing BARs

### DIFF
--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -76,9 +76,23 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 
 	/// Returns the bar at bar-register `slot`.
 	pub fn get_bar(&self, slot: u8) -> Option<Bar> {
-		let header = self.header();
-		let endpoint = EndpointHeader::from_header(header, &self.access)?;
-		endpoint.bar(slot, &self.access)
+		let endpoint = EndpointHeader::from_header(self.header(), &self.access)?;
+		let mut header = self.header();
+
+		// Determining the size of a bar writes all-ones into it and restores the
+		// old value afterwards. While decoding is enabled, the device decodes
+		// these intermediate values as real addresses and relocates itself. On a
+		// passed-through device the host follows that relocation and tries to map
+		// the bar at an address outside of the guest, which kills the VM. The PCI
+		// specification requires decoding to be disabled while sizing a bar.
+		let command = header.command(&self.access);
+		header.update_command(&self.access, |command| {
+			command & !(CommandRegister::IO_ENABLE | CommandRegister::MEMORY_ENABLE)
+		});
+		let bar = endpoint.bar(slot, &self.access);
+		header.update_command(&self.access, |_| command);
+
+		bar
 	}
 
 	/// Configure the bar at register `slot`
@@ -292,7 +306,7 @@ impl<T: ConfigRegionAccess> fmt::Display for PciDevice<T> {
 
 			let mut slot: u8 = 0;
 			while usize::from(slot) < MAX_BARS {
-				if let Some(pci_bar) = endpoint.bar(slot, &self.access) {
+				if let Some(pci_bar) = self.get_bar(slot) {
 					match pci_bar {
 						Bar::Memory64 {
 							address,


### PR DESCRIPTION
Determining the size of a BAR writes all-ones into it and restores the previous value afterwards. While decoding is enabled, the device decodes those intermediate values as real addresses and relocates itself. For a passed-through device the host follows that relocation and tries to map the BAR outside of the guest, which aborts the VM:

    kvm_set_user_memory_region: KVM_SET_USER_MEMORY_REGION failed,
    slot=5, start=0xfffffffffe000000, size=0x400000: Invalid argument

Disable decoding around the probe, as the PCI specification requires, and route the informational bus dump through get_bar so that it is covered as well.

Depends on https://github.com/hermit-os/kernel/pull/2611.