### PR TITLE
refactor(start_info): add default impl of `FdtStartInfo::fdt()`

### DIFF
--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -1,7 +1,6 @@
+use core::fmt;
 use core::num::NonZero;
-use core::{fmt, ptr};
 
-use fdt::Fdt;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 
@@ -52,13 +51,6 @@ unsafe impl StartInfo for BootInfo {
 }
 
 unsafe impl FdtStartInfo for BootInfo {
-	fn fdt(&self) -> Option<Fdt<'_>> {
-		let fdt_addr = self.fdt_addr()?;
-		let ptr = ptr::with_exposed_provenance(fdt_addr.get());
-		let fdt = unsafe { Fdt::from_ptr(ptr).unwrap() };
-		Some(fdt)
-	}
-
 	fn fdt_addr(&self) -> Option<NonZero<usize>> {
 		let fdt_addr = self.hardware_info.device_tree?;
 		let fdt_addr = NonZero::new(fdt_addr.get() as usize).unwrap();

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -42,10 +42,14 @@ pub unsafe trait StartInfo {
 ))]
 pub unsafe trait FdtStartInfo: StartInfo {
 	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
-		None
+		let phys_addr = self.fdt_addr()?.get();
+		// We require this to be identity-mapped at boot time for now.
+		let virt_addr = phys_addr;
+		let ptr = core::ptr::with_exposed_provenance(virt_addr);
+		let fdt = unsafe { fdt::Fdt::from_ptr(ptr).ok()? };
+		Some(fdt)
 	}
 
-	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
 	fn fdt_addr(&self) -> Option<NonZero<usize>> {
 		None
 	}


### PR DESCRIPTION
Depends on https://github.com/hermit-os/kernel/pull/2625.