### PR TITLE
fix(scheduler): avoid boot loop when aborting before core scheduler is initialized

### DIFF
--- a/src/arch/aarch64/kernel/core_local.rs
+++ b/src/arch/aarch64/kernel/core_local.rs
@@ -93,6 +93,10 @@ pub(crate) fn core_scheduler() -> &'static mut PerCoreScheduler {
 	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
 }
 
+pub(crate) fn maybe_core_scheduler() -> Option<&'static mut PerCoreScheduler> {
+	unsafe { CoreLocal::get().scheduler.get().as_mut() }
+}
+
 pub(crate) fn ex() -> &'static StaticLocalExecutor<RawSpinMutex, RawRwSpinLock> {
 	&CoreLocal::get().ex
 }

--- a/src/arch/riscv64/kernel/core_local.rs
+++ b/src/arch/riscv64/kernel/core_local.rs
@@ -79,6 +79,10 @@ pub fn core_scheduler() -> &'static mut PerCoreScheduler {
 	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
 }
 
+pub(crate) fn maybe_core_scheduler() -> Option<&'static mut PerCoreScheduler> {
+	unsafe { CoreLocal::get().scheduler.get().as_mut() }
+}
+
 #[inline]
 pub fn set_core_scheduler(scheduler: *mut PerCoreScheduler) {
 	CoreLocal::get().scheduler.set(scheduler);

--- a/src/arch/x86_64/kernel/core_local.rs
+++ b/src/arch/x86_64/kernel/core_local.rs
@@ -104,6 +104,10 @@ pub(crate) fn core_scheduler() -> &'static mut PerCoreScheduler {
 	unsafe { CoreLocal::get().scheduler.get().as_mut().unwrap() }
 }
 
+pub(crate) fn maybe_core_scheduler() -> Option<&'static mut PerCoreScheduler> {
+	unsafe { CoreLocal::get().scheduler.get().as_mut() }
+}
+
 pub(crate) fn ex() -> &'static StaticLocalExecutor<RawSpinMutex, RawRwSpinLock> {
 	&CoreLocal::get().ex
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -846,7 +846,11 @@ fn get_tid() -> TaskId {
 
 #[inline]
 pub(crate) fn abort() -> ! {
-	core_scheduler().exit(-1)
+	let Some(core_scheduler) = maybe_core_scheduler() else {
+		shutdown(-1)
+	};
+
+	core_scheduler.exit(-1)
 }
 
 /// Add a per-core scheduler for the current core.


### PR DESCRIPTION
Found while working on:
- https://github.com/hermit-os/kernel/pull/2650