### PR TITLE
feat: add the icmp-echo-reply feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           cargo clippy --target x86_64-unknown-none --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock --all-targets
           cargo clippy --target x86_64-unknown-none --no-default-features --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock
-          cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net
-          cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net --features pci
+          cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply
+          cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply --features pci
           cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features gem-net,rtl8139 --features tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features gem-net,rtl8139 --features pci,tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target x86_64-unknown-none --exclude-features gem-net,virtio-net --features tcp,rtl8139
@@ -58,8 +58,8 @@ jobs:
         run: |
           cargo clippy --target aarch64-unknown-none-softfloat --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock --all-targets
           cargo clippy --target aarch64-unknown-none-softfloat --no-default-features --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock
-          cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net
-          cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net --features pci
+          cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply
+          cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply --features pci
           cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features gem-net,rtl8139 --features tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features gem-net,rtl8139 --features pci,tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target aarch64-unknown-none-softfloat --exclude-features gem-net,virtio-net --features tcp,rtl8139
@@ -68,8 +68,8 @@ jobs:
         run: |
           cargo clippy --target riscv64gc-unknown-none-elf --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock --all-targets
           cargo clippy --target riscv64gc-unknown-none-elf --no-default-features --features tcp,virtio-console,virtio-fs,virtio-net,virtio-vsock
-          cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net
-          cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net --features pci
+          cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply
+          cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features dhcpv4,dns,gem-net,net,rtl8139,virtio-net,icmp-echo-reply --features pci
           cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features gem-net,rtl8139 --features tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features gem-net,rtl8139 --features pci,tcp,virtio-net
           cargo hack clippy --each-feature --no-dev-deps --target riscv64gc-unknown-none-elf --exclude-features rtl8139,virtio-net --features tcp,gem-net

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,9 @@ dhcpv4 = ["net", "smoltcp", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]
 ## Enables DNS support.
 dns = ["net", "smoltcp", "smoltcp/socket-dns"]
 
+## Enables support for ICMP echo reply (ping).
+icmp-echo-reply = ["net", "smoltcp", "smoltcp/auto-icmp-echo-reply"]
+
 ## Enables pretty-printing the network traffic to the serial device.
 net-trace = ["smoltcp?/log", "smoltcp?/verbose"]
 


### PR DESCRIPTION
smoltcp answers ICMP echo requests by itself once auto-icmp-echo-reply is set, for IPv4 as well as IPv6, so making a Hermit guest respond to ping needs nothing beyond the feature flag.

I tested the configuration on macOS as follows:

```sh
$ cargo build --release -Zbuild-std=std,panic_abort --target=aarch64-unknown-hermit -p httpd --features hermit/echo-reply,hermit/pci,hermit/virtio-net,hermit/dhcpv4
$ sudo qemu-system-aarch64 -display none -serial stdio \
  -machine virt,gic-version=3 \
  -cpu max,lpa2=off  \
  -smp 1 -m 1024M \
  -global virtio-mmio.force-legacy=off \
  -kernel hermit-loader-aarch64 \
  -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/httpd \
  -netdev vmnet-shared,id=net0,start-address=192.168.68.2,end-address=192.168.68.254,subnet-mask=255.255.255.0 \
  -device virtio-net-pci,netdev=net0,mac=52:54:00:12:34:56,disable-legacy=on,packed=on,mq=on
$ ping -c 5 192.168.68.3
PING 192.168.68.3 (192.168.68.3): 56 data bytes
64 bytes from 192.168.68.3: icmp_seq=0 ttl=64 time=2.790 ms
64 bytes from 192.168.68.3: icmp_seq=1 ttl=64 time=0.485 ms
64 bytes from 192.168.68.3: icmp_seq=2 ttl=64 time=0.724 ms
64 bytes from 192.168.68.3: icmp_seq=3 ttl=64 time=0.621 ms
64 bytes from 192.168.68.3: icmp_seq=4 ttl=64 time=0.855 ms
```

close #2608