### PR TITLE
fix: prepare build system for Nix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,8 +27,8 @@ fn assemble_x86_64_smp_boot() -> Result<()> {
 	let boot_bc = out_dir.join("boot.bc");
 	let boot_bin = out_dir.join("boot.bin");
 
-	let llvm_as = binutil("llvm-as")?;
-	let rust_lld = binutil("rust-lld")?;
+	let llvm_as = binutil("llvm-as");
+	let lld = lld();
 
 	let assembly = fs::read_to_string(boot_s)?;
 
@@ -55,7 +55,7 @@ module asm "
 		.with_context(|| format!("Failed to run llvm-as from {}", llvm_as.display()))?;
 	assert!(status.success());
 
-	let status = Command::new(&rust_lld)
+	let status = Command::new(&lld)
 		.arg("-flavor")
 		.arg("gnu")
 		.arg("--image-base=0x8000")
@@ -65,27 +65,32 @@ module asm "
 		.arg(&boot_bin)
 		.arg(&boot_bc)
 		.status()
-		.with_context(|| format!("Failed to run rust-lld from {}", rust_lld.display()))?;
+		.with_context(|| format!("Failed to run lld from {}", lld.display()))?;
 	assert!(status.success());
 
 	println!("cargo:rerun-if-changed={}", boot_s.display());
 	Ok(())
 }
 
-fn binutil(name: &str) -> Result<PathBuf> {
+fn lld() -> PathBuf {
+	let rust_lld = binutil("rust-lld");
+
+	if rust_lld.exists() {
+		return rust_lld;
+	}
+
+	binutil("lld")
+}
+
+fn binutil(name: &str) -> PathBuf {
 	let exe = format!("{name}{}", env::consts::EXE_SUFFIX);
 
-	let path = LlvmTools::new()
-		.map_err(|err| match err {
-			llvm_tools::Error::NotFound => anyhow!(
-				"Could not find llvm-tools component\n\
-				\n\
-				Maybe the rustup component `llvm-tools` is missing? Install it through: `rustup component add llvm-tools`"
-			),
-			err => anyhow!("{err:?}"),
-		})?
-		.tool(&exe)
-		.ok_or_else(|| anyhow!("could not find {exe}"))?;
+	if let Some(tool) = LlvmTools::new()
+		.ok()
+		.and_then(|llvm_tools| llvm_tools.tool(&exe))
+	{
+		return tool;
+	}
 
-	Ok(path)
+	PathBuf::from(exe)
 }

--- a/xtask/src/arch.rs
+++ b/xtask/src/arch.rs
@@ -30,7 +30,11 @@ impl Arch {
 		rustup.args(["target", "add", self.triple()]);
 
 		eprintln!("$ {rustup:?}");
-		let status = rustup.status()?;
+		let status = match rustup.status() {
+			Ok(status) => status,
+			Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+			Err(err) => return Err(err),
+		};
 		assert!(status.success());
 
 		Ok(())

--- a/xtask/src/archive.rs
+++ b/xtask/src/archive.rs
@@ -49,8 +49,10 @@ impl Archive {
 		};
 
 		let all_symbols = {
-			let nm = crate::binutil("nm").unwrap();
-			let stdout = cmd!(sh, "{nm} --export-symbols {archive}").output()?.stdout;
+			let llvm_nm = crate::binutil("llvm-nm").unwrap();
+			let stdout = cmd!(sh, "{llvm_nm} --export-symbols {archive}")
+				.output()?
+				.stdout;
 			String::from_utf8(stdout)?
 		};
 
@@ -79,8 +81,8 @@ impl Archive {
 		let rename_path = archive.with_extension("redefine-syms");
 		sh.write_file(&rename_path, symbol_renames)?;
 
-		let objcopy = crate::binutil("objcopy").unwrap();
-		cmd!(sh, "{objcopy} --redefine-syms={rename_path} {archive}").run()?;
+		let llvm_objcopy = crate::binutil("llvm-objcopy").unwrap();
+		cmd!(sh, "{llvm_objcopy} --redefine-syms={rename_path} {archive}").run()?;
 
 		sh.remove_path(&rename_path)?;
 
@@ -92,8 +94,8 @@ impl Archive {
 		let archive = self.as_ref();
 		let file = file.as_ref();
 
-		let ar = crate::binutil("ar").unwrap();
-		cmd!(sh, "{ar} qL {archive} {file}").run()?;
+		let llvm_ar = crate::binutil("llvm-ar").unwrap();
+		cmd!(sh, "{llvm_ar} qL {archive} {file}").run()?;
 
 		Ok(())
 	}

--- a/xtask/src/archive.rs
+++ b/xtask/src/archive.rs
@@ -49,7 +49,7 @@ impl Archive {
 		};
 
 		let all_symbols = {
-			let llvm_nm = crate::binutil("llvm-nm").unwrap();
+			let llvm_nm = crate::binutil("llvm-nm");
 			let stdout = cmd!(sh, "{llvm_nm} --export-symbols {archive}")
 				.output()?
 				.stdout;
@@ -81,7 +81,7 @@ impl Archive {
 		let rename_path = archive.with_extension("redefine-syms");
 		sh.write_file(&rename_path, symbol_renames)?;
 
-		let llvm_objcopy = crate::binutil("llvm-objcopy").unwrap();
+		let llvm_objcopy = crate::binutil("llvm-objcopy");
 		cmd!(sh, "{llvm_objcopy} --redefine-syms={rename_path} {archive}").run()?;
 
 		sh.remove_path(&rename_path)?;
@@ -94,7 +94,7 @@ impl Archive {
 		let archive = self.as_ref();
 		let file = file.as_ref();
 
-		let llvm_ar = crate::binutil("llvm-ar").unwrap();
+		let llvm_ar = crate::binutil("llvm-ar");
 		cmd!(sh, "{llvm_ar} qL {archive} {file}").run()?;
 
 		Ok(())

--- a/xtask/src/binutil.rs
+++ b/xtask/src/binutil.rs
@@ -1,9 +1,9 @@
-use std::io;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
 pub fn binutil(name: &str) -> Option<PathBuf> {
-	static LLVM_TOOLS: LazyLock<LlvmTools> = LazyLock::new(|| LlvmTools::new().unwrap());
+	static LLVM_TOOLS: LazyLock<LlvmTools> =
+		LazyLock::new(|| LlvmTools::new().expect("llvm-tools should be found"));
 
 	LLVM_TOOLS.tool(name)
 }
@@ -13,12 +13,12 @@ struct LlvmTools {
 }
 
 impl LlvmTools {
-	pub fn new() -> io::Result<Self> {
+	pub fn new() -> Option<Self> {
 		let mut rustc = crate::rustc();
 		rustc.args(["--print", "sysroot"]);
 
 		eprintln!("$ {rustc:?}");
-		let output = rustc.output()?;
+		let output = rustc.output().unwrap();
 		assert!(output.status.success());
 
 		let sysroot = String::from_utf8(output.stdout).unwrap();
@@ -27,18 +27,14 @@ impl LlvmTools {
 			.collect::<PathBuf>();
 
 		let example_exe = exe("objdump");
-		for entry in rustlib.read_dir()? {
-			let bin = entry?.path().join("bin");
+		for entry in rustlib.read_dir().unwrap() {
+			let bin = entry.unwrap().path().join("bin");
 			if bin.join(&example_exe).exists() {
-				return Ok(Self { bin });
+				return Some(Self { bin });
 			}
 		}
-		Err(io::Error::new(
-			io::ErrorKind::NotFound,
-			"Could not find llvm-tools component\n\
-			\n\
-			Maybe the rustup component `llvm-tools` is missing? Install it through: `rustup component add llvm-tools`",
-		))
+
+		None
 	}
 
 	pub fn tool(&self, name: &str) -> Option<PathBuf> {

--- a/xtask/src/binutil.rs
+++ b/xtask/src/binutil.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-pub fn binutil(name: &str) -> Option<PathBuf> {
-	static LLVM_TOOLS: LazyLock<LlvmTools> =
-		LazyLock::new(|| LlvmTools::new().expect("llvm-tools should be found"));
+pub fn binutil(name: &str) -> PathBuf {
+	static LLVM_TOOLS: LazyLock<Option<LlvmTools>> = LazyLock::new(LlvmTools::new);
 
-	LLVM_TOOLS.tool(name)
+	LLVM_TOOLS
+		.as_ref()
+		.and_then(|llvm_tools| llvm_tools.tool(name))
+		.unwrap_or(PathBuf::from(name))
 }
 
 struct LlvmTools {

--- a/xtask/src/binutil.rs
+++ b/xtask/src/binutil.rs
@@ -26,7 +26,7 @@ impl LlvmTools {
 			.iter()
 			.collect::<PathBuf>();
 
-		let example_exe = exe("objdump");
+		let example_exe = exe("llvm-objdump");
 		for entry in rustlib.read_dir().unwrap() {
 			let bin = entry.unwrap().path().join("bin");
 			if bin.join(&example_exe).exists() {
@@ -45,5 +45,5 @@ impl LlvmTools {
 
 fn exe(name: &str) -> String {
 	let exe_suffix = std::env::consts::EXE_SUFFIX;
-	format!("llvm-{name}{exe_suffix}")
+	format!("{name}{exe_suffix}")
 }

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -74,8 +74,8 @@ impl Build {
 		eprintln!("Building hermit-builtins");
 		let mut cargo = crate::cargo();
 		cargo
+			.current_dir("hermit-builtins")
 			.arg("build")
-			.arg("--manifest-path=hermit-builtins/Cargo.toml")
 			.arg("--profile")
 			.arg(self.cargo_build.artifact.builtins_profile_path_component())
 			.args(self.cargo_build.artifact.arch.builtins_cargo_args())

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -780,8 +780,8 @@ fn check_rftrace(image: &Path) -> Result<()> {
 	let sh = crate::sh()?;
 	let image_name = image.file_name().unwrap().to_str().unwrap();
 
-	let nm = crate::binutil("nm").unwrap();
-	let symbols = cmd!(sh, "{nm} --demangle --numeric-sort {image}")
+	let llvm_nm = crate::binutil("llvm-nm").unwrap();
+	let symbols = cmd!(sh, "{llvm_nm} --demangle --numeric-sort {image}")
 		.output()?
 		.stdout;
 	sh.write_file(format!("shared/tracedir/{image_name}.sym"), symbols)?;

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -780,7 +780,7 @@ fn check_rftrace(image: &Path) -> Result<()> {
 	let sh = crate::sh()?;
 	let image_name = image.file_name().unwrap().to_str().unwrap();
 
-	let llvm_nm = crate::binutil("llvm-nm").unwrap();
+	let llvm_nm = crate::binutil("llvm-nm");
 	let symbols = cmd!(sh, "{llvm_nm} --demangle --numeric-sort {image}")
 		.output()?
 		.stdout;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -99,7 +99,9 @@ fn sanitize(cmd: &str) -> Command {
 	env::vars()
 		.filter(|(key, _value)| {
 			key.starts_with("CARGO") && !key.starts_with("CARGO_HOME")
-				|| key.starts_with("RUST") && !key.starts_with("RUSTUP_HOME")
+				|| key.starts_with("RUST")
+					&& !key.starts_with("RUSTUP_HOME")
+					&& !key.starts_with("RUSTC_BOOTSTRAP")
 		})
 		.for_each(|(key, _value)| {
 			cmd.env_remove(&key);


### PR DESCRIPTION
This PR applies most of @alyssais's patches to make Hermit build with Nix: https://gist.github.com/alyssais/cf9362e46da004cde1cec85e857e01fa

The only thing that I did not apply is disabling build-std for hermit-builtins. `RUSTC_BOOTSTRAP` should be sufficient to enable build-std.