### PR TITLE
chore(Cargo.toml): remove deprecated authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hermit-kernel"
 version = "0.13.0"
-authors = ["The Hermit Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["unikernel", "libos"]

--- a/hermit-macro/Cargo.toml
+++ b/hermit-macro/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "hermit-macro"
 version = "0.1.0"
-authors = [
-	"Martin Kröning <martin.kroening@eonerc.rwth-aachen.de>",
-]
 edition = "2024"
 description = "Proc macro implementation to defined system calls"
 repository = "https://github.com/hermit-os/kernel"


### PR DESCRIPTION
`package.authors` was deprecated in https://github.com/rust-lang/cargo/pull/15068 and is listed as deprecated in the docs: [The Manifest Format - The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field)

Also see:
- https://github.com/hermit-os/hermit-rs/pull/1063