### PR TITLE
feat(start_info): add `StartInfo::modules`

### DIFF
--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -4,7 +4,7 @@ use core::num::NonZero;
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 
-use super::{FdtStartInfo, StartInfo};
+use super::{FdtStartInfo, Module, StartInfo};
 
 static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
@@ -47,6 +47,26 @@ unsafe impl StartInfo for BootInfo {
 			.starting_address
 			.addr();
 		NonZero::new(rsdp)
+	}
+
+	fn modules(&self) -> impl Iterator<Item = Module> {
+		fn initrd(fdt: fdt::Fdt<'_>) -> Option<Module> {
+			let chosen = fdt.find_node("/chosen")?;
+
+			let start = chosen.property("linux,initrd-start")?;
+			let end = chosen.property("linux,initrd-end")?;
+
+			let start = start.as_usize()?;
+			let end = end.as_usize()?;
+			let len = end.checked_sub(start)?;
+
+			// SAFETY: The bootloader guarantees the addresses to be valid.
+			let module = unsafe { Module::new(start, len) };
+
+			Some(module)
+		}
+
+		self.fdt().and_then(initrd).into_iter()
 	}
 }
 

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -1,17 +1,16 @@
-#[cfg(feature = "hermit-entry")]
-mod hermit_entry;
-
-#[cfg(feature = "hermit-entry")]
-pub use hermit_entry::*;
-
-#[cfg(not(feature = "hermit-entry"))]
-mod unsupported;
+cfg_select! {
+	feature = "hermit-entry" => {
+		mod hermit_entry;
+		pub use self::hermit_entry::*;
+	}
+	_ => {
+		mod unsupported;
+		pub use self::unsupported::*;
+	}
+}
 
 use core::fmt;
 use core::num::NonZero;
-
-#[cfg(not(feature = "hermit-entry"))]
-pub use unsupported::*;
 
 pub unsafe trait StartInfo {
 	fn display(&self) -> impl fmt::Display {

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -9,12 +9,22 @@ cfg_select! {
 	}
 }
 
-use core::fmt;
+mod module;
+
 use core::num::NonZero;
+use core::{fmt, iter};
+
+pub use self::module::Module;
 
 pub unsafe trait StartInfo {
 	fn display(&self) -> impl fmt::Display {
 		fmt::from_fn(|f| f.write_str("StartInfo::display not implemented"))
+	}
+
+	/// Returns the modules passed to the kernel at start.
+	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
+	fn modules(&self) -> impl Iterator<Item = Module> {
+		iter::empty()
 	}
 
 	fn bootargs(&self) -> Option<&str> {

--- a/src/env/start_info/module.rs
+++ b/src/env/start_info/module.rs
@@ -1,0 +1,62 @@
+use core::{ptr, slice};
+
+use free_list::PageRange;
+
+use crate::page_range_ext::PageRangeExt;
+
+/// A module that is passed to the kernel at start.
+///
+/// This blob is loaded into physical memory by the bootloader or VMM and is described via the start info.
+///
+/// Examples of modules:
+/// - an initramfs
+/// - another kernel image
+///
+/// This type can be thought of as a physical-memory version of `&'static [u8]`.
+#[derive(Clone, Copy, Debug)]
+pub struct Module {
+	phys_addr: usize,
+	len: usize,
+}
+
+impl Module {
+	/// Constructs a new `Module` from a given `phys_addr` and `len`.
+	///
+	/// # Safety
+	///
+	/// The physical memory must be identity-mapped and valid for creating a slice.
+	#[expect(dead_code)]
+	pub unsafe fn new(phys_addr: usize, len: usize) -> Self {
+		Self { phys_addr, len }
+	}
+
+	/// The physical address of the module.
+	#[expect(dead_code)]
+	pub fn phys_addr(&self) -> usize {
+		self.phys_addr
+	}
+
+	/// The length of the module.
+	#[expect(dead_code)]
+	pub fn len(&self) -> usize {
+		self.len
+	}
+
+	/// The module as a readable slice.
+	#[expect(dead_code)]
+	pub fn as_slice(&self) -> &'static [u8] {
+		// We require this to be identity-mapped at boot time for now.
+		let virt_addr = self.phys_addr;
+		let ptr = ptr::with_exposed_provenance(virt_addr);
+		// SAFETY: upheld by `Self::new()`
+		unsafe { slice::from_raw_parts(ptr, self.len) }
+	}
+
+	/// The physical frames covered by this module.
+	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
+	pub fn phys_frame_range(&self) -> PageRange {
+		let start = self.phys_addr;
+		let end = self.phys_addr + self.len;
+		PageRange::containing(start, end).unwrap()
+	}
+}

--- a/src/env/start_info/module.rs
+++ b/src/env/start_info/module.rs
@@ -25,7 +25,7 @@ impl Module {
 	/// # Safety
 	///
 	/// The physical memory must be identity-mapped and valid for creating a slice.
-	#[expect(dead_code)]
+	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
 	pub unsafe fn new(phys_addr: usize, len: usize) -> Self {
 		Self { phys_addr, len }
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ mod init_buf;
 mod init_cell;
 pub mod io;
 pub mod mm;
+mod page_range_ext;
 #[cfg(target_os = "none")]
 pub mod rt;
 pub mod scheduler;

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -14,7 +14,7 @@ use crate::arch::mm::paging::PageTableEntryFlags;
 use crate::arch::mm::paging::PageTableEntryFlagsExt;
 use crate::arch::mm::paging::{self, HugePageSize, PageSize};
 #[cfg(feature = "hermit-entry")]
-use crate::env::{self, FdtStartInfo};
+use crate::env::{self, FdtStartInfo, StartInfo};
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
 #[cfg(feature = "hermit-entry")]
@@ -186,6 +186,10 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 	let fdt_end = fdt_start + fdt.total_size();
 	let fdt_region = PageRange::containing(fdt_start, fdt_end).unwrap();
 	reserve(fdt_region);
+
+	for module in env::start_info().modules() {
+		reserve(module.phys_frame_range());
+	}
 
 	Ok(())
 }

--- a/src/mm/physicalmem.rs
+++ b/src/mm/physicalmem.rs
@@ -4,8 +4,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "hermit-entry")]
 use align_address::Align;
-#[cfg(feature = "hermit-entry")]
-use free_list::PageRangeError;
 use free_list::{FreeList, PageLayout, PageRange};
 use hermit_sync::InterruptTicketMutex;
 use memory_addresses::VirtAddr;
@@ -19,6 +17,8 @@ use crate::arch::mm::paging::{self, HugePageSize, PageSize};
 use crate::env::{self, FdtStartInfo};
 use crate::mm::device_alloc::DeviceAlloc;
 use crate::mm::{PageRangeAllocator, PageRangeBox};
+#[cfg(feature = "hermit-entry")]
+use crate::page_range_ext::PageRangeExt;
 
 static PHYSICAL_FREE_LIST: InterruptTicketMutex<FreeList<16>> =
 	InterruptTicketMutex::new(FreeList::new());
@@ -188,29 +188,6 @@ unsafe fn detect_from_fdt() -> Result<(), ()> {
 	reserve(fdt_region);
 
 	Ok(())
-}
-
-// FIXME: upstream these
-#[cfg(feature = "hermit-entry")]
-trait PageRangeExt: Sized {
-	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError>;
-
-	fn and(self, rhs: Self) -> Option<Self>;
-}
-
-#[cfg(feature = "hermit-entry")]
-impl PageRangeExt for PageRange {
-	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError> {
-		let start = start.align_down(free_list::PAGE_SIZE);
-		let end = end.align_up(free_list::PAGE_SIZE);
-		Self::new(start, end)
-	}
-
-	fn and(self, rhs: Self) -> Option<Self> {
-		let start = self.start().max(rhs.start());
-		let end = self.end().min(rhs.end());
-		Self::new(start, end).ok()
-	}
 }
 
 unsafe fn init() {

--- a/src/page_range_ext.rs
+++ b/src/page_range_ext.rs
@@ -1,0 +1,26 @@
+//! FIXME(mkroening): upstream these
+
+#![cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
+
+use align_address::Align;
+use free_list::{PageRange, PageRangeError};
+
+pub trait PageRangeExt: Sized {
+	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError>;
+
+	fn and(self, rhs: Self) -> Option<Self>;
+}
+
+impl PageRangeExt for PageRange {
+	fn containing(start: usize, end: usize) -> Result<Self, PageRangeError> {
+		let start = start.align_down(free_list::PAGE_SIZE);
+		let end = end.align_up(free_list::PAGE_SIZE);
+		Self::new(start, end)
+	}
+
+	fn and(self, rhs: Self) -> Option<Self> {
+		let start = self.start().max(rhs.start());
+		let end = self.end().min(rhs.end());
+		Self::new(start, end).ok()
+	}
+}


### PR DESCRIPTION
This adds support for a start info impl to communicate physically loaded modules such as the initramfs.

Depends on https://github.com/hermit-os/kernel/pull/2625.