### PR TITLE
refactor(env): rename items and move start info into module

### DIFF
--- a/src/arch/aarch64/start/hermit_entry.rs
+++ b/src/arch/aarch64/start/hermit_entry.rs
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_i
 	dsb(SY);
 
 	if cpu_id == 0 {
-		env::set_boot_info(*boot_info.unwrap());
+		env::set_start_info(*boot_info.unwrap());
 		crate::rt::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -53,7 +53,7 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 	if CPU_ONLINE.load(Ordering::Acquire) == 0 {
 		crate::logging::KERNEL_LOGGER.set_time(true);
 
-		env::set_boot_info(*boot_info.unwrap());
+		env::set_start_info(*boot_info.unwrap());
 		let fdt = env::fdt().unwrap();
 		// Init HART_MASK
 		let mut hart_mask = 0;

--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -291,10 +291,10 @@ fn detect_rsdp(start_address: PhysAddr, end_address: PhysAddr) -> Result<&'stati
 /// Detects ACPI support of the computer system.
 /// Returns a reference to the ACPI RSDP within the Ok() if successful or an empty Err() on failure.
 fn detect_acpi() -> Result<&'static AcpiRsdp, ()> {
-	if let Some(rsdp) = env::rsdp() {
-		trace!("RSDP detected successfully at {rsdp:#x?}");
+	if let Some(rsdp_addr) = env::rsdp_addr() {
+		trace!("RSDP detected successfully at {rsdp_addr:#x?}");
 		let rsdp = unsafe {
-			ptr::with_exposed_provenance::<AcpiRsdp>(rsdp.get())
+			ptr::with_exposed_provenance::<AcpiRsdp>(rsdp_addr.get())
 				.as_ref()
 				.unwrap()
 		};

--- a/src/arch/x86_64/start/hermit_entry.rs
+++ b/src/arch/x86_64/start/hermit_entry.rs
@@ -76,7 +76,7 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 	}
 
 	if cpu_id == 0 {
-		env::set_boot_info(*boot_info.unwrap());
+		env::set_start_info(*boot_info.unwrap());
 
 		crate::rt::boot_processor_main()
 	} else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -93,7 +93,14 @@ pub fn fdt() -> Option<Fdt<'static>> {
 }
 
 /// Returns the RSDP physical address if available.
-#[cfg(all(target_arch = "x86_64", feature = "acpi"))]
+#[cfg_attr(
+	any(
+		not(feature = "acpi"),
+		target_arch = "aarch64",
+		target_arch = "riscv64"
+	),
+	expect(dead_code)
+)]
 pub fn rsdp() -> Option<NonZero<usize>> {
 	let rsdp = fdt()?
 		.find_node("/hermit,rsdp")?

--- a/src/env.rs
+++ b/src/env.rs
@@ -14,15 +14,15 @@ use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 use shlex::Shlex;
 
-static BOOT_INFO: OnceCell<BootInfo> = OnceCell::new();
+static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
-pub fn boot_info() -> &'static BootInfo {
-	BOOT_INFO.get().unwrap()
+pub fn start_info() -> &'static BootInfo {
+	START_INFO.get().unwrap()
 }
 
-pub fn set_boot_info(raw_boot_info: RawBootInfo) {
-	let boot_info = BootInfo::from(raw_boot_info);
-	BOOT_INFO.set(boot_info).unwrap();
+pub fn set_start_info(raw_boot_info: RawBootInfo) {
+	let start_info = BootInfo::from(raw_boot_info);
+	START_INFO.set(start_info).unwrap();
 }
 
 static CLI: OnceCell<Cli> = OnceCell::new();
@@ -48,7 +48,7 @@ struct Cli {
 pub fn is_uhyve() -> bool {
 	use hermit_entry::boot_info::PlatformInfo;
 
-	matches!(boot_info().platform_info, PlatformInfo::Uhyve { .. })
+	matches!(start_info().platform_info, PlatformInfo::Uhyve { .. })
 }
 
 #[cfg_attr(target_arch = "riscv64", expect(dead_code))]
@@ -56,7 +56,7 @@ pub fn is_uhyve() -> bool {
 pub fn uhyve_boot_time() -> Option<time::OffsetDateTime> {
 	use hermit_entry::boot_info::PlatformInfo;
 
-	match boot_info().platform_info {
+	match start_info().platform_info {
 		PlatformInfo::Uhyve { boot_time, .. } => Some(boot_time),
 		_ => None,
 	}
@@ -70,7 +70,7 @@ pub fn uhyve_boot_time() -> Option<time::OffsetDateTime> {
 pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
 	use hermit_entry::boot_info::PlatformInfo;
 
-	match boot_info().platform_info {
+	match start_info().platform_info {
 		PlatformInfo::Uhyve { num_cpus, .. } => {
 			Some(NonZero::new(num_cpus.get() as usize).unwrap())
 		}
@@ -79,7 +79,7 @@ pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
 }
 
 pub fn fdt_addr() -> Option<NonZero<usize>> {
-	boot_info()
+	start_info()
 		.hardware_info
 		.device_tree
 		.map(|fdt| NonZero::new(fdt.get() as usize).unwrap())

--- a/src/env.rs
+++ b/src/env.rs
@@ -101,14 +101,14 @@ pub fn fdt() -> Option<Fdt<'static>> {
 	),
 	expect(dead_code)
 )]
-pub fn rsdp() -> Option<NonZero<usize>> {
-	let rsdp = fdt()?
+pub fn rsdp_addr() -> Option<NonZero<usize>> {
+	let rsdp_addr = fdt()?
 		.find_node("/hermit,rsdp")?
 		.reg()?
 		.next()?
 		.starting_address
 		.addr();
-	NonZero::new(rsdp)
+	NonZero::new(rsdp_addr)
 }
 
 pub fn bootargs() -> Option<&'static str> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -111,7 +111,7 @@ pub fn rsdp() -> Option<NonZero<usize>> {
 	NonZero::new(rsdp)
 }
 
-pub fn fdt_args() -> Option<&'static str> {
+pub fn bootargs() -> Option<&'static str> {
 	fdt().and_then(|fdt| fdt.chosen().bootargs())
 }
 
@@ -124,7 +124,7 @@ impl Default for Cli {
 			RandomState::with_seeds(0, 0, 0, 0),
 		);
 
-		let args = fdt_args().unwrap_or_default();
+		let args = bootargs().unwrap_or_default();
 		info!("bootargs = {args}");
 		let mut words = Shlex::new(args);
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,29 +1,19 @@
 //! Inspection and manipulation of the kernel's environment.
 
+mod start_info;
+
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::num::NonZero;
-use core::{ptr, str};
+use core::str;
 
 use ahash::RandomState;
-use fdt::Fdt;
 use hashbrown::HashMap;
 use hashbrown::hash_map::Iter;
-use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 use shlex::Shlex;
 
-static START_INFO: OnceCell<BootInfo> = OnceCell::new();
-
-pub fn start_info() -> &'static BootInfo {
-	START_INFO.get().unwrap()
-}
-
-pub fn set_start_info(raw_boot_info: RawBootInfo) {
-	let start_info = BootInfo::from(raw_boot_info);
-	START_INFO.set(start_info).unwrap();
-}
+pub use self::start_info::*;
 
 static CLI: OnceCell<Cli> = OnceCell::new();
 
@@ -41,78 +31,6 @@ struct Cli {
 	args: Vec<String>,
 	#[allow(dead_code)]
 	mmio: Vec<String>,
-}
-
-/// Whether Hermit is running under the "uhyve" hypervisor.
-#[cfg(feature = "uhyve")]
-pub fn is_uhyve() -> bool {
-	use hermit_entry::boot_info::PlatformInfo;
-
-	matches!(start_info().platform_info, PlatformInfo::Uhyve { .. })
-}
-
-#[cfg_attr(target_arch = "riscv64", expect(dead_code))]
-#[cfg(feature = "uhyve")]
-pub fn uhyve_boot_time() -> Option<time::OffsetDateTime> {
-	use hermit_entry::boot_info::PlatformInfo;
-
-	match start_info().platform_info {
-		PlatformInfo::Uhyve { boot_time, .. } => Some(boot_time),
-		_ => None,
-	}
-}
-
-#[cfg_attr(
-	any(not(target_arch = "x86_64"), not(feature = "smp")),
-	expect(dead_code)
-)]
-#[cfg(feature = "uhyve")]
-pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
-	use hermit_entry::boot_info::PlatformInfo;
-
-	match start_info().platform_info {
-		PlatformInfo::Uhyve { num_cpus, .. } => {
-			Some(NonZero::new(num_cpus.get() as usize).unwrap())
-		}
-		_ => None,
-	}
-}
-
-pub fn fdt_addr() -> Option<NonZero<usize>> {
-	start_info()
-		.hardware_info
-		.device_tree
-		.map(|fdt| NonZero::new(fdt.get() as usize).unwrap())
-}
-
-pub fn fdt() -> Option<Fdt<'static>> {
-	fdt_addr().map(|fdt| {
-		let ptr = ptr::with_exposed_provenance(fdt.get());
-		unsafe { Fdt::from_ptr(ptr).unwrap() }
-	})
-}
-
-/// Returns the RSDP physical address if available.
-#[cfg_attr(
-	any(
-		not(feature = "acpi"),
-		target_arch = "aarch64",
-		target_arch = "riscv64"
-	),
-	expect(dead_code)
-)]
-pub fn rsdp_addr() -> Option<NonZero<usize>> {
-	let rsdp_addr = fdt()?
-		.find_node("/hermit,rsdp")?
-		.reg()?
-		.next()?
-		.starting_address
-		.addr();
-	NonZero::new(rsdp_addr)
-}
-
-pub fn bootargs() -> Option<&'static str> {
-	fdt().and_then(|fdt| fdt.chosen().bootargs())
 }
 
 impl Default for Cli {

--- a/src/env/start_info.rs
+++ b/src/env/start_info.rs
@@ -1,0 +1,89 @@
+use core::num::NonZero;
+use core::ptr;
+
+use fdt::Fdt;
+use hermit_entry::boot_info::{BootInfo, RawBootInfo};
+use hermit_sync::OnceCell;
+
+static START_INFO: OnceCell<BootInfo> = OnceCell::new();
+
+pub fn start_info() -> &'static BootInfo {
+	START_INFO.get().unwrap()
+}
+
+pub fn set_start_info(raw_boot_info: RawBootInfo) {
+	let start_info = BootInfo::from(raw_boot_info);
+	START_INFO.set(start_info).unwrap();
+}
+
+/// Whether Hermit is running under the "uhyve" hypervisor.
+#[cfg(feature = "uhyve")]
+pub fn is_uhyve() -> bool {
+	use hermit_entry::boot_info::PlatformInfo;
+
+	matches!(start_info().platform_info, PlatformInfo::Uhyve { .. })
+}
+
+#[cfg_attr(target_arch = "riscv64", expect(dead_code))]
+#[cfg(feature = "uhyve")]
+pub fn uhyve_boot_time() -> Option<time::OffsetDateTime> {
+	use hermit_entry::boot_info::PlatformInfo;
+
+	match start_info().platform_info {
+		PlatformInfo::Uhyve { boot_time, .. } => Some(boot_time),
+		_ => None,
+	}
+}
+
+#[cfg_attr(
+	any(not(target_arch = "x86_64"), not(feature = "smp")),
+	expect(dead_code)
+)]
+#[cfg(feature = "uhyve")]
+pub fn uhyve_num_cpus() -> Option<NonZero<usize>> {
+	use hermit_entry::boot_info::PlatformInfo;
+
+	match start_info().platform_info {
+		PlatformInfo::Uhyve { num_cpus, .. } => {
+			Some(NonZero::new(num_cpus.get() as usize).unwrap())
+		}
+		_ => None,
+	}
+}
+
+pub fn fdt_addr() -> Option<NonZero<usize>> {
+	start_info()
+		.hardware_info
+		.device_tree
+		.map(|fdt| NonZero::new(fdt.get() as usize).unwrap())
+}
+
+pub fn fdt() -> Option<Fdt<'static>> {
+	fdt_addr().map(|fdt| {
+		let ptr = ptr::with_exposed_provenance(fdt.get());
+		unsafe { Fdt::from_ptr(ptr).unwrap() }
+	})
+}
+
+/// Returns the RSDP physical address if available.
+#[cfg_attr(
+	any(
+		not(feature = "acpi"),
+		target_arch = "aarch64",
+		target_arch = "riscv64"
+	),
+	expect(dead_code)
+)]
+pub fn rsdp_addr() -> Option<NonZero<usize>> {
+	let rsdp_addr = fdt()?
+		.find_node("/hermit,rsdp")?
+		.reg()?
+		.next()?
+		.starting_address
+		.addr();
+	NonZero::new(rsdp_addr)
+}
+
+pub fn bootargs() -> Option<&'static str> {
+	fdt().and_then(|fdt| fdt.chosen().bootargs())
+}


### PR DESCRIPTION
This prepares the start info traitification.

This is required for
- https://github.com/hermit-os/kernel/pull/2546