### PR TITLE
build(deps): upgrade cfg_aliases to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -1191,7 +1191,7 @@ checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
 ]


### PR DESCRIPTION
Upgrading this dependency of nix fixes the following future incompat report:

```console
$ cargo build --package xtask --future-incompat-report
warning: the following packages contain code that will be rejected by a future version of Rust: nix v0.31.2
help: update to a newer version to see if the issue has been fixed
        - nix v0.31.2 has the following newer versions available: 0.31.3
help: ensure the maintainers know of this problem (e.g. creating a bug report if needed)
      or even helping with a fix (e.g. by creating a pull request)
        - nix@0.31.2
        - repository: https://github.com/nix-rust/nix
        - detailed warning command: `cargo report future-incompatibilities --id 1 --package nix@0.31.2`
help: use your own version of the dependency with the `[patch]` section in `Cargo.toml`
      For more information, see:
      https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
note: this report can be shown with `cargo report future-incompatibilities --id 1`
```