### PR TITLE
fix(vga): compilation with `--features uhyve,vga`

### DIFF
--- a/src/arch/x86_64/kernel/vga.rs
+++ b/src/arch/x86_64/kernel/vga.rs
@@ -134,7 +134,10 @@ impl VgaScreen {
 
 pub fn init() {
 	#[cfg(feature = "uhyve")]
-	if crate::env::is_uhyve() {
+	use crate::env::{self, UhyveStartInfo};
+
+	#[cfg(feature = "uhyve")]
+	if env::start_info().is_uhyve() {
 		return;
 	}
 


### PR DESCRIPTION
This is left over from https://github.com/hermit-os/kernel/pull/2546.