### PR TITLE
style(Cargo.toml): cargo-cargofmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,10 +386,7 @@ free-list = { version = "0.3", features = ["x86_64"] }
 raw-cpuid = "11"
 uart_16550 = { version = "0.6", features = ["embedded-io"] }
 x86_64 = { version = "0.15", default-features = false, features = ["instructions", "abi_x86_interrupt"] }
-memory_addresses = { version = "0.4", default-features = false, features = [
-	"x86_64",
-	"conv-x86_64",
-] }
+memory_addresses = { version = "0.4", default-features = false, features = ["x86_64", "conv-x86_64"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "11"
@@ -397,9 +394,7 @@ arm-gic = { version = "0.8" }
 arm-pl011-uart = { version = "0.5", default-features = false }
 fdt = { version = "0.1", features = ["pretty-printing"] }
 semihosting = { version = "0.1", optional = true }
-memory_addresses = { version = "0.4", default-features = false, features = [
-	"aarch64",
-] }
+memory_addresses = { version = "0.4", default-features = false, features = ["aarch64"] }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 fdt = { version = "0.1", features = ["pretty-printing"] }
@@ -408,9 +403,7 @@ sbi-rt = "0.0.4"
 semihosting = { version = "0.1", optional = true }
 tock-registers = { version = "0.10", optional = true }
 trapframe = "0.11"
-memory_addresses = { version = "0.4", default-features = false, features = [
-	"riscv64",
-] }
+memory_addresses = { version = "0.4", default-features = false, features = ["riscv64"] }
 volatile = { version = "0.6", features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,12 @@ tcp = ["net", "smoltcp", "smoltcp/socket-tcp"]
 udp = ["net", "smoltcp", "smoltcp/socket-udp"]
 
 ## Enables DHCPv4 support.
-dhcpv4 = ["net", "smoltcp", "smoltcp/proto-dhcpv4", "smoltcp/socket-dhcpv4"]
+dhcpv4 = [
+	"net",
+	"smoltcp",
+	"smoltcp/proto-dhcpv4",
+	"smoltcp/socket-dhcpv4",
+]
 
 ## Enables DNS support.
 dns = ["net", "smoltcp", "smoltcp/socket-dns"]
@@ -291,7 +296,11 @@ net = []
 ## Enables the virtio driver backend.
 ##
 ## This is automatically enabled by any virtio driver.
-virtio = ["dep:virtio", "dep:mem-barrier", "volatile/derive"]
+virtio = [
+	"dep:virtio",
+	"dep:mem-barrier",
+	"volatile/derive",
+]
 
 ## Enables a warning that this libhermit.a was prebuilt.
 warn-prebuilt = []
@@ -417,13 +426,8 @@ built = { version = "0.8", features = ["git2", "chrono"] }
 llvm-tools = "0.1"
 
 [workspace]
-members = [
-	"hermit-macro",
-	"xtask",
-]
-exclude = [
-	"hermit-builtins",
-]
+members = ["hermit-macro", "xtask"]
+exclude = ["hermit-builtins"]
 
 [workspace.lints.rust]
 # Lint groups
@@ -433,7 +437,7 @@ rust_2018_idioms = "warn"
 # Lints
 redundant_imports = "warn"
 single_use_lifetimes = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(careful)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(careful)"] }
 unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,7 +326,7 @@ workspace = true
 
 [dependencies]
 hermit-macro = { version = "=0.1.0", path = "hermit-macro" }
-virtio = { package = "virtio-spec", version = "0.3", optional = true, features = ["alloc", "mmio", "nightly", "zerocopy"] }
+
 ahash = { version = "0.8", default-features = false }
 align-address = "0.4"
 anstyle = { version = "1", default-features = false }
@@ -353,8 +353,8 @@ hermit-sync = "0.1"
 log = { version = "0.4", default-features = false }
 mem-barrier = { version = "0.1.0", optional = true, features = ["nightly"] }
 num_enum = { version = "0.7", default-features = false }
-pci-ids = { version = "0.2", optional = true }
 pci_types = { version = "0.10" }
+pci-ids = { version = "0.2", optional = true }
 rand_chacha = { version = "0.10", default-features = false }
 shlex = { version = "2", default-features = false }
 simple-shell = { version = "0.0.1", optional = true }
@@ -363,8 +363,9 @@ take-static = "0.1"
 talc = { version = "5" }
 thiserror = { version = "2", default-features = false }
 time = { version = "0.3", default-features = false }
-volatile = "0.6"
 uhyve-interface = { version = "0.3", optional = true }
+virtio = { package = "virtio-spec", version = "0.3", optional = true, features = ["alloc", "mmio", "nightly", "zerocopy"] }
+volatile = "0.6"
 
 [dependencies.smoltcp]
 version = "0.13"
@@ -383,27 +384,27 @@ features = [
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 fdt = { version = "0.1", features = ["pretty-printing"], optional = true }
 free-list = { version = "0.3", features = ["x86_64"] }
+memory_addresses = { version = "0.4", default-features = false, features = ["x86_64", "conv-x86_64"] }
 raw-cpuid = "11"
 uart_16550 = { version = "0.6", features = ["embedded-io"] }
 x86_64 = { version = "0.15", default-features = false, features = ["instructions", "abi_x86_interrupt"] }
-memory_addresses = { version = "0.4", default-features = false, features = ["x86_64", "conv-x86_64"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "11"
 arm-gic = { version = "0.8" }
 arm-pl011-uart = { version = "0.5", default-features = false }
 fdt = { version = "0.1", features = ["pretty-printing"] }
-semihosting = { version = "0.1", optional = true }
 memory_addresses = { version = "0.4", default-features = false, features = ["aarch64"] }
+semihosting = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 fdt = { version = "0.1", features = ["pretty-printing"] }
+memory_addresses = { version = "0.4", default-features = false, features = ["riscv64"] }
 riscv = "0.16"
 sbi-rt = "0.0.4"
 semihosting = { version = "0.1", optional = true }
 tock-registers = { version = "0.10", optional = true }
 trapframe = "0.11"
-memory_addresses = { version = "0.4", default-features = false, features = ["riscv64"] }
 volatile = { version = "0.6", features = ["derive"] }
 
 [dev-dependencies]

--- a/hermit-macro/Cargo.toml
+++ b/hermit-macro/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "hermit-macro"
 version = "0.1.0"
-authors = ["Martin Kröning <martin.kroening@eonerc.rwth-aachen.de>"]
+authors = [
+	"Martin Kröning <martin.kroening@eonerc.rwth-aachen.de>",
+]
 edition = "2024"
 description = "Proc macro implementation to defined system calls"
 repository = "https://github.com/hermit-os/kernel"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,7 +5,15 @@ edition = "2024"
 
 [features]
 default = ["ci"]
-ci = ["dep:libc", "dep:ovmf-prebuilt", "dep:shlex", "dep:sysinfo", "dep:ureq", "dep:vsock", "dep:wait-timeout"]
+ci = [
+	"dep:libc",
+	"dep:ovmf-prebuilt",
+	"dep:shlex",
+	"dep:sysinfo",
+	"dep:ureq",
+	"dep:vsock",
+	"dep:wait-timeout",
+]
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This applies the formatting of https://github.com/hermit-os/kernel/pull/2274 without enforcing it in CI.