### PR TITLE
fix(start_info): make `StartInfo` unsafe to implement

### DIFF
--- a/src/arch/aarch64/start/hermit_entry.rs
+++ b/src/arch/aarch64/start/hermit_entry.rs
@@ -91,7 +91,9 @@ pub unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_i
 	dsb(SY);
 
 	if cpu_id == 0 {
-		env::set_start_info(*boot_info.unwrap());
+		unsafe {
+			env::set_start_info(*boot_info.unwrap());
+		}
 		crate::rt::boot_processor_main()
 	} else {
 		#[cfg(not(feature = "smp"))]

--- a/src/arch/riscv64/start/hermit_entry.rs
+++ b/src/arch/riscv64/start/hermit_entry.rs
@@ -53,7 +53,9 @@ unsafe extern "C" fn pre_init(hart_id: usize, boot_info: Option<&'static RawBoot
 	if CPU_ONLINE.load(Ordering::Acquire) == 0 {
 		crate::logging::KERNEL_LOGGER.set_time(true);
 
-		env::set_start_info(*boot_info.unwrap());
+		unsafe {
+			env::set_start_info(*boot_info.unwrap());
+		}
 		let fdt = env::start_info().fdt().unwrap();
 		// Init HART_MASK
 		let mut hart_mask = 0;

--- a/src/arch/x86_64/start/hermit_entry.rs
+++ b/src/arch/x86_64/start/hermit_entry.rs
@@ -76,7 +76,9 @@ unsafe extern "C" fn pre_init(boot_info: Option<&'static RawBootInfo>, cpu_id: u
 	}
 
 	if cpu_id == 0 {
-		env::set_start_info(*boot_info.unwrap());
+		unsafe {
+			env::set_start_info(*boot_info.unwrap());
+		}
 
 		crate::rt::boot_processor_main()
 	} else {

--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -19,12 +19,12 @@ pub fn start_info() -> &'static impl super::UhyveStartInfo {
 	START_INFO.get().unwrap()
 }
 
-pub fn set_start_info(raw_boot_info: RawBootInfo) {
+pub unsafe fn set_start_info(raw_boot_info: RawBootInfo) {
 	let start_info = BootInfo::from(raw_boot_info);
 	START_INFO.set(start_info).unwrap();
 }
 
-impl StartInfo for BootInfo {
+unsafe impl StartInfo for BootInfo {
 	fn display(&self) -> impl fmt::Display {
 		fmt::from_fn(|f| {
 			if let Some(fdt) = self.fdt() {
@@ -51,7 +51,7 @@ impl StartInfo for BootInfo {
 	}
 }
 
-impl FdtStartInfo for BootInfo {
+unsafe impl FdtStartInfo for BootInfo {
 	fn fdt(&self) -> Option<Fdt<'_>> {
 		let fdt_addr = self.fdt_addr()?;
 		let ptr = ptr::with_exposed_provenance(fdt_addr.get());

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -13,7 +13,7 @@ use core::num::NonZero;
 #[cfg(not(feature = "hermit-entry"))]
 pub use unsupported::*;
 
-pub trait StartInfo {
+pub unsafe trait StartInfo {
 	fn display(&self) -> impl fmt::Display {
 		fmt::from_fn(|f| f.write_str("StartInfo::display not implemented"))
 	}
@@ -40,7 +40,7 @@ pub trait StartInfo {
 	target_arch = "aarch64",
 	target_arch = "riscv64"
 ))]
-pub trait FdtStartInfo: StartInfo {
+pub unsafe trait FdtStartInfo: StartInfo {
 	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
 		None
 	}

--- a/src/env/start_info/unsupported.rs
+++ b/src/env/start_info/unsupported.rs
@@ -12,7 +12,7 @@ pub fn start_info() -> &'static impl super::FdtStartInfo {
 	&panic!()
 }
 
-impl super::StartInfo for ! {
+unsafe impl super::StartInfo for ! {
 	fn bootargs(&self) -> Option<&str> {
 		*self
 	}
@@ -23,7 +23,7 @@ impl super::StartInfo for ! {
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-impl super::FdtStartInfo for ! {
+unsafe impl super::FdtStartInfo for ! {
 	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
 		*self
 	}


### PR DESCRIPTION
This is required since users need to be able to rely on the provided addresses to be correct to be safe.