### PR TITLE
refactor(start_info): add `StartInfo` blanket impl based on `FdtStartInfo`

### DIFF
--- a/src/env/start_info/fdt.rs
+++ b/src/env/start_info/fdt.rs
@@ -1,6 +1,10 @@
+use alloc::vec::Vec;
+use core::fmt;
 use core::num::NonZero;
 
 use fdt::Fdt;
+
+use super::{MemmapEntry, MemmapType, Module, StartInfo};
 
 pub unsafe trait FdtStartInfo {
 	fn fdt(&self) -> Option<Fdt<'_>> {
@@ -14,5 +18,69 @@ pub unsafe trait FdtStartInfo {
 
 	fn fdt_addr(&self) -> Option<NonZero<usize>> {
 		None
+	}
+}
+
+unsafe impl<T: FdtStartInfo> StartInfo for T {
+	fn display(&self) -> impl fmt::Display {
+		fmt::from_fn(|f| {
+			if let Some(fdt) = self.fdt() {
+				write!(f, "FDT:\n{fdt:#?}")
+			} else {
+				f.write_str("No FDT.")
+			}
+		})
+	}
+
+	fn bootargs(&self) -> Option<&str> {
+		self.fdt()?.chosen().bootargs()
+	}
+
+	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
+		let rsdp = self
+			.fdt()?
+			.find_node("/hermit,rsdp")?
+			.reg()?
+			.next()?
+			.starting_address
+			.addr();
+		NonZero::new(rsdp)
+	}
+
+	fn modules(&self) -> impl Iterator<Item = Module> {
+		fn initrd(fdt: Fdt<'_>) -> Option<Module> {
+			let chosen = fdt.find_node("/chosen")?;
+
+			let start = chosen.property("linux,initrd-start")?;
+			let end = chosen.property("linux,initrd-end")?;
+
+			let start = start.as_usize()?;
+			let end = end.as_usize()?;
+			let len = end.checked_sub(start)?;
+
+			// SAFETY: The bootloader guarantees the addresses to be valid.
+			let module = unsafe { Module::new(start, len) };
+
+			Some(module)
+		}
+
+		self.fdt().and_then(initrd).into_iter()
+	}
+
+	fn memmap(&self) -> impl Iterator<Item = MemmapEntry> {
+		// FIXME: use super let when available and don't collect
+		let memmap = self
+			.fdt()
+			.iter()
+			.flat_map(|fdt| fdt.find_all_nodes("/memory"))
+			.flat_map(|node| node.reg())
+			.flatten()
+			.map(|region| MemmapEntry {
+				phys_addr: region.starting_address.expose_provenance(),
+				len: region.size.unwrap(),
+				ty: MemmapType::Ram,
+			})
+			.collect::<Vec<_>>();
+		memmap.into_iter()
 	}
 }

--- a/src/env/start_info/fdt.rs
+++ b/src/env/start_info/fdt.rs
@@ -2,9 +2,7 @@ use core::num::NonZero;
 
 use fdt::Fdt;
 
-use super::StartInfo;
-
-pub unsafe trait FdtStartInfo: StartInfo {
+pub unsafe trait FdtStartInfo {
 	fn fdt(&self) -> Option<Fdt<'_>> {
 		let phys_addr = self.fdt_addr()?.get();
 		// We require this to be identity-mapped at boot time for now.

--- a/src/env/start_info/fdt.rs
+++ b/src/env/start_info/fdt.rs
@@ -1,0 +1,20 @@
+use core::num::NonZero;
+
+use fdt::Fdt;
+
+use super::StartInfo;
+
+pub unsafe trait FdtStartInfo: StartInfo {
+	fn fdt(&self) -> Option<Fdt<'_>> {
+		let phys_addr = self.fdt_addr()?.get();
+		// We require this to be identity-mapped at boot time for now.
+		let virt_addr = phys_addr;
+		let ptr = core::ptr::with_exposed_provenance(virt_addr);
+		let fdt = unsafe { Fdt::from_ptr(ptr).ok()? };
+		Some(fdt)
+	}
+
+	fn fdt_addr(&self) -> Option<NonZero<usize>> {
+		None
+	}
+}

--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -10,12 +10,12 @@ use super::{FdtStartInfo, MemmapEntry, MemmapType, Module, StartInfo};
 static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
 #[cfg(not(feature = "uhyve"))]
-pub fn start_info() -> &'static impl FdtStartInfo {
+pub fn start_info() -> &'static (impl StartInfo + FdtStartInfo) {
 	START_INFO.get().unwrap()
 }
 
 #[cfg(feature = "uhyve")]
-pub fn start_info() -> &'static impl super::UhyveStartInfo {
+pub fn start_info() -> &'static (impl StartInfo + super::UhyveStartInfo) {
 	START_INFO.get().unwrap()
 }
 

--- a/src/env/start_info/hermit_entry.rs
+++ b/src/env/start_info/hermit_entry.rs
@@ -1,11 +1,9 @@
-use alloc::vec::Vec;
-use core::fmt;
 use core::num::NonZero;
 
 use hermit_entry::boot_info::{BootInfo, RawBootInfo};
 use hermit_sync::OnceCell;
 
-use super::{FdtStartInfo, MemmapEntry, MemmapType, Module, StartInfo};
+use super::{FdtStartInfo, StartInfo};
 
 static START_INFO: OnceCell<BootInfo> = OnceCell::new();
 
@@ -22,70 +20,6 @@ pub fn start_info() -> &'static (impl StartInfo + super::UhyveStartInfo) {
 pub unsafe fn set_start_info(raw_boot_info: RawBootInfo) {
 	let start_info = BootInfo::from(raw_boot_info);
 	START_INFO.set(start_info).unwrap();
-}
-
-unsafe impl StartInfo for BootInfo {
-	fn display(&self) -> impl fmt::Display {
-		fmt::from_fn(|f| {
-			if let Some(fdt) = self.fdt() {
-				write!(f, "FDT:\n{fdt:#?}")
-			} else {
-				f.write_str("No FDT.")
-			}
-		})
-	}
-
-	fn bootargs(&self) -> Option<&str> {
-		self.fdt()?.chosen().bootargs()
-	}
-
-	fn rsdp_addr(&self) -> Option<NonZero<usize>> {
-		let rsdp = self
-			.fdt()?
-			.find_node("/hermit,rsdp")?
-			.reg()?
-			.next()?
-			.starting_address
-			.addr();
-		NonZero::new(rsdp)
-	}
-
-	fn modules(&self) -> impl Iterator<Item = Module> {
-		fn initrd(fdt: fdt::Fdt<'_>) -> Option<Module> {
-			let chosen = fdt.find_node("/chosen")?;
-
-			let start = chosen.property("linux,initrd-start")?;
-			let end = chosen.property("linux,initrd-end")?;
-
-			let start = start.as_usize()?;
-			let end = end.as_usize()?;
-			let len = end.checked_sub(start)?;
-
-			// SAFETY: The bootloader guarantees the addresses to be valid.
-			let module = unsafe { Module::new(start, len) };
-
-			Some(module)
-		}
-
-		self.fdt().and_then(initrd).into_iter()
-	}
-
-	fn memmap(&self) -> impl Iterator<Item = MemmapEntry> {
-		// FIXME: use super let when available and don't collect
-		let memmap = self
-			.fdt()
-			.iter()
-			.flat_map(|fdt| fdt.find_all_nodes("/memory"))
-			.flat_map(|node| node.reg())
-			.flatten()
-			.map(|region| MemmapEntry {
-				phys_addr: region.starting_address.expose_provenance(),
-				len: region.size.unwrap(),
-				ty: MemmapType::Ram,
-			})
-			.collect::<Vec<_>>();
-		memmap.into_iter()
-	}
 }
 
 unsafe impl FdtStartInfo for BootInfo {

--- a/src/env/start_info/mod.rs
+++ b/src/env/start_info/mod.rs
@@ -9,12 +9,24 @@ cfg_select! {
 	}
 }
 
+#[cfg(any(
+	feature = "hermit-entry",
+	target_arch = "aarch64",
+	target_arch = "riscv64"
+))]
+mod fdt;
 mod memmap;
 mod module;
 
 use core::num::NonZero;
 use core::{fmt, iter};
 
+#[cfg(any(
+	feature = "hermit-entry",
+	target_arch = "aarch64",
+	target_arch = "riscv64"
+))]
+pub use self::fdt::FdtStartInfo;
 pub use self::memmap::{MemmapEntry, MemmapType};
 pub use self::module::Module;
 
@@ -46,26 +58,6 @@ pub unsafe trait StartInfo {
 
 	fn memmap(&self) -> impl Iterator<Item = MemmapEntry> {
 		iter::empty()
-	}
-}
-
-#[cfg(any(
-	feature = "hermit-entry",
-	target_arch = "aarch64",
-	target_arch = "riscv64"
-))]
-pub unsafe trait FdtStartInfo: StartInfo {
-	fn fdt(&self) -> Option<fdt::Fdt<'_>> {
-		let phys_addr = self.fdt_addr()?.get();
-		// We require this to be identity-mapped at boot time for now.
-		let virt_addr = phys_addr;
-		let ptr = core::ptr::with_exposed_provenance(virt_addr);
-		let fdt = unsafe { fdt::Fdt::from_ptr(ptr).ok()? };
-		Some(fdt)
-	}
-
-	fn fdt_addr(&self) -> Option<NonZero<usize>> {
-		None
 	}
 }
 

--- a/src/env/start_info/module.rs
+++ b/src/env/start_info/module.rs
@@ -25,7 +25,14 @@ impl Module {
 	/// # Safety
 	///
 	/// The physical memory must be identity-mapped and valid for creating a slice.
-	#[cfg_attr(not(feature = "hermit-entry"), expect(dead_code))]
+	#[cfg_attr(
+		not(any(
+			feature = "hermit-entry",
+			target_arch = "aarch64",
+			target_arch = "riscv64"
+		)),
+		expect(dead_code)
+	)]
 	pub unsafe fn new(phys_addr: usize, len: usize) -> Self {
 		Self { phys_addr, len }
 	}

--- a/src/env/start_info/unsupported.rs
+++ b/src/env/start_info/unsupported.rs
@@ -14,6 +14,7 @@ pub fn start_info() -> &'static (impl StartInfo + super::FdtStartInfo) {
 	&panic!()
 }
 
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 unsafe impl StartInfo for ! {
 	fn bootargs(&self) -> Option<&str> {
 		*self

--- a/src/env/start_info/unsupported.rs
+++ b/src/env/start_info/unsupported.rs
@@ -1,7 +1,9 @@
 use core::num::NonZero;
 
+use super::StartInfo;
+
 #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
-pub fn start_info() -> &'static impl super::StartInfo {
+pub fn start_info() -> &'static impl StartInfo {
 	#[expect(unreachable_code)]
 	&panic!()
 }
@@ -12,7 +14,7 @@ pub fn start_info() -> &'static impl super::FdtStartInfo {
 	&panic!()
 }
 
-unsafe impl super::StartInfo for ! {
+unsafe impl StartInfo for ! {
 	fn bootargs(&self) -> Option<&str> {
 		*self
 	}

--- a/src/env/start_info/unsupported.rs
+++ b/src/env/start_info/unsupported.rs
@@ -9,7 +9,7 @@ pub fn start_info() -> &'static impl StartInfo {
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-pub fn start_info() -> &'static impl super::FdtStartInfo {
+pub fn start_info() -> &'static (impl StartInfo + super::FdtStartInfo) {
 	#[expect(unreachable_code)]
 	&panic!()
 }


### PR DESCRIPTION
I had to remove the supertrait relationship due to:
- https://github.com/rust-lang/rust/issues/154868