### PR TITLE
feat(xtask): Search in system paths for OpenSBI binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,11 +210,6 @@ jobs:
           toolchain-file: "kernel/rust-toolchain.toml"
       - name: Download loader
         run: gh release download --repo hermit-os/loader --pattern 'hermit-loader-${{ matrix.arch }}*'
-      - name: Dowload OpenSBI
-        if: matrix.arch == 'riscv64'
-        run: |
-          gh release download v1.7 --repo riscv-software-src/opensbi --pattern 'opensbi-*-rv-bin.tar.xz'
-          tar -xvf opensbi-*-rv-bin.tar.xz opensbi-1.7-rv-bin/share/opensbi/lp64/generic/firmware/fw_jump.bin
       - name: Install Firecracker
         run: |
           gh release download --repo firecracker-microvm/firecracker v1.12.0 --pattern "firecracker-*-${{ matrix.arch }}.tgz"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /hermit-loader-*
-/opensbi-*-rv-bin
+/opensbi*
 /shared
 /target
 /vhostqemu.pid

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -294,11 +294,23 @@ impl Qemu {
 			} else {
 				"virt"
 			};
+
+			let opensbi_paths = &[
+				"opensbi/generic/firmware/fw_jump.bin", // Local
+				"/usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.bin", // Ubuntu
+				"/usr/share/opensbi/generic/firmware/fw_jump.bin", // Alpine
+			];
+			let opensbi_path = opensbi_paths
+				.iter()
+				.copied()
+				.find(|p| fs::exists(p).unwrap_or_default())
+				.expect("OpenSBI was not found");
+
 			vec![
 				"-machine".to_owned(),
 				machine.to_owned(),
 				"-bios".to_owned(),
-				"opensbi-1.7-rv-bin/share/opensbi/lp64/generic/firmware/fw_jump.bin".to_owned(),
+				opensbi_path.to_owned(),
 			]
 		} else {
 			vec![]


### PR DESCRIPTION
This aligns the locations where xtask searches for the OpenSBI binary with the loader and uses the system-wide paths rather than a local directory.

See:
- https://github.com/hermit-os/loader/pull/629