### PR TITLE
fix(fs/mem): Detect when mount point is already a virtual directory

### DIFF
--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -661,6 +661,10 @@ impl VfsNode for MemDirectory {
 			async {
 				let (component, rest) = path.split_once("/").unwrap_or((path, ""));
 
+				if component.is_empty() {
+					return Err(Errno::Exist);
+				}
+
 				if let Some(directory) = self.inner.read().await.get(component) {
 					return directory.traverse_mount(rest, obj);
 				}


### PR DESCRIPTION
This was noticed during initramfs testing.