### PR TITLE
refactor(mm): remove `static KERNEL_ADDR_RANGE`

### DIFF
--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -47,11 +47,10 @@ mod virtualmem;
 
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
-use core::ops::Range;
 
 use align_address::Align;
 use free_list::{PageLayout, PageRange};
-use hermit_sync::{Lazy, RawInterruptTicketMutex};
+use hermit_sync::RawInterruptTicketMutex;
 pub use memory_addresses::{PhysAddr, VirtAddr};
 #[cfg(target_os = "none")]
 use talc::TalcLock;
@@ -70,26 +69,6 @@ use crate::arch::mm::paging::{BasePageSize, LargePageSize, PageSize};
 #[cfg(target_os = "none")]
 #[global_allocator]
 pub(crate) static ALLOCATOR: TalcLock<RawInterruptTicketMutex, Manual> = TalcLock::new(Manual);
-
-/// Physical and virtual address range of the 2 MiB pages that map the kernel.
-static KERNEL_ADDR_RANGE: Lazy<Range<VirtAddr>> = Lazy::new(|| {
-	if cfg!(target_os = "none") {
-		// Calculate the start and end addresses of the 2 MiB page(s) that map the kernel.
-		let start = VirtAddr::from_ptr(elf_symbols::executable_start());
-		let end = VirtAddr::from_ptr(elf_symbols::executable_end());
-		start.align_down(LargePageSize::SIZE)..end.align_up(LargePageSize::SIZE)
-	} else {
-		VirtAddr::zero()..VirtAddr::zero()
-	}
-});
-
-pub(crate) fn kernel_start_address() -> VirtAddr {
-	KERNEL_ADDR_RANGE.start
-}
-
-pub(crate) fn kernel_end_address() -> VirtAddr {
-	KERNEL_ADDR_RANGE.end
-}
 
 #[cfg(target_os = "none")]
 pub(crate) fn claim_initial_heap() {
@@ -114,19 +93,12 @@ pub(crate) fn claim_initial_heap() {
 pub(crate) fn init() {
 	use crate::arch::mm::paging;
 
-	Lazy::force(&KERNEL_ADDR_RANGE);
-
 	unsafe {
 		arch::mm::init();
 	}
 
 	let total_mem = physicalmem::total_memory_size();
-	let kernel_addr_range = KERNEL_ADDR_RANGE.clone();
 	info!("Total memory size: {} MiB", total_mem >> 20);
-	info!(
-		"Kernel region: {:p}..{:p}",
-		kernel_addr_range.start, kernel_addr_range.end
-	);
 
 	// we reserve physical memory for the required page tables
 	// In worst case, we use page size of BasePageSize::SIZE

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -125,11 +125,11 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 
 		#[cfg(target_arch = "x86_64")]
 		if paging::is_recursive() {
-			start_addr = start_addr.max(super::kernel_end_address().as_usize());
+			start_addr = start_addr.max(elf_symbols::executable_end().addr());
 		}
 
 		if cfg!(target_arch = "aarch64") || cfg!(target_arch = "riscv64") {
-			start_addr = start_addr.max(super::kernel_end_address().as_usize());
+			start_addr = start_addr.max(elf_symbols::executable_end().addr());
 		}
 
 		start_addr = start_addr.align_up(0x1000);
@@ -167,9 +167,9 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 		reserve(reservation);
 	}
 
-	let kernel_start = super::kernel_start_address().as_usize();
-	let kernel_end = super::kernel_end_address().as_usize();
-	let kernel_region = PageRange::new(kernel_start, kernel_end).unwrap();
+	let kernel_start = elf_symbols::executable_start().addr();
+	let kernel_end = elf_symbols::executable_end().addr();
+	let kernel_region = PageRange::containing(kernel_start, kernel_end).unwrap();
 	reserve(kernel_region);
 
 	let fdt_start = env::fdt_addr().unwrap().get();

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -8,6 +8,7 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::{ptr, slice};
 
+use align_address::Align;
 use dirent_display::Dirent64Display;
 
 pub use self::condvar::*;
@@ -890,7 +891,11 @@ pub extern "C" fn sys_eventfd(initval: u64, flags: i16) -> i32 {
 #[hermit_macro::system]
 #[unsafe(no_mangle)]
 pub extern "C" fn sys_image_start_addr() -> usize {
-	crate::mm::kernel_start_address().as_usize()
+	use crate::arch::mm::paging::{LargePageSize, PageSize};
+
+	elf_symbols::executable_start()
+		.addr()
+		.align_down(LargePageSize::SIZE as usize)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR removes `static KERNEL_ADDR_RANGE`. Looking up the symbols directly should be cheaper too.

Found while working on https://github.com/hermit-os/kernel/pull/2546.