### PR TITLE
add simple virtio-based block device driver and basic support of a FAT file system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,8 +856,8 @@ dependencies = [
 
 [[package]]
 name = "hadris-common"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 dependencies = [
  "hadris-fixed",
  "hadris-io",
@@ -868,8 +868,8 @@ dependencies = [
 
 [[package]]
 name = "hadris-fat"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -885,13 +885,13 @@ dependencies = [
 
 [[package]]
 name = "hadris-fixed"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 
 [[package]]
 name = "hadris-io"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -901,16 +901,16 @@ dependencies = [
 
 [[package]]
 name = "hadris-macros"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "hadris-path"
-version = "2.1.0"
-source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+version = "2.2.0"
+source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
 
 [[package]]
 name = "hash32"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,21 +57,15 @@ checksum = "cee078b3ed87e2621e0389729e2f032cc0408a4548768ced01678c9451c62237"
 
 [[package]]
 name = "allocator-api2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
-
-[[package]]
-name = "allocator-api2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -244,9 +238,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -268,13 +262,13 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitfield-struct"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ca019570363e800b05ad4fd890734f28ac7b72f563ad8a35079efb793616f8"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -308,7 +302,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -323,9 +317,29 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "byteorder"
@@ -335,9 +349,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "call-once"
@@ -347,14 +361,14 @@ checksum = "3a57a50948117a233b27f9bf73ab74709ab90d245216c4707cc16eea067a50bb"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 1.3.0",
+ "shlex",
 ]
 
 [[package]]
@@ -377,9 +391,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -417,20 +431,20 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -449,9 +463,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_fn"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "const_parse"
@@ -467,9 +481,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -485,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "critical-section"
@@ -529,7 +543,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -549,7 +563,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -613,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "endian-num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +653,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -679,9 +702,9 @@ checksum = "d5b9e9908e50b47ebbc3d6fd66ed295b997c270e8d2312a035bcc62722a160ef"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdt"
@@ -691,20 +714,19 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "float-cmp"
@@ -737,15 +759,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -758,6 +780,24 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -782,14 +822,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
@@ -814,6 +853,64 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "hadris-common"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+dependencies = [
+ "hadris-fixed",
+ "hadris-io",
+ "hadris-path",
+ "heapless",
+ "zerocopy",
+]
+
+[[package]]
+name = "hadris-fat"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "chrono",
+ "hadris-common",
+ "hadris-fixed",
+ "hadris-io",
+ "hadris-macros",
+ "hadris-path",
+ "parse-size",
+ "spin",
+]
+
+[[package]]
+name = "hadris-fixed"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+
+[[package]]
+name = "hadris-io"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "embedded-io",
+ "embedded-io-async",
+]
+
+[[package]]
+name = "hadris-macros"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "hadris-path"
+version = "2.1.0"
+source = "git+https://github.com/stlankes/hadris.git?branch=sync#75efa1b78b1d551251c983ecc01a507f21905794"
 
 [[package]]
 name = "hash32"
@@ -893,6 +990,7 @@ dependencies = [
  "float-cmp",
  "free-list",
  "fuse-abi",
+ "hadris-fat",
  "hashbrown",
  "heapless",
  "hermit-entry",
@@ -911,7 +1009,7 @@ dependencies = [
  "riscv",
  "sbi-rt",
  "semihosting",
- "shlex 2.0.1",
+ "shlex",
  "simple-shell",
  "smallvec",
  "smoltcp",
@@ -935,7 +1033,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -964,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -980,9 +1078,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1039,27 +1137,28 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.89"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1071,9 +1170,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
@@ -1082,21 +1181,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -1133,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lzma-rs"
@@ -1164,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1218,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -1281,7 +1369,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1343,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1381,6 +1469,12 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "paste"
@@ -1463,15 +1557,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -1514,15 +1608,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -1554,15 +1648,6 @@ name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -1602,7 +1687,7 @@ checksum = "6ad9f6dda08d90d091bc0743967cab369b8fe39ea74b26783ba2ca5c0ce39e86"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1626,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1641,18 +1726,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1661,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "safe-mmio"
@@ -1714,7 +1799,7 @@ checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1736,12 +1821,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -1754,9 +1833,9 @@ checksum = "e977035c0f40249ba591c6b8c03b8b5393779817b8db5f29753acf6c012d234a"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1783,6 +1862,15 @@ dependencies = [
  "heapless",
  "log",
  "managed",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1814,9 +1902,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1825,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1860,11 +1948,11 @@ dependencies = [
 
 [[package]]
 name = "talc"
-version = "5.0.4"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a5888b3189a89207eea4190e74387b5db3150d213f84186cac637dcd55259d"
+checksum = "49661c532dfd6e4f570ef10a45cb92f6f4fce5a28245558ae48307b57b40a5b4"
 dependencies = [
- "allocator-api2 0.4.0",
+ "allocator-api2",
  "lock_api",
 ]
 
@@ -1896,7 +1984,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2035,10 +2123,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-spec"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2f32d50a7e480738d6e43ea2048cd1c34cc33362e55d87d1eebd02bd2f563f"
+source = "git+https://github.com/stlankes/virtio-spec-rs?branch=block#94d7608884052f55d0ee869fb6b274d20f14853f"
 dependencies = [
- "allocator-api2 0.3.1",
+ "allocator-api2",
  "bitfield-struct",
  "bitflags 2.13.1",
  "endian-num",
@@ -2071,7 +2158,7 @@ checksum = "65c67ce935f3b4329e473ecaff7bab444fcdc3d1d19f8bae61fabfa90b84f93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2081,7 +2168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
 ]
 
 [[package]]
@@ -2100,19 +2187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.112"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2123,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.112"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2133,31 +2211,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.112"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.112"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2237,7 +2315,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2248,7 +2326,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2377,12 +2455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "x86_64"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,7 +2502,7 @@ dependencies = [
  "home",
  "libc",
  "ovmf-prebuilt",
- "shlex 2.0.1",
+ "shlex",
  "sysinfo",
  "ureq",
  "vsock",
@@ -2455,7 +2527,7 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,8 @@ dependencies = [
 [[package]]
 name = "hadris-common"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde64f152bae3f3769ad9ea577d1dde2b53e6558f7e1d80a7db81357ba3b206c"
 dependencies = [
  "hadris-fixed",
  "hadris-io",
@@ -869,7 +870,8 @@ dependencies = [
 [[package]]
 name = "hadris-fat"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ae9e0e215766441538874f21f12340b6ae3edfb0f4f59b72794131d91bf01b"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -886,12 +888,14 @@ dependencies = [
 [[package]]
 name = "hadris-fixed"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180bcbed00c242dd5536dd3057f9f9a84364cf1ad066d78a2da5553c4a9d626c"
 
 [[package]]
 name = "hadris-io"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221c30d8f5ef8fd4ef384a28b92202c7952fd240e08b76501832550095d09c12"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -902,7 +906,8 @@ dependencies = [
 [[package]]
 name = "hadris-macros"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d9dd36e24610fa44d804c87762d641be064894b2513ce1dda3ce678a36ffe2"
 dependencies = [
  "proc-macro2",
 ]
@@ -910,7 +915,8 @@ dependencies = [
 [[package]]
 name = "hadris-path"
 version = "2.2.0"
-source = "git+https://github.com/hxyulin/hadris.git?branch=main#b11106ee397dbc64b65c63c4d38b1138a541eacc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36bd3d8b538a8115d802da9b1be12effb3cd3f2178be8ccab61079999adedb1f"
 
 [[package]]
 name = "hash32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ enum_dispatch = "0.3"
 env_filter = { version = "2.0.0", default-features = false }
 free-list = "0.3"
 fuse-abi = { version = "0.2", optional = true, features = ["linux"] }
-hadris-fat = { version = "2.1.0", default-features = false, features = ["read", "write", "alloc", "lfn", "async"], optional = true }
+hadris-fat = { version = "2.2.0", default-features = false, features = ["read", "write", "alloc", "lfn", "async"], optional = true }
 hashbrown = { version = "0.17", default-features = false }
 heapless = "0.9"
 hermit-entry = { version = "0.10", features = ["kernel"], optional = true }
@@ -482,7 +482,6 @@ unreadable_literal = "warn"
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
 virtio-spec = {	git = "https://github.com/stlankes/virtio-spec-rs", branch = "block" }
-hadris-fat = { git = "https://github.com/hxyulin/hadris.git", branch = "main" }
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ enum_dispatch = "0.3"
 env_filter = { version = "2.0.0", default-features = false }
 free-list = "0.3"
 fuse-abi = { version = "0.2", optional = true, features = ["linux"] }
-hadris-fat = { version = "2.0.0", default-features = false, features = ["read", "write", "alloc", "lfn", "async"], optional = true } 
+hadris-fat = { version = "2.1.0", default-features = false, features = ["read", "write", "alloc", "lfn", "async"], optional = true }
 hashbrown = { version = "0.17", default-features = false }
 heapless = "0.9"
 hermit-entry = { version = "0.10", features = ["kernel"], optional = true }
@@ -482,7 +482,7 @@ unreadable_literal = "warn"
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
 virtio-spec = {	git = "https://github.com/stlankes/virtio-spec-rs", branch = "block" }
-hadris-fat = { git = "https://github.com/stlankes/hadris.git", branch = "sync" }
+hadris-fat = { git = "https://github.com/hxyulin/hadris.git", branch = "main" }
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ gem-net = ["net", "dep:tock-registers"]
 #! ### Virtio Drivers
 
 ## Enables the virtio-blk driver.
-virtio-blk = ["virtio"]
+virtio-blk = ["virtio", "hadris-fat"]
 
 ## Enables the virtio-console driver.
 virtio-console = ["virtio"]
@@ -366,6 +366,7 @@ enum_dispatch = "0.3"
 env_filter = { version = "2.0.0", default-features = false }
 free-list = "0.3"
 fuse-abi = { version = "0.2", optional = true, features = ["linux"] }
+hadris-fat = { version = "2.0.0", default-features = false, features = ["read", "write", "alloc", "lfn", "async"], optional = true } 
 hashbrown = { version = "0.17", default-features = false }
 heapless = "0.9"
 hermit-entry = { version = "0.10", features = ["kernel"], optional = true }
@@ -481,6 +482,7 @@ unreadable_literal = "warn"
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
 virtio-spec = {	git = "https://github.com/stlankes/virtio-spec-rs", branch = "block" }
+hadris-fat = { git = "https://github.com/stlankes/hadris.git", branch = "sync" }
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,9 @@ gem-net = ["net", "dep:tock-registers"]
 
 #! ### Virtio Drivers
 
+## Enables the virtio-blk driver.
+virtio-blk = ["virtio"]
+
 ## Enables the virtio-console driver.
 virtio-console = ["virtio"]
 
@@ -477,6 +480,7 @@ unreadable_literal = "warn"
 
 [patch.crates-io]
 safe-mmio = { git = "https://github.com/hermit-os/safe-mmio", branch = "0.3.x" }
+virtio-spec = {	git = "https://github.com/stlankes/virtio-spec-rs", branch = "block" }
 
 [profile.dist]
 inherits = "release"

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -4,6 +4,7 @@ use core::ptr::NonNull;
 use align_address::Align;
 use arm_gic::{IntId, Trigger};
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -16,6 +17,8 @@ use volatile::VolatileRef;
 use crate::arch::kernel::interrupts::GIC;
 use crate::arch::mm::paging::{self, PageSize};
 use crate::drivers::InterruptHandlerMap;
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
@@ -24,6 +27,7 @@ use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-net",
@@ -44,6 +48,8 @@ pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::n
 #[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -53,6 +59,15 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioBlk(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptTicketMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -82,6 +97,7 @@ impl MmioDriver {
 }
 
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock"
@@ -99,6 +115,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-blk")]
+pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_block_driver())
 }
 
 #[cfg(feature = "virtio-rng")]
@@ -231,6 +255,10 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 					match drv {
 						#[cfg(feature = "virtio-console")]
 						VirtioDriver::Console(drv) => crate::console::switch_to_virtio(*drv),
+						#[cfg(feature = "virtio-blk")]
+						VirtioDriver::Blk(drv) => {
+							register_driver(MmioDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
+						}
 						#[cfg(feature = "virtio-fs")]
 						VirtioDriver::Fs(drv) => {
 							register_driver(MmioDriver::VirtioFs(InterruptTicketMutex::new(*drv)));

--- a/src/arch/aarch64/kernel/mmio.rs
+++ b/src/arch/aarch64/kernel/mmio.rs
@@ -4,10 +4,9 @@ use core::ptr::NonNull;
 use align_address::Align;
 use arm_gic::{IntId, Trigger};
 #[cfg(any(
-	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
-	feature = "virtio-vsock",
+	feature = "virtio-vsock"
 ))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
@@ -49,7 +48,7 @@ pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::n
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
+	VirtioBlk(VirtioBlkDriver),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -60,7 +59,7 @@ pub(crate) enum MmioDriver {
 
 impl MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+	fn get_block_driver(&self) -> Option<&VirtioBlkDriver> {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioBlk(drv) => Some(drv),
@@ -118,7 +117,7 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 }
 
 #[cfg(feature = "virtio-blk")]
-pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+pub(crate) fn get_block_driver() -> Option<&'static VirtioBlkDriver> {
 	MMIO_DRIVERS
 		.get()?
 		.iter()
@@ -257,7 +256,7 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 						VirtioDriver::Console(drv) => crate::console::switch_to_virtio(*drv),
 						#[cfg(feature = "virtio-blk")]
 						VirtioDriver::Blk(drv) => {
-							register_driver(MmioDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
+							register_driver(MmioDriver::VirtioBlk(*drv));
 						}
 						#[cfg(feature = "virtio-fs")]
 						VirtioDriver::Fs(drv) => {

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -12,6 +12,7 @@ use volatile::VolatileRef;
 use crate::arch::kernel::interrupts::init_plic;
 #[cfg(all(
 	any(
+		feature = "virtio-blk",
 		feature = "virtio-fs",
 		feature = "virtio-rng",
 		feature = "virtio-vsock",
@@ -21,6 +22,7 @@ use crate::arch::kernel::interrupts::init_plic;
 use crate::arch::kernel::mmio::MmioDriver;
 #[cfg(all(
 	any(
+		feature = "virtio-blk",
 		feature = "virtio-fs",
 		feature = "virtio-rng",
 		feature = "virtio-vsock",
@@ -36,6 +38,7 @@ use crate::drivers::net::gem;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(all(
 	any(
+		feature = "virtio-blk",
 		feature = "virtio-console",
 		feature = "virtio-fs",
 		feature = "virtio-net",
@@ -282,6 +285,12 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 					register_driver(MmioDriver::VirtioVsock(
 						hermit_sync::InterruptSpinMutex::new(*drv),
 					));
+				}
+				#[cfg(feature = "virtio-blk")]
+				Ok(VirtioDriver::Blk(drv)) => {
+					register_driver(MmioDriver::VirtioBlk(hermit_sync::InterruptSpinMutex::new(
+						*drv,
+					)));
 				}
 				Err(DriverError::InitVirtioDevFail(VirtioError::DevNotSupported(0))) => (),
 				Err(err) => error!("Could not initialize virtio-mmio device: {err}"),

--- a/src/arch/riscv64/kernel/devicetree.rs
+++ b/src/arch/riscv64/kernel/devicetree.rs
@@ -288,9 +288,7 @@ pub fn init_drivers(handlers: &mut InterruptHandlerMap) {
 				}
 				#[cfg(feature = "virtio-blk")]
 				Ok(VirtioDriver::Blk(drv)) => {
-					register_driver(MmioDriver::VirtioBlk(hermit_sync::InterruptSpinMutex::new(
-						*drv,
-					)));
+					register_driver(MmioDriver::VirtioBlk(*drv));
 				}
 				Err(DriverError::InitVirtioDevFail(VirtioError::DevNotSupported(0))) => (),
 				Err(err) => error!("Could not initialize virtio-mmio device: {err}"),

--- a/src/arch/riscv64/kernel/mmio.rs
+++ b/src/arch/riscv64/kernel/mmio.rs
@@ -1,10 +1,9 @@
 use alloc::vec::Vec;
 
 #[cfg(any(
-	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
-	feature = "virtio-vsock",
+	feature = "virtio-vsock"
 ))]
 use hermit_sync::InterruptSpinMutex;
 
@@ -28,7 +27,7 @@ pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::n
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	VirtioBlk(InterruptSpinMutex<VirtioBlkDriver>),
+	VirtioBlk(VirtioBlkDriver),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptSpinMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -39,7 +38,7 @@ pub(crate) enum MmioDriver {
 
 impl MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	fn get_block_driver(&self) -> Option<&InterruptSpinMutex<VirtioBlkDriver>> {
+	fn get_block_driver(&self) -> Option<&VirtioBlkDriver> {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioBlk(drv) => Some(drv),
@@ -100,7 +99,7 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptSpinMutex<Virt
 }
 
 #[cfg(feature = "virtio-blk")]
-pub(crate) fn get_block_driver() -> Option<&'static InterruptSpinMutex<VirtioBlkDriver>> {
+pub(crate) fn get_block_driver() -> Option<&'static VirtioBlkDriver> {
 	MMIO_DRIVERS
 		.get()?
 		.iter()

--- a/src/arch/riscv64/kernel/mmio.rs
+++ b/src/arch/riscv64/kernel/mmio.rs
@@ -1,12 +1,15 @@
 use alloc::vec::Vec;
 
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
 ))]
 use hermit_sync::InterruptSpinMutex;
 
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "gem-net")]
@@ -24,6 +27,8 @@ pub(crate) static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::n
 #[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	VirtioBlk(InterruptSpinMutex<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptSpinMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -33,6 +38,15 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	fn get_block_driver(&self) -> Option<&InterruptSpinMutex<VirtioBlkDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioBlk(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptSpinMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -62,6 +76,7 @@ impl MmioDriver {
 }
 
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -82,6 +97,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptSpinMutex<Virt
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-blk")]
+pub(crate) fn get_block_driver() -> Option<&'static InterruptSpinMutex<VirtioBlkDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_block_driver())
 }
 
 #[cfg(feature = "virtio-rng")]

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -6,6 +6,7 @@ use core::{ptr, str};
 use align_address::Align;
 use free_list::PageRange;
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -18,6 +19,8 @@ use volatile::VolatileRef;
 use crate::arch::mm::paging;
 use crate::arch::mm::paging::{BasePageSize, PageSize};
 use crate::drivers::InterruptHandlerMap;
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "virtio-net")]
@@ -26,6 +29,7 @@ use crate::drivers::net::virtio::VirtioNetDriver;
 use crate::drivers::rng::VirtioRngDriver;
 use crate::drivers::virtio::transport::mmio as mmio_virtio;
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-console",
 	feature = "virtio-fs",
 	feature = "virtio-net",
@@ -48,6 +52,8 @@ static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 #[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -57,6 +63,15 @@ pub(crate) enum MmioDriver {
 }
 
 impl MmioDriver {
+	#[cfg(feature = "virtio-blk")]
+	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioBlk(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-fs")]
 	fn get_filesystem_driver(&self) -> Option<&InterruptTicketMutex<VirtioFsDriver>> {
 		#[allow(unreachable_patterns)]
@@ -167,6 +182,7 @@ fn guess_device() -> impl Iterator<Item = (VolatileRef<'static, DeviceRegisters>
 }
 
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
 	feature = "virtio-vsock",
@@ -184,6 +200,14 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 		.get()?
 		.iter()
 		.find_map(|drv| drv.get_filesystem_driver())
+}
+
+#[cfg(feature = "virtio-blk")]
+pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+	MMIO_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_block_driver())
 }
 
 #[cfg(feature = "virtio-rng")]
@@ -211,6 +235,10 @@ fn register_mmio(
 		#[cfg(feature = "virtio-console")]
 		Ok(VirtioDriver::Console(drv)) => {
 			crate::console::switch_to_virtio(*drv);
+		}
+		#[cfg(feature = "virtio-blk")]
+		Ok(VirtioDriver::Blk(drv)) => {
+			register_driver(MmioDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
 		}
 		#[cfg(feature = "virtio-fs")]
 		Ok(VirtioDriver::Fs(drv)) => {

--- a/src/arch/x86_64/kernel/mmio.rs
+++ b/src/arch/x86_64/kernel/mmio.rs
@@ -6,10 +6,9 @@ use core::{ptr, str};
 use align_address::Align;
 use free_list::PageRange;
 #[cfg(any(
-	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-rng",
-	feature = "virtio-vsock",
+	feature = "virtio-vsock"
 ))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
@@ -53,7 +52,7 @@ static MMIO_DRIVERS: InitCell<Vec<MmioDriver>> = InitCell::new(Vec::new());
 #[non_exhaustive]
 pub(crate) enum MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
+	VirtioBlk(VirtioBlkDriver),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -64,7 +63,7 @@ pub(crate) enum MmioDriver {
 
 impl MmioDriver {
 	#[cfg(feature = "virtio-blk")]
-	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+	fn get_block_driver(&self) -> Option<&VirtioBlkDriver> {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioBlk(drv) => Some(drv),
@@ -203,7 +202,7 @@ pub(crate) fn get_filesystem_driver() -> Option<&'static InterruptTicketMutex<Vi
 }
 
 #[cfg(feature = "virtio-blk")]
-pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+pub(crate) fn get_block_driver() -> Option<&'static VirtioBlkDriver> {
 	MMIO_DRIVERS
 		.get()?
 		.iter()
@@ -238,7 +237,7 @@ fn register_mmio(
 		}
 		#[cfg(feature = "virtio-blk")]
 		Ok(VirtioDriver::Blk(drv)) => {
-			register_driver(MmioDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
+			register_driver(MmioDriver::VirtioBlk(*drv));
 		}
 		#[cfg(feature = "virtio-fs")]
 		Ok(VirtioDriver::Fs(drv)) => {

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -137,28 +137,16 @@ impl VirtioBlkDriver {
 		Ok(())
 	}
 
-	/// Writes `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
-	pub async fn write(&self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
-		let _len = self.checked_len(sector, buf.len())?;
-
-		if self.read_only {
-			return Err(Errno::Rofs);
+	/// Starts a set of requests that stay in flight together.
+	///
+	/// The queue is held for the lifetime of the batch, so the completions
+	/// collected by `Batch::finish` can only be the batch's own.
+	pub async fn batch(&self) -> Batch<'_> {
+		Batch {
+			driver: self,
+			vq: self.vq().lock().await,
+			outstanding: 0,
 		}
-
-		let mut data = Vec::with_capacity_in(buf.len(), DeviceAlloc);
-		data.extend_from_slice(buf);
-
-		let send = SmallVec::from_buf([
-			BufferElem::Sized(Box::new_in(
-				RequestHeader::new(RequestType::OUT, sector.try_into().unwrap()),
-				DeviceAlloc,
-			)),
-			BufferElem::Vector(data),
-		]);
-		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
-
-		let mut used = self.dispatch(send, recv).await?;
-		Self::check_status(&mut used)
 	}
 
 	/// Asks the device to write out its cache.
@@ -286,6 +274,85 @@ impl VirtioBlkDriver {
 			// Either VIRTIO_BLK_S_IOERR or a status this driver does not know.
 			Err(Errno::Io)
 		}
+	}
+}
+
+/// Requests submitted together and awaited in one go.
+///
+/// One request per round trip leaves the device idle between them. Submitting
+/// a whole write-back and waiting once lets the device work through the queue
+/// while the driver is still filling it. The batch must be finished, even
+/// after a failed `Batch::write`, or its completions are left for whoever
+/// uses the queue next.
+pub(crate) struct Batch<'a> {
+	driver: &'a VirtioBlkDriver,
+	vq: async_lock::MutexGuard<'a, VirtQueue>,
+	outstanding: usize,
+}
+
+impl Batch<'_> {
+	/// Queues a write without waiting for it.
+	pub fn write(&mut self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
+		self.driver.checked_len(sector, buf.len())?;
+
+		if self.driver.read_only {
+			return Err(Errno::Rofs);
+		}
+
+		let mut data = Vec::with_capacity_in(buf.len(), DeviceAlloc);
+		data.extend_from_slice(buf);
+
+		let send = SmallVec::from_buf([
+			BufferElem::Sized(Box::new_in(
+				RequestHeader::new(RequestType::OUT, sector.try_into().unwrap()),
+				DeviceAlloc,
+			)),
+			BufferElem::Vector(data),
+		]);
+		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
+
+		let tkn = AvailBufferToken::new(send, recv).map_err(|_| Errno::Io)?;
+		self.vq
+			.dispatch(tkn, false, BufferType::Direct)
+			.map_err(|_| Errno::Io)?;
+		self.outstanding += 1;
+
+		Ok(())
+	}
+
+	/// Waits for every queued request and reports the first failure.
+	pub async fn finish(mut self) -> Result<(), Errno> {
+		let mut result = Ok(());
+
+		while self.outstanding > 0 {
+			let vq = &mut self.vq;
+			let used = core::future::poll_fn(|cx| match vq.try_recv() {
+				Ok(used) => Poll::Ready(Ok(used)),
+				Err(VirtqError::NoNewUsed) => {
+					cx.waker().wake_by_ref();
+					Poll::Pending
+				}
+				Err(_) => Poll::Ready(Err(Errno::Io)),
+			})
+			.await;
+
+			self.outstanding -= 1;
+
+			let status = match used {
+				Ok(mut used) => VirtioBlkDriver::check_status(&mut used),
+				// The queue itself failed, so the remaining completions are
+				// not going to arrive either.
+				Err(err) => return Err(err),
+			};
+
+			if let Err(err) = status
+				&& result.is_ok()
+			{
+				result = Err(err);
+			}
+		}
+
+		result
 	}
 }
 

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -7,11 +7,13 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+use hermit_sync::InterruptTicketMutex;
 use smallvec::SmallVec;
 use virtio::blk::{ConfigVolatileFieldAccess, RequestHeader, RequestType, Status};
 use volatile::VolatileRef;
 use volatile::access::ReadOnly;
 
+use crate::arch::kernel::core_local::core_id;
 use crate::config::VIRTIO_MAX_QUEUE_SIZE;
 #[cfg(not(feature = "pci"))]
 use crate::drivers::mmio::get_block_driver;
@@ -28,8 +30,8 @@ use crate::errno::Errno;
 use crate::mm::device_alloc::DeviceAlloc;
 
 /// Runs `f` on the block device driver, if the system has one.
-pub(crate) fn with_driver<T>(f: impl FnOnce(&mut VirtioBlkDriver) -> T) -> Option<T> {
-	get_block_driver().map(|drv| f(&mut drv.lock()))
+pub(crate) fn with_driver<T>(f: impl FnOnce(&VirtioBlkDriver) -> T) -> Option<T> {
+	get_block_driver().map(f)
 }
 
 /// The unit in which the device addresses its storage.
@@ -37,6 +39,20 @@ pub(crate) fn with_driver<T>(f: impl FnOnce(&mut VirtioBlkDriver) -> T) -> Optio
 /// This is fixed by the specification and unrelated to
 /// `VirtioBlkDriver::block_size`, which merely reports the optimal I/O size.
 pub(crate) const SECTOR_SIZE: usize = 512;
+
+/// The number of cores that may ever issue a request.
+///
+/// Deliberately not `get_processor_count`: that one counts the cores which
+/// have finished starting, and at driver initialization time only the boot
+/// processor has, so sizing the queues by it would always settle on one.
+fn possible_cores() -> usize {
+	#[cfg(feature = "smp")]
+	let count = crate::arch::kernel::get_possible_cpus();
+	#[cfg(not(feature = "smp"))]
+	let count = 1;
+
+	usize::try_from(count).unwrap()
+}
 
 /// Wraps a single buffer element in the [`SmallVec`] the virtqueue expects.
 fn single(elem: BufferElem) -> SmallVec<[BufferElem; 2]> {
@@ -51,9 +67,14 @@ fn single(elem: BufferElem) -> SmallVec<[BufferElem; 2]> {
 /// so the driver needs no interrupt handler and keeps device notifications
 /// disabled.
 pub(crate) struct VirtioBlkDriver {
-	pub(super) dev_cfg: super::virtio::DevCfg<Self>,
-	pub(super) caps_coll: UniCapsColl,
-	vq: VirtQueue,
+	/// The request virtqueues, at least one. `Self::vq` picks one per
+	/// requesting core.
+	vqs: Vec<InterruptTicketMutex<VirtQueue>>,
+	/// Reached only by `Self::handle_interrupt` during operation; everything
+	/// else in here belongs to initialization.
+	caps: InterruptTicketMutex<UniCapsColl>,
+	/// Negotiated feature set, fixed once the device is live.
+	features: virtio::blk::F,
 	capacity: usize,
 	blk_size: u32,
 	read_only: bool,
@@ -79,7 +100,7 @@ impl VirtioBlkDriver {
 	}
 
 	/// Reads `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
-	pub fn read(&mut self, sector: usize, buf: &mut [u8]) -> Result<(), Errno> {
+	pub fn read(&self, sector: usize, buf: &mut [u8]) -> Result<(), Errno> {
 		let len = self.checked_len(sector, buf.len())?;
 
 		let send = single(BufferElem::Sized(Box::new_in(
@@ -105,7 +126,7 @@ impl VirtioBlkDriver {
 	}
 
 	/// Writes `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
-	pub fn write(&mut self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
+	pub fn write(&self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
 		let _len = self.checked_len(sector, buf.len())?;
 
 		if self.read_only {
@@ -135,8 +156,8 @@ impl VirtioBlkDriver {
 	/// that withholds it has nothing left to write out once `dispatch`
 	/// returned. Reporting an error here would fail an `fsync` whose data did
 	/// reach the device.
-	pub fn flush(&mut self) -> Result<(), Errno> {
-		if !self.dev_cfg.features.contains(virtio::blk::F::FLUSH) {
+	pub fn flush(&self) -> Result<(), Errno> {
+		if !self.features.contains(virtio::blk::F::FLUSH) {
 			return Ok(());
 		}
 
@@ -168,13 +189,27 @@ impl VirtioBlkDriver {
 		Ok(len)
 	}
 
+	/// Picks the virtqueue for a request issued on the current core.
+	///
+	/// Sharing one queue between cores would make them contend for its lock;
+	/// mapping each core to its own keeps a request on the core that issued
+	/// it. The modulo covers a device that offers fewer queues than the system
+	/// has cores — those cores then share a queue, which costs contention but
+	/// stays correct.
+	fn vq(&self) -> &InterruptTicketMutex<VirtQueue> {
+		let index = usize::try_from(core_id()).unwrap() % self.vqs.len();
+
+		&self.vqs[index]
+	}
+
 	fn dispatch(
-		&mut self,
+		&self,
 		send: SmallVec<[BufferElem; 2]>,
 		recv: SmallVec<[BufferElem; 2]>,
 	) -> Result<crate::drivers::virtio::virtqueue::UsedBufferToken, Errno> {
 		let tkn = AvailBufferToken::new(send, recv).map_err(|_| Errno::Io)?;
-		self.vq
+		self.vq()
+			.lock()
 			.dispatch_blocking(tkn, BufferType::Direct)
 			.map_err(|_| Errno::Io)
 	}
@@ -183,12 +218,14 @@ impl VirtioBlkDriver {
 	///
 	/// The driver completes requests by polling, so nothing has to be done
 	/// with the information — but the ISR status register *must* be read.
-	pub fn handle_interrupt(&mut self) {
+	pub fn handle_interrupt(&self) {
+		let mut caps = self.caps.lock();
+
 		#[cfg_attr(
 			not(all(feature = "pci", target_arch = "x86_64")),
 			expect(irrefutable_let_patterns)
 		)]
-		let InterruptCapability::IsrStatus(isr_stat) = &mut self.caps_coll.int_cap else {
+		let InterruptCapability::IsrStatus(isr_stat) = &mut caps.int_cap else {
 			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
 		};
 
@@ -234,28 +271,44 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 		.union(virtio::blk::F::SEG_MAX)
 		.union(virtio::blk::F::RO)
 		.union(virtio::blk::F::BLK_SIZE)
-		.union(virtio::blk::F::FLUSH);
+		.union(virtio::blk::F::FLUSH)
+		.union(virtio::blk::F::MQ);
 
 	fn init_dev(
 		(mut caps_coll, dev_cfg_raw): (UniCapsColl, VolatileRef<'static, Self::Config, ReadOnly>),
 		handlers: &mut InterruptHandlerMap,
 		irq: Option<InterruptLine>,
 	) -> Result<Self, (VirtioError, UniCapsColl)> {
-		let mut vq = None;
+		let mut queues = Vec::new();
 
-		let dev_cfg = match caps_coll.init_caps(dev_cfg_raw, |caps_coll, dev_cfg| {
-			// The device exposes one request queue unless VIRTIO_BLK_F_MQ is
-			// negotiated, which this driver does not ask for.
-			vq = Some(VirtQueue::Split(
-				SplitVq::new(
-					&mut caps_coll.com_cfg,
-					&caps_coll.notif_cfg,
-					VIRTIO_MAX_QUEUE_SIZE,
-					0,
-					virtio::F::from(dev_cfg.features),
-				)
-				.unwrap(),
-			));
+		let dev_cfg = match caps_coll.init_caps::<Self>(dev_cfg_raw, |caps_coll, dev_cfg| {
+			// `num_queues` only carries a meaning once MQ was negotiated; a
+			// device without it exposes exactly one request queue.
+			let features: virtio::blk::F = dev_cfg.features;
+			let offered = if features.contains(virtio::blk::F::MQ) {
+				dev_cfg.raw.as_ptr().num_queues().read().to_ne()
+			} else {
+				1
+			};
+
+			// More queues than cores would stay idle, since a queue is chosen
+			// by the core issuing the request. A device is free to offer up to
+			// 65535 of them, so the clamp also bounds the memory the rings
+			// take.
+			let count = usize::from(offered.max(1)).min(possible_cores());
+
+			for index in 0..count {
+				queues.push(VirtQueue::Split(
+					SplitVq::new(
+						&mut caps_coll.com_cfg,
+						&caps_coll.notif_cfg,
+						VIRTIO_MAX_QUEUE_SIZE,
+						u16::try_from(index).unwrap(),
+						virtio::F::from(dev_cfg.features),
+					)
+					.unwrap(),
+				));
+			}
 
 			// The driver never waits for interrupts, but the ISR status still
 			// has to be acknowledged on every interrupt
@@ -264,7 +317,7 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 					let irq = irq.unwrap();
 					handlers.entry(irq).or_default().push_back(|| {
 						if let Some(driver) = get_block_driver() {
-							driver.lock().handle_interrupt();
+							driver.handle_interrupt();
 						};
 					});
 					crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
@@ -279,11 +332,11 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 						handlers,
 						|| {
 							if let Some(driver) = get_block_driver() {
-								driver.lock().handle_interrupt();
+								driver.handle_interrupt();
 							};
 						},
 						iter::empty::<(iter::Empty<_>, _)>(),
-						0..1,
+						0..u16::try_from(queues.len()).unwrap(),
 					);
 				}
 			}
@@ -294,9 +347,10 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 			Err(err) => return Err((err, caps_coll)),
 		};
 
-		let mut vq = vq.unwrap();
 		// Requests are awaited by polling, so the device never has to notify us.
-		vq.disable_notifs();
+		for vq in &mut queues {
+			vq.disable_notifs();
+		}
 
 		let cfg = dev_cfg.raw.as_ptr();
 		let features: virtio::blk::F = dev_cfg.features;
@@ -308,17 +362,19 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 			u32::try_from(SECTOR_SIZE).unwrap()
 		};
 		let read_only = features.contains(virtio::blk::F::RO);
+		let vqs: Vec<_> = queues.into_iter().map(InterruptTicketMutex::new).collect();
 
 		info!(
-			"virtio-blk: {capacity} sectors ({} MiB), block size {blk_size}{}",
+			"virtio-blk: {capacity} sectors ({} MiB), block size {blk_size}, {} request queue(s){}",
 			capacity * u64::try_from(SECTOR_SIZE).unwrap() / (1024 * 1024),
+			vqs.len(),
 			if read_only { ", read-only" } else { "" }
 		);
 
 		Ok(Self {
-			dev_cfg,
-			caps_coll,
-			vq,
+			vqs,
+			caps: InterruptTicketMutex::new(caps_coll),
+			features,
 			capacity: capacity.try_into().unwrap(),
 			blk_size,
 			read_only,

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -1,0 +1,343 @@
+//! A virtio-blk driver.
+//!
+//! For details on the device, see [Block Device].
+//!
+//! [Block Device]: https://docs.oasis-open.org/virtio/virtio/v1.4/cs01/virtio-v1.4-cs01.html#x1-3120002
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use smallvec::SmallVec;
+use virtio::blk::{ConfigVolatileFieldAccess, RequestHeader, RequestType, Status};
+use volatile::VolatileRef;
+use volatile::access::ReadOnly;
+
+use crate::config::VIRTIO_MAX_QUEUE_SIZE;
+#[cfg(not(feature = "pci"))]
+use crate::drivers::mmio::get_block_driver;
+#[cfg(feature = "pci")]
+use crate::drivers::pci::get_block_driver;
+use crate::drivers::virtio::error::VirtioError;
+use crate::drivers::virtio::transport::{InterruptCapability, UniCapsColl};
+use crate::drivers::virtio::virtqueue::split::SplitVq;
+use crate::drivers::virtio::virtqueue::{
+	AvailBufferToken, BufferElem, BufferType, VirtQueue, Virtq,
+};
+use crate::drivers::{Driver, InterruptHandlerMap, InterruptLine};
+use crate::errno::Errno;
+use crate::mm::device_alloc::DeviceAlloc;
+
+/// Runs `f` on the block device driver, if the system has one.
+pub(crate) fn with_driver<T>(f: impl FnOnce(&mut VirtioBlkDriver) -> T) -> Option<T> {
+	get_block_driver().map(|drv| f(&mut drv.lock()))
+}
+
+/// The unit in which the device addresses its storage.
+///
+/// This is fixed by the specification and unrelated to
+/// `VirtioBlkDriver::block_size`, which merely reports the optimal I/O size.
+pub(crate) const SECTOR_SIZE: usize = 512;
+
+/// Wraps a single buffer element in the [`SmallVec`] the virtqueue expects.
+fn single(elem: BufferElem) -> SmallVec<[BufferElem; 2]> {
+	let mut vec = SmallVec::new();
+	vec.push(elem);
+	vec
+}
+
+/// Driver for a virtio block device.
+///
+/// Requests are dispatched one at a time and awaited by polling the used ring,
+/// so the driver needs no interrupt handler and keeps device notifications
+/// disabled.
+pub(crate) struct VirtioBlkDriver {
+	pub(super) dev_cfg: super::virtio::DevCfg<Self>,
+	pub(super) caps_coll: UniCapsColl,
+	vq: VirtQueue,
+	capacity: usize,
+	blk_size: u32,
+	read_only: bool,
+}
+
+impl VirtioBlkDriver {
+	/// The capacity of the device in `SECTOR_SIZE`-byte sectors.
+	pub fn capacity(&self) -> usize {
+		self.capacity
+	}
+
+	/// The optimal I/O size in bytes, or `SECTOR_SIZE` if the device does not
+	/// report one.
+	#[allow(dead_code)]
+	pub fn block_size(&self) -> u32 {
+		self.blk_size
+	}
+
+	/// Whether the device refuses writes.
+	#[allow(dead_code)]
+	pub fn is_read_only(&self) -> bool {
+		self.read_only
+	}
+
+	/// Reads `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
+	pub fn read(&mut self, sector: usize, buf: &mut [u8]) -> Result<(), Errno> {
+		let len = self.checked_len(sector, buf.len())?;
+
+		let send = single(BufferElem::Sized(Box::new_in(
+			RequestHeader::new(RequestType::IN, sector.try_into().unwrap()),
+			DeviceAlloc,
+		)));
+		let recv = SmallVec::from_buf([
+			BufferElem::Vector(Vec::with_capacity_in(len, DeviceAlloc)),
+			BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)),
+		]);
+
+		let mut used = self.dispatch(send, recv)?;
+
+		let data = used.used_recv_buff.pop_front_vec().ok_or(Errno::Io)?;
+		Self::check_status(&mut used)?;
+
+		if data.len() != len {
+			return Err(Errno::Io);
+		}
+		buf.copy_from_slice(&data);
+
+		Ok(())
+	}
+
+	/// Writes `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
+	pub fn write(&mut self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
+		let _len = self.checked_len(sector, buf.len())?;
+
+		if self.read_only {
+			return Err(Errno::Rofs);
+		}
+
+		let mut data = Vec::with_capacity_in(buf.len(), DeviceAlloc);
+		data.extend_from_slice(buf);
+
+		let send = SmallVec::from_buf([
+			BufferElem::Sized(Box::new_in(
+				RequestHeader::new(RequestType::OUT, sector.try_into().unwrap()),
+				DeviceAlloc,
+			)),
+			BufferElem::Vector(data),
+		]);
+		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
+
+		let mut used = self.dispatch(send, recv)?;
+		Self::check_status(&mut used)
+	}
+
+	/// Asks the device to write out its cache.
+	///
+	/// Returns `Errno::Nosys` if the device did not negotiate
+	/// [`feature::FLUSH`].
+	pub fn flush(&mut self) -> Result<(), Errno> {
+		if !self.dev_cfg.features.contains(virtio::blk::F::FLUSH) {
+			return Err(Errno::Nosys);
+		}
+
+		let send = single(BufferElem::Sized(Box::new_in(
+			RequestHeader::new(RequestType::FLUSH, 0),
+			DeviceAlloc,
+		)));
+		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
+
+		let mut used = self.dispatch(send, recv)?;
+		Self::check_status(&mut used)
+	}
+
+	/// Validates a transfer against the sector size and the device capacity and
+	/// returns its length in bytes.
+	fn checked_len(&self, sector: usize, len: usize) -> Result<usize, Errno> {
+		if len == 0 || !len.is_multiple_of(SECTOR_SIZE) {
+			return Err(Errno::Inval);
+		}
+
+		let sectors = len / SECTOR_SIZE;
+		if sector
+			.checked_add(sectors)
+			.is_none_or(|end| end > self.capacity)
+		{
+			return Err(Errno::Inval);
+		}
+
+		Ok(len)
+	}
+
+	fn dispatch(
+		&mut self,
+		send: SmallVec<[BufferElem; 2]>,
+		recv: SmallVec<[BufferElem; 2]>,
+	) -> Result<crate::drivers::virtio::virtqueue::UsedBufferToken, Errno> {
+		let tkn = AvailBufferToken::new(send, recv).map_err(|_| Errno::Io)?;
+		self.vq
+			.dispatch_blocking(tkn, BufferType::Direct)
+			.map_err(|_| Errno::Io)
+	}
+
+	/// Acknowledges a device interrupt.
+	///
+	/// The driver completes requests by polling, so nothing has to be done
+	/// with the information — but the ISR status register *must* be read.
+	pub fn handle_interrupt(&mut self) {
+		#[cfg_attr(
+			not(all(feature = "pci", target_arch = "x86_64")),
+			expect(irrefutable_let_patterns)
+		)]
+		let InterruptCapability::IsrStatus(isr_stat) = &mut self.caps_coll.int_cap else {
+			panic!("MSI-X vectors should be configured to the interrupt type-specific handlers.")
+		};
+
+		let _ = isr_stat.acknowledge();
+	}
+
+	/// Pops the trailing status byte and maps it onto an `Errno`.
+	fn check_status(
+		used: &mut crate::drivers::virtio::virtqueue::UsedBufferToken,
+	) -> Result<(), Errno> {
+		// The byte is taken as a `u8` rather than as a `Status`, because the
+		// device is free to write any value.
+		let status = unsafe { used.used_recv_buff.pop_front_downcast::<u8>() };
+		let Some(status) = status.as_deref().copied() else {
+			// The device did not write the status byte at all.
+			return Err(Errno::Io);
+		};
+
+		if status == u8::from(Status::OK) {
+			Ok(())
+		} else if status == u8::from(Status::UNSUPP) {
+			Err(Errno::Nosys)
+		} else {
+			// Either VIRTIO_BLK_S_IOERR or a status this driver does not know.
+			Err(Errno::Io)
+		}
+	}
+}
+
+impl Driver for VirtioBlkDriver {
+	fn get_name() -> &'static str {
+		"virtio-blk"
+	}
+}
+
+impl super::virtio::VirtioDriver for VirtioBlkDriver {
+	type Config = virtio::blk::Config;
+	type Error = error::VirtioBlkError;
+	type DeviceFeatures = virtio::blk::F;
+
+	const MINIMAL_FEATURES: Self::DeviceFeatures = virtio::blk::F::VERSION_1;
+	const OPTIONAL_FEATURES: Self::DeviceFeatures = virtio::blk::F::SIZE_MAX
+		.union(virtio::blk::F::SEG_MAX)
+		.union(virtio::blk::F::RO)
+		.union(virtio::blk::F::BLK_SIZE)
+		.union(virtio::blk::F::FLUSH);
+
+	fn init_dev(
+		(mut caps_coll, dev_cfg_raw): (UniCapsColl, VolatileRef<'static, Self::Config, ReadOnly>),
+		handlers: &mut InterruptHandlerMap,
+		irq: Option<InterruptLine>,
+	) -> Result<Self, (VirtioError, UniCapsColl)> {
+		let mut vq = None;
+
+		let dev_cfg = match caps_coll.init_caps(dev_cfg_raw, |caps_coll, dev_cfg| {
+			// The device exposes one request queue unless VIRTIO_BLK_F_MQ is
+			// negotiated, which this driver does not ask for.
+			vq = Some(VirtQueue::Split(
+				SplitVq::new(
+					&mut caps_coll.com_cfg,
+					&caps_coll.notif_cfg,
+					VIRTIO_MAX_QUEUE_SIZE,
+					0,
+					virtio::F::from(dev_cfg.features),
+				)
+				.unwrap(),
+			));
+
+			// The driver never waits for interrupts, but the ISR status still
+			// has to be acknowledged on every interrupt
+			match &mut caps_coll.int_cap {
+				InterruptCapability::IsrStatus(_) => {
+					let irq = irq.unwrap();
+					handlers.entry(irq).or_default().push_back(|| {
+						if let Some(driver) = get_block_driver() {
+							driver.lock().handle_interrupt();
+						};
+					});
+					crate::arch::kernel::interrupts::add_irq_name(irq, "virtio");
+					info!("Virtio interrupt handler at line {irq}");
+				}
+				#[cfg(all(feature = "pci", target_arch = "x86_64"))]
+				InterruptCapability::Msix(msix_table) => {
+					use core::iter;
+
+					caps_coll.com_cfg.register_msix_vectors(
+						msix_table,
+						handlers,
+						|| {
+							if let Some(driver) = get_block_driver() {
+								driver.lock().handle_interrupt();
+							};
+						},
+						iter::empty::<(iter::Empty<_>, _)>(),
+						0..1,
+					);
+				}
+			}
+
+			Ok(())
+		}) {
+			Ok(dev_cfg) => dev_cfg,
+			Err(err) => return Err((err, caps_coll)),
+		};
+
+		let mut vq = vq.unwrap();
+		// Requests are awaited by polling, so the device never has to notify us.
+		vq.disable_notifs();
+
+		let cfg = dev_cfg.raw.as_ptr();
+		let features: virtio::blk::F = dev_cfg.features;
+
+		let capacity = cfg.capacity().read().to_ne();
+		let blk_size = if features.contains(virtio::blk::F::BLK_SIZE) {
+			cfg.blk_size().read().to_ne()
+		} else {
+			u32::try_from(SECTOR_SIZE).unwrap()
+		};
+		let read_only = features.contains(virtio::blk::F::RO);
+
+		info!(
+			"virtio-blk: {capacity} sectors ({} MiB), block size {blk_size}{}",
+			capacity * u64::try_from(SECTOR_SIZE).unwrap() / (1024 * 1024),
+			if read_only { ", read-only" } else { "" }
+		);
+
+		Ok(Self {
+			dev_cfg,
+			caps_coll,
+			vq,
+			capacity: capacity.try_into().unwrap(),
+			blk_size,
+			read_only,
+		})
+	}
+
+	#[cfg(feature = "pci")]
+	fn no_dev_cfg_err(dev_id: u16) -> Self::Error {
+		error::VirtioBlkError::NoDevCfg(dev_id)
+	}
+}
+
+/// Error module of the virtio block driver.
+pub mod error {
+	use thiserror::Error;
+
+	#[derive(Error, Debug, Copy, Clone)]
+	pub enum VirtioBlkError {
+		#[cfg(feature = "pci")]
+		#[error(
+			"Virtio block device driver failed, for device {0:x}, due to a missing or malformed device config!"
+		)]
+		NoDevCfg(u16),
+	}
+}

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -6,6 +6,7 @@
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::task::Poll;
 
 use hermit_sync::InterruptTicketMutex;
 use smallvec::SmallVec;
@@ -21,6 +22,7 @@ use crate::drivers::mmio::get_block_driver;
 use crate::drivers::pci::get_block_driver;
 use crate::drivers::virtio::error::VirtioError;
 use crate::drivers::virtio::transport::{InterruptCapability, UniCapsColl};
+use crate::drivers::virtio::virtqueue::error::VirtqError;
 use crate::drivers::virtio::virtqueue::split::SplitVq;
 use crate::drivers::virtio::virtqueue::{
 	AvailBufferToken, BufferElem, BufferType, VirtQueue, Virtq,
@@ -28,6 +30,11 @@ use crate::drivers::virtio::virtqueue::{
 use crate::drivers::{Driver, InterruptHandlerMap, InterruptLine};
 use crate::errno::Errno;
 use crate::mm::device_alloc::DeviceAlloc;
+
+/// The block device driver, if the system has one.
+pub(crate) fn driver() -> Option<&'static VirtioBlkDriver> {
+	get_block_driver()
+}
 
 /// Runs `f` on the block device driver, if the system has one.
 pub(crate) fn with_driver<T>(f: impl FnOnce(&VirtioBlkDriver) -> T) -> Option<T> {
@@ -69,7 +76,12 @@ fn single(elem: BufferElem) -> SmallVec<[BufferElem; 2]> {
 pub(crate) struct VirtioBlkDriver {
 	/// The request virtqueues, at least one. `Self::vq` picks one per
 	/// requesting core.
-	vqs: Vec<InterruptTicketMutex<VirtQueue>>,
+	///
+	/// The lock is asynchronous because it is held across the wait for the
+	/// device: a second task on the same queue then yields instead of
+	/// spinning, and the interrupt handler never takes it, so nothing here
+	/// needs interrupts masked.
+	vqs: Vec<async_lock::Mutex<VirtQueue>>,
 	/// Reached only by `Self::handle_interrupt` during operation; everything
 	/// else in here belongs to initialization.
 	caps: InterruptTicketMutex<UniCapsColl>,
@@ -100,7 +112,7 @@ impl VirtioBlkDriver {
 	}
 
 	/// Reads `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
-	pub fn read(&self, sector: usize, buf: &mut [u8]) -> Result<(), Errno> {
+	pub async fn read(&self, sector: usize, buf: &mut [u8]) -> Result<(), Errno> {
 		let len = self.checked_len(sector, buf.len())?;
 
 		let send = single(BufferElem::Sized(Box::new_in(
@@ -112,7 +124,7 @@ impl VirtioBlkDriver {
 			BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)),
 		]);
 
-		let mut used = self.dispatch(send, recv)?;
+		let mut used = self.dispatch(send, recv).await?;
 
 		let data = used.used_recv_buff.pop_front_vec().ok_or(Errno::Io)?;
 		Self::check_status(&mut used)?;
@@ -126,7 +138,7 @@ impl VirtioBlkDriver {
 	}
 
 	/// Writes `buf.len() / SECTOR_SIZE` sectors starting at `sector`.
-	pub fn write(&self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
+	pub async fn write(&self, sector: usize, buf: &[u8]) -> Result<(), Errno> {
 		let _len = self.checked_len(sector, buf.len())?;
 
 		if self.read_only {
@@ -145,7 +157,7 @@ impl VirtioBlkDriver {
 		]);
 		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
 
-		let mut used = self.dispatch(send, recv)?;
+		let mut used = self.dispatch(send, recv).await?;
 		Self::check_status(&mut used)
 	}
 
@@ -156,7 +168,7 @@ impl VirtioBlkDriver {
 	/// that withholds it has nothing left to write out once `dispatch`
 	/// returned. Reporting an error here would fail an `fsync` whose data did
 	/// reach the device.
-	pub fn flush(&self) -> Result<(), Errno> {
+	pub async fn flush(&self) -> Result<(), Errno> {
 		if !self.features.contains(virtio::blk::F::FLUSH) {
 			return Ok(());
 		}
@@ -167,7 +179,7 @@ impl VirtioBlkDriver {
 		)));
 		let recv = single(BufferElem::Sized(Box::<u8, _>::new_uninit_in(DeviceAlloc)));
 
-		let mut used = self.dispatch(send, recv)?;
+		let mut used = self.dispatch(send, recv).await?;
 		Self::check_status(&mut used)
 	}
 
@@ -196,22 +208,44 @@ impl VirtioBlkDriver {
 	/// it. The modulo covers a device that offers fewer queues than the system
 	/// has cores — those cores then share a queue, which costs contention but
 	/// stays correct.
-	fn vq(&self) -> &InterruptTicketMutex<VirtQueue> {
+	fn vq(&self) -> &async_lock::Mutex<VirtQueue> {
 		let index = usize::try_from(core_id()).unwrap() % self.vqs.len();
 
 		&self.vqs[index]
 	}
 
-	fn dispatch(
+	/// Sends a request and waits for the device to complete it.
+	///
+	/// The queue lock is held for the whole exchange, which is what makes the
+	/// `try_recv` below unambiguous: the completion it finds can only be the
+	/// one this call put in. A second task wanting the same queue waits on the
+	/// lock, and because that lock is asynchronous it yields the core rather
+	/// than spinning on it.
+	async fn dispatch(
 		&self,
 		send: SmallVec<[BufferElem; 2]>,
 		recv: SmallVec<[BufferElem; 2]>,
 	) -> Result<crate::drivers::virtio::virtqueue::UsedBufferToken, Errno> {
 		let tkn = AvailBufferToken::new(send, recv).map_err(|_| Errno::Io)?;
-		self.vq()
-			.lock()
-			.dispatch_blocking(tkn, BufferType::Direct)
-			.map_err(|_| Errno::Io)
+		let mut vq = self.vq().lock().await;
+
+		vq.dispatch(tkn, false, BufferType::Direct)
+			.map_err(|_| Errno::Io)?;
+
+		core::future::poll_fn(|cx| match vq.try_recv() {
+			Ok(used) => Poll::Ready(Ok(used)),
+			Err(VirtqError::NoNewUsed) => {
+				// The device is still working. Ask to be polled again rather
+				// than spinning here: `block_on` runs the executor's other
+				// tasks between polls and puts the task to sleep once its
+				// backoff is exhausted, and interrupts stay unmasked
+				// throughout.
+				cx.waker().wake_by_ref();
+				Poll::Pending
+			}
+			Err(_) => Poll::Ready(Err(Errno::Io)),
+		})
+		.await
 	}
 
 	/// Acknowledges a device interrupt.
@@ -362,7 +396,7 @@ impl super::virtio::VirtioDriver for VirtioBlkDriver {
 			u32::try_from(SECTOR_SIZE).unwrap()
 		};
 		let read_only = features.contains(virtio::blk::F::RO);
-		let vqs: Vec<_> = queues.into_iter().map(InterruptTicketMutex::new).collect();
+		let vqs: Vec<_> = queues.into_iter().map(async_lock::Mutex::new).collect();
 
 		info!(
 			"virtio-blk: {capacity} sectors ({} MiB), block size {blk_size}, {} request queue(s){}",

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -131,7 +131,7 @@ impl VirtioBlkDriver {
 	/// Asks the device to write out its cache.
 	///
 	/// Returns `Errno::Nosys` if the device did not negotiate
-	/// [`feature::FLUSH`].
+	/// `feature::FLUSH`.
 	pub fn flush(&mut self) -> Result<(), Errno> {
 		if !self.dev_cfg.features.contains(virtio::blk::F::FLUSH) {
 			return Err(Errno::Nosys);

--- a/src/drivers/blk.rs
+++ b/src/drivers/blk.rs
@@ -130,11 +130,14 @@ impl VirtioBlkDriver {
 
 	/// Asks the device to write out its cache.
 	///
-	/// Returns `Errno::Nosys` if the device did not negotiate
-	/// `feature::FLUSH`.
+	/// Without `virtio::blk::F::FLUSH` this is a no-op. That feature is how a
+	/// device announces that it may hold writes in a volatile cache, so one
+	/// that withholds it has nothing left to write out once `dispatch`
+	/// returned. Reporting an error here would fail an `fsync` whose data did
+	/// reach the device.
 	pub fn flush(&mut self) -> Result<(), Errno> {
 		if !self.dev_cfg.features.contains(virtio::blk::F::FLUSH) {
-			return Err(Errno::Nosys);
+			return Ok(());
 		}
 
 		let send = single(BufferElem::Sized(Box::new_in(

--- a/src/drivers/mmio.rs
+++ b/src/drivers/mmio.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "virtio-blk")]
+pub(crate) use crate::arch::kernel::mmio::get_block_driver;
 #[cfg(feature = "virtio-fs")]
 pub(crate) use crate::arch::kernel::mmio::get_filesystem_driver;
 #[cfg(feature = "virtio-rng")]

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,5 +1,7 @@
 //! A module containing hermit-rs driver, hermit-rs driver trait and driver specific errors.
 
+#[cfg(feature = "virtio-blk")]
+pub mod blk;
 #[cfg(feature = "virtio-console")]
 pub mod console;
 #[cfg(feature = "virtio-fs")]

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -4,10 +4,9 @@ use alloc::vec::Vec;
 use core::fmt;
 
 #[cfg(any(
-	feature = "virtio-blk",
 	feature = "virtio-fs",
-	feature = "virtio-vsock",
 	feature = "virtio-rng",
+	feature = "virtio-vsock"
 ))]
 use hermit_sync::InterruptTicketMutex;
 use hermit_sync::without_interrupts;
@@ -366,7 +365,7 @@ pub(crate) fn print_information() {
 #[non_exhaustive]
 pub(crate) enum PciDriver {
 	#[cfg(feature = "virtio-blk")]
-	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
+	VirtioBlk(VirtioBlkDriver),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -377,7 +376,7 @@ pub(crate) enum PciDriver {
 
 impl PciDriver {
 	#[cfg(feature = "virtio-blk")]
-	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+	fn get_block_driver(&self) -> Option<&VirtioBlkDriver> {
 		#[allow(unreachable_patterns)]
 		match self {
 			Self::VirtioBlk(drv) => Some(drv),
@@ -424,7 +423,7 @@ pub(crate) type NetworkDevice = VirtioNetDriver;
 pub(crate) type NetworkDevice = RTL8139Driver;
 
 #[cfg(feature = "virtio-blk")]
-pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+pub(crate) fn get_block_driver() -> Option<&'static VirtioBlkDriver> {
 	PCI_DRIVERS
 		.get()?
 		.iter()
@@ -482,7 +481,7 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				}
 				#[cfg(feature = "virtio-blk")]
 				Ok(VirtioDriver::Blk(drv)) => {
-					register_driver(PciDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
+					register_driver(PciDriver::VirtioBlk(*drv));
 				}
 				#[cfg(feature = "virtio-fs")]
 				Ok(VirtioDriver::Fs(drv)) => {

--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 #[cfg(any(
+	feature = "virtio-blk",
 	feature = "virtio-fs",
 	feature = "virtio-vsock",
 	feature = "virtio-rng",
@@ -21,6 +22,8 @@ use crate::arch::kernel::pci::PciConfigRegion;
 #[allow(unused_imports)]
 use crate::drivers::Driver;
 use crate::drivers::InterruptHandlerMap;
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-fs")]
 use crate::drivers::fs::VirtioFsDriver;
 #[cfg(feature = "rtl8139")]
@@ -362,6 +365,8 @@ pub(crate) fn print_information() {
 #[allow(clippy::enum_variant_names)]
 #[non_exhaustive]
 pub(crate) enum PciDriver {
+	#[cfg(feature = "virtio-blk")]
+	VirtioBlk(InterruptTicketMutex<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFs(InterruptTicketMutex<VirtioFsDriver>),
 	#[cfg(feature = "virtio-rng")]
@@ -371,6 +376,15 @@ pub(crate) enum PciDriver {
 }
 
 impl PciDriver {
+	#[cfg(feature = "virtio-blk")]
+	fn get_block_driver(&self) -> Option<&InterruptTicketMutex<VirtioBlkDriver>> {
+		#[allow(unreachable_patterns)]
+		match self {
+			Self::VirtioBlk(drv) => Some(drv),
+			_ => None,
+		}
+	}
+
 	#[cfg(feature = "virtio-rng")]
 	fn get_rng_driver(&self) -> Option<&InterruptTicketMutex<VirtioRngDriver>> {
 		#[allow(unreachable_patterns)]
@@ -408,6 +422,14 @@ pub(crate) type NetworkDevice = VirtioNetDriver;
 
 #[cfg(feature = "rtl8139")]
 pub(crate) type NetworkDevice = RTL8139Driver;
+
+#[cfg(feature = "virtio-blk")]
+pub(crate) fn get_block_driver() -> Option<&'static InterruptTicketMutex<VirtioBlkDriver>> {
+	PCI_DRIVERS
+		.get()?
+		.iter()
+		.find_map(|drv| drv.get_block_driver())
+}
 
 #[cfg(feature = "virtio-rng")]
 pub(crate) fn get_rng_driver() -> Option<&'static InterruptTicketMutex<VirtioRngDriver>> {
@@ -457,6 +479,10 @@ pub(crate) fn init(handlers: &mut InterruptHandlerMap) {
 				#[cfg(feature = "virtio-console")]
 				Ok(VirtioDriver::Console(drv)) => {
 					crate::console::switch_to_virtio(*drv);
+				}
+				#[cfg(feature = "virtio-blk")]
+				Ok(VirtioDriver::Blk(drv)) => {
+					register_driver(PciDriver::VirtioBlk(InterruptTicketMutex::new(*drv)));
 				}
 				#[cfg(feature = "virtio-fs")]
 				Ok(VirtioDriver::Fs(drv)) => {

--- a/src/drivers/virtio/mod.rs
+++ b/src/drivers/virtio/mod.rs
@@ -31,6 +31,7 @@ impl VirtioIdExt for virtio::Id {
 	fn as_feature(&self) -> Option<&str> {
 		let feature = match self {
 			Self::Net => "virtio-net",
+			Self::Block => "virtio-blk",
 			Self::Console => "virtio-console",
 			Self::Fs => "virtio-fs",
 			Self::Vsock => "virtio-vsock",
@@ -273,6 +274,8 @@ where
 pub mod error {
 	use thiserror::Error;
 
+	#[cfg(feature = "virtio-blk")]
+	pub use crate::drivers::blk::error::VirtioBlkError;
 	#[cfg(feature = "virtio-console")]
 	pub use crate::drivers::console::error::VirtioConsoleError;
 	#[cfg(feature = "virtio-fs")]
@@ -343,5 +346,9 @@ pub mod error {
 		#[cfg(feature = "virtio-rng")]
 		#[error(transparent)]
 		RngDriver(#[from] VirtioRngError),
+
+		#[cfg(feature = "virtio-blk")]
+		#[error(transparent)]
+		BlkDriver(#[from] VirtioBlkError),
 	}
 }

--- a/src/drivers/virtio/transport/mmio.rs
+++ b/src/drivers/virtio/transport/mmio.rs
@@ -16,6 +16,8 @@ use virtio::{DeviceStatus, le32};
 use volatile::access::ReadOnly;
 use volatile::{VolatilePtr, VolatileRef};
 
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-console")]
 use crate::drivers::console::VirtioConsoleDriver;
 use crate::drivers::error::DriverError;
@@ -324,6 +326,8 @@ impl IsrStatus {
 }
 
 pub(crate) enum VirtioDriver {
+	#[cfg(feature = "virtio-blk")]
+	Blk(alloc::boxed::Box<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-console")]
 	Console(alloc::boxed::Box<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]
@@ -390,6 +394,17 @@ pub(crate) fn init_device(
 			}
 			Err(virtio_error) => {
 				error!("Virtio network driver could not be initialized with device");
+				Err(DriverError::InitVirtioDevFail(virtio_error))
+			}
+		},
+		#[cfg(feature = "virtio-blk")]
+		virtio::Id::Block => match init::<VirtioBlkDriver>(registers, irq_no, handlers) {
+			Ok(virt_blk_drv) => {
+				info!("Virtio block device driver initialized.");
+				Ok(VirtioDriver::Blk(alloc::boxed::Box::new(virt_blk_drv)))
+			}
+			Err(virtio_error) => {
+				error!("Virtio block device driver could not be initialized with device");
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},

--- a/src/drivers/virtio/transport/pci.rs
+++ b/src/drivers/virtio/transport/pci.rs
@@ -21,6 +21,8 @@ use volatile::{VolatilePtr, VolatileRef};
 
 use crate::arch::kernel::pci::PciConfigRegion;
 use crate::drivers::InterruptHandlerMap;
+#[cfg(feature = "virtio-blk")]
+use crate::drivers::blk::VirtioBlkDriver;
 #[cfg(feature = "virtio-console")]
 use crate::drivers::console::VirtioConsoleDriver;
 use crate::drivers::error::DriverError;
@@ -136,6 +138,11 @@ impl CapCfg for CommonCfg {
 
 impl CapCfg for IsrStatusRaw {
 	const TYPE: CapCfgType = CapCfgType::Isr;
+}
+
+#[cfg(feature = "virtio-blk")]
+impl CapCfg for virtio::blk::Config {
+	const TYPE: CapCfgType = CapCfgType::Device;
 }
 
 impl CapCfg for virtio::console::Config {
@@ -726,6 +733,7 @@ pub(crate) fn map_caps(
 #[cfg_attr(
 	not(any(
 		feature = "virtio-console",
+		feature = "virtio-blk",
 		feature = "virtio-fs",
 		all(
 			not(all(target_arch = "riscv64", feature = "gem-net", not(feature = "pci"))),
@@ -810,6 +818,19 @@ pub(crate) fn init_device(
 				Err(DriverError::InitVirtioDevFail(virtio_error))
 			}
 		},
+		#[cfg(feature = "virtio-blk")]
+		virtio::Id::Block => match init::<VirtioBlkDriver>(device, handlers) {
+			Ok(virt_blk_drv) => {
+				info!("Virtio block device driver initialized.");
+				Ok(VirtioDriver::Blk(alloc::boxed::Box::new(virt_blk_drv)))
+			}
+			Err(virtio_error) => {
+				error!(
+					"Virtio block device driver could not be initialized with device: {device_id:x}"
+				);
+				Err(DriverError::InitVirtioDevFail(virtio_error))
+			}
+		},
 		#[cfg(feature = "virtio-rng")]
 		virtio::Id::Rng => match init::<VirtioRngDriver>(device, handlers) {
 			Ok(virt_rng_drv) => {
@@ -850,6 +871,8 @@ pub(crate) fn init_device(
 }
 
 pub(crate) enum VirtioDriver {
+	#[cfg(feature = "virtio-blk")]
+	Blk(alloc::boxed::Box<VirtioBlkDriver>),
 	#[cfg(feature = "virtio-console")]
 	Console(alloc::boxed::Box<VirtioConsoleDriver>),
 	#[cfg(feature = "virtio-fs")]

--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -23,6 +23,8 @@ use crate::fd::{Endpoint, ListenEndpoint, SocketOption};
 use crate::fs::mem::{MemDirectoryInterface, RamFileInterface, RomFileInterface};
 #[cfg(feature = "uhyve")]
 use crate::fs::uhyve::UhyveFileHandle;
+#[cfg(feature = "virtio-blk")]
+use crate::fs::vfat::{VfatDirectoryHandle, VfatFileHandle};
 #[cfg(feature = "virtio-fs")]
 use crate::fs::virtio_fs::{VirtioFsDirectoryHandle, VirtioFsFileHandle};
 use crate::fs::{DirectoryReader, FileAttr, SeekWhence};
@@ -49,6 +51,10 @@ pub(crate) enum Fd {
 	VirtioFsFileHandle(VirtioFsFileHandle),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFsDirectoryHandle(VirtioFsDirectoryHandle),
+	#[cfg(feature = "virtio-blk")]
+	VfatFileHandle(VfatFileHandle),
+	#[cfg(feature = "virtio-blk")]
+	VfatDirectoryHandle(VfatDirectoryHandle),
 	RomFileInterface(RomFileInterface),
 	RamFileInterface(RamFileInterface),
 	MemDirectoryInterface(MemDirectoryInterface),
@@ -97,6 +103,10 @@ fd_from! {
 	VirtioFsFileHandle(VirtioFsFileHandle),
 	#[cfg(feature = "virtio-fs")]
 	VirtioFsDirectoryHandle(VirtioFsDirectoryHandle),
+	#[cfg(feature = "virtio-blk")]
+	VfatFileHandle(VfatFileHandle),
+	#[cfg(feature = "virtio-blk")]
+	VfatDirectoryHandle(VfatDirectoryHandle),
 	RomFileInterface(RomFileInterface),
 	RamFileInterface(RamFileInterface),
 	MemDirectoryInterface(MemDirectoryInterface),
@@ -129,6 +139,10 @@ impl ObjectInterface for Fd {
 			Self::VirtioFsFileHandle(fd) => fd,
 			#[cfg(feature = "virtio-fs")]
 			Self::VirtioFsDirectoryHandle(fd) => fd,
+			#[cfg(feature = "virtio-blk")]
+			Self::VfatFileHandle(fd) => fd,
+			#[cfg(feature = "virtio-blk")]
+			Self::VfatDirectoryHandle(fd) => fd,
 			Self::RomFileInterface(fd) => fd,
 			Self::RamFileInterface(fd) => fd,
 			Self::MemDirectoryInterface(fd) => fd,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -615,3 +615,11 @@ impl Drop for File {
 		}
 	}
 }
+
+/// force completion of pending disk writes (flush cache)
+pub(crate) fn sync() -> io::Result<()> {
+	#[cfg(feature = "virtio-blk")]
+	vfat::sync()?;
+
+	Ok(())
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -2,6 +2,8 @@ pub(crate) mod dev_directory;
 pub(crate) mod mem;
 #[cfg(feature = "uhyve")]
 pub(crate) mod uhyve;
+#[cfg(feature = "virtio-blk")]
+pub(crate) mod vfat;
 #[cfg(feature = "virtio-fs")]
 pub(crate) mod virtio_fs;
 
@@ -330,6 +332,9 @@ pub(crate) fn init() {
 
 	#[cfg(feature = "virtio-fs")]
 	virtio_fs::init();
+
+	#[cfg(feature = "virtio-blk")]
+	vfat::init();
 
 	#[cfg(feature = "uhyve")]
 	use crate::env::UhyveStartInfo;

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -747,6 +747,11 @@ impl ObjectInterface for VfatFileHandle {
 	async fn isatty(&self) -> io::Result<bool> {
 		Ok(false)
 	}
+
+	async fn fsync(&self) -> io::Result<()> {
+		// currently, we can just sync the whole file system
+		volume()?.sync().await.map_err(map_err)
+	}
 }
 
 /// An open directory of the FAT file system.
@@ -821,4 +826,13 @@ impl ObjectInterface for VfatDirectoryHandle {
 	async fn fstat(&self) -> io::Result<FileAttr> {
 		Ok(file_attr(0, NodeKind::Directory))
 	}
+
+	async fn fsync(&self) -> io::Result<()> {
+		// currently, we can just sync the whole file system
+		volume()?.sync().await.map_err(map_err)
+	}
+}
+
+pub(crate) fn sync() -> io::Result<()> {
+	block_on(async { volume()?.sync().await.map_err(map_err) }, None)
 }

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -33,11 +33,11 @@ use crate::time::SystemTime;
 /// transfers of a plain sequential read. The cache keeps the active FAT and
 /// directory sectors resident while data streams past, and has to be several
 /// times [`RUN_SECTORS`] so that one read-ahead cannot displace them.
-const CACHE_SECTORS: usize = 128;
+const CACHE_SECTORS: usize = 256;
 
 /// Number of sectors a cache miss fetches, and the largest write the cache
 /// coalesces adjacent dirty sectors into.
-const RUN_SECTORS: usize = 32;
+const RUN_SECTORS: usize = 64;
 
 /// One cached device sector.
 struct CachedSector {
@@ -211,7 +211,19 @@ impl FatStream {
 		let mut dirty: Vec<usize> = (0..self.cache.len())
 			.filter(|&slot| self.cache[slot].dirty)
 			.collect();
+		if dirty.is_empty() {
+			return Ok(());
+		}
 		dirty.sort_unstable_by_key(|&slot| self.cache[slot].sector);
+
+		// The staging buffer is lent out for the duration so that a transfer
+		// does not allocate, and returned even when one fails. `Batch::write`
+		// copies before it returns, so one buffer serves every run.
+		let mut run = core::mem::take(&mut self.write_run);
+		run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
+
+		let mut batch = driver().ok_or(Errno::Nodev)?.batch().await;
+		let mut submitted = Ok(());
 
 		let mut rest = dirty.as_slice();
 		while let Some((&first, _)) = rest.split_first() {
@@ -227,42 +239,25 @@ impl FatStream {
 			let (group, tail) = rest.split_at(len);
 			rest = tail;
 
-			let sector = self.cache[first].sector;
-			let group: Vec<usize> = group.to_vec();
+			for (index, &slot) in group.iter().enumerate() {
+				run[index * SECTOR_SIZE..(index + 1) * SECTOR_SIZE]
+					.copy_from_slice(&self.cache[slot].data);
+			}
 
-			// As in `slot`, the staging buffer is lent out for the duration so
-			// that the transfer does not allocate, and returned even when it
-			// fails.
-			let mut run = core::mem::take(&mut self.write_run);
-			run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
-
-			let result = self
-				.write_run_group(sector, &group, &mut run[..len * SECTOR_SIZE])
-				.await;
-
-			self.write_run = run;
-
-			result?;
+			submitted = batch.write(self.cache[first].sector, &run[..len * SECTOR_SIZE]);
+			if submitted.is_err() {
+				break;
+			}
 		}
 
-		Ok(())
-	}
+		self.write_run = run;
 
-	/// Writes one run of adjacent dirty sectors and marks them clean.
-	async fn write_run_group(
-		&mut self,
-		sector: usize,
-		group: &[usize],
-		run: &mut [u8],
-	) -> Result<(), Errno> {
-		for (index, &slot) in group.iter().enumerate() {
-			run[index * SECTOR_SIZE..(index + 1) * SECTOR_SIZE]
-				.copy_from_slice(&self.cache[slot].data);
-		}
+		// The sectors stay dirty until the device has acknowledged all of
+		// them; marking them earlier would drop the data on a failed flush.
+		batch.finish().await?;
+		submitted?;
 
-		driver().ok_or(Errno::Nodev)?.write(sector, run).await?;
-
-		for &slot in group {
+		for &slot in &dirty {
 			self.cache[slot].dirty = false;
 		}
 

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -14,7 +14,7 @@ use time::OffsetDateTime;
 
 #[cfg(not(feature = "pci"))]
 use crate::arch::kernel::mmio::get_block_driver;
-use crate::drivers::blk::{SECTOR_SIZE, with_driver};
+use crate::drivers::blk::{SECTOR_SIZE, driver, with_driver};
 #[cfg(feature = "pci")]
 use crate::drivers::pci::get_block_driver;
 use crate::errno::Errno;
@@ -84,27 +84,6 @@ impl FatStream {
 		}
 	}
 
-	/// Lends out one of the staging buffers for a multi-sector transfer.
-	///
-	/// The buffers are owned by the stream so that a transfer does not
-	/// allocate, but the driver call needs `&mut self` for the cache as well.
-	/// Taking the buffer out for the duration and putting it back keeps both
-	/// borrows disjoint.
-	fn with_run<T>(
-		&mut self,
-		pick: fn(&mut Self) -> &mut Vec<u8>,
-		sectors: usize,
-		f: impl FnOnce(&mut Self, &mut [u8]) -> T,
-	) -> T {
-		let mut run = core::mem::take(pick(self));
-		run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
-
-		let result = f(self, &mut run[..sectors * SECTOR_SIZE]);
-
-		*pick(self) = run;
-		result
-	}
-
 	/// The number of sectors the device holds.
 	fn capacity(&self) -> Result<usize, Errno> {
 		with_driver(|drv| drv.capacity()).ok_or(Errno::Nodev)
@@ -114,7 +93,7 @@ impl FatStream {
 	///
 	/// `fill` requests the sector's current contents. A caller that overwrites
 	/// the whole sector can pass `false` and save the read.
-	fn slot(&mut self, sector: usize, fill: bool) -> Result<usize, Errno> {
+	async fn slot(&mut self, sector: usize, fill: bool) -> Result<usize, Errno> {
 		self.clock += 1;
 
 		if let Some(slot) = self.find(sector) {
@@ -123,46 +102,59 @@ impl FatStream {
 		}
 
 		if !fill {
-			return self.install(sector, &[0u8; SECTOR_SIZE]);
+			return self.install(sector, &[0u8; SECTOR_SIZE]).await;
 		}
 
 		// Fetch the requested sector together with the ones that follow it,
 		// bounded by the device. One request for the whole run costs about
 		// what a single-sector one would, and a file system reads forwards.
 		let sectors = RUN_SECTORS.min(self.capacity()? - sector);
-		self.with_run(
-			|this| &mut this.read_run,
-			sectors,
-			|this, run| {
-				with_driver(|drv| drv.read(sector, run)).ok_or(Errno::Nodev)??;
 
-				let mut requested = None;
-				for (index, data) in run.as_chunks::<SECTOR_SIZE>().0.iter().enumerate() {
-					// A sector already in the cache keeps its cached copy: that one
-					// may be dirty, and would then be newer than what the device
-					// just handed us.
-					if this
-						.cache
-						.iter()
-						.any(|entry| entry.sector == sector + index)
-					{
-						continue;
-					}
+		// The staging buffer is owned by the stream so that a transfer does
+		// not allocate, but the work below needs `&mut self` for the cache as
+		// well. Taking it out for the duration keeps the two borrows disjoint;
+		// the inner call may fail, so the buffer goes back either way.
+		let mut run = core::mem::take(&mut self.read_run);
+		run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
 
-					let slot = this.install(sector + index, data)?;
-					if index == 0 {
-						requested = Some(slot);
-					}
-				}
+		let result = self
+			.fill_run(sector, &mut run[..sectors * SECTOR_SIZE])
+			.await;
 
-				match requested {
-					Some(slot) => Ok(slot),
-					// Only reachable if the requested sector was cached after all,
-					// which `slot` has already ruled out above.
-					None => this.find(sector).ok_or(Errno::Io),
-				}
-			},
-		)
+		self.read_run = run;
+		result
+	}
+
+	/// Reads a run of sectors into the cache and returns the slot holding
+	/// `sector`.
+	async fn fill_run(&mut self, sector: usize, run: &mut [u8]) -> Result<usize, Errno> {
+		driver().ok_or(Errno::Nodev)?.read(sector, run).await?;
+
+		let mut requested = None;
+		for (index, data) in run.as_chunks::<SECTOR_SIZE>().0.iter().enumerate() {
+			// A sector already in the cache keeps its cached copy: that one
+			// may be dirty, and would then be newer than what the device
+			// just handed us.
+			if self
+				.cache
+				.iter()
+				.any(|entry| entry.sector == sector + index)
+			{
+				continue;
+			}
+
+			let slot = self.install(sector + index, data).await?;
+			if index == 0 {
+				requested = Some(slot);
+			}
+		}
+
+		match requested {
+			Some(slot) => Ok(slot),
+			// Only reachable if the requested sector was cached after all,
+			// which `slot` has already ruled out above.
+			None => self.find(sector).ok_or(Errno::Io),
+		}
 	}
 
 	/// Returns the slot holding `sector`, if it is cached.
@@ -171,7 +163,7 @@ impl FatStream {
 	}
 
 	/// Puts `data` into a free or freshly evicted slot and returns it.
-	fn install(&mut self, sector: usize, data: &[u8]) -> Result<usize, Errno> {
+	async fn install(&mut self, sector: usize, data: &[u8]) -> Result<usize, Errno> {
 		let entry = CachedSector {
 			sector,
 			data: data.try_into().unwrap(),
@@ -201,7 +193,7 @@ impl FatStream {
 		// merge, and leaves every later eviction free until something is
 		// dirtied again.
 		if self.cache[victim].dirty {
-			self.flush_all()?;
+			self.flush_all().await?;
 		}
 
 		self.cache[victim] = entry;
@@ -215,7 +207,7 @@ impl FatStream {
 	/// chain and the directory entry naming it occupy runs of neighbours — so
 	/// sorting them and writing each run as a whole turns a flush of the
 	/// entire cache into a handful of requests.
-	fn flush_all(&mut self) -> Result<(), Errno> {
+	async fn flush_all(&mut self) -> Result<(), Errno> {
 		let mut dirty: Vec<usize> = (0..self.cache.len())
 			.filter(|&slot| self.cache[slot].dirty)
 			.collect();
@@ -238,24 +230,40 @@ impl FatStream {
 			let sector = self.cache[first].sector;
 			let group: Vec<usize> = group.to_vec();
 
-			self.with_run(
-				|this| &mut this.write_run,
-				len,
-				|this, run| {
-					for (index, &slot) in group.iter().enumerate() {
-						run[index * SECTOR_SIZE..(index + 1) * SECTOR_SIZE]
-							.copy_from_slice(&this.cache[slot].data);
-					}
+			// As in `slot`, the staging buffer is lent out for the duration so
+			// that the transfer does not allocate, and returned even when it
+			// fails.
+			let mut run = core::mem::take(&mut self.write_run);
+			run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
 
-					with_driver(|drv| drv.write(sector, run)).ok_or(Errno::Nodev)??;
+			let result = self
+				.write_run_group(sector, &group, &mut run[..len * SECTOR_SIZE])
+				.await;
 
-					for &slot in &group {
-						this.cache[slot].dirty = false;
-					}
+			self.write_run = run;
+			
+			result?;
+		}
 
-					Ok::<(), Errno>(())
-				},
-			)?;
+		Ok(())
+	}
+
+	/// Writes one run of adjacent dirty sectors and marks them clean.
+	async fn write_run_group(
+		&mut self,
+		sector: usize,
+		group: &[usize],
+		run: &mut [u8],
+	) -> Result<(), Errno> {
+		for (index, &slot) in group.iter().enumerate() {
+			run[index * SECTOR_SIZE..(index + 1) * SECTOR_SIZE]
+				.copy_from_slice(&self.cache[slot].data);
+		}
+
+		driver().ok_or(Errno::Nodev)?.write(sector, run).await?;
+
+		for &slot in group {
+			self.cache[slot].dirty = false;
 		}
 
 		Ok(())
@@ -284,7 +292,7 @@ impl Read for FatStream {
 			return Ok(0);
 		}
 
-		let slot = self.slot(sector, true)?;
+		let slot = self.slot(sector, true).await?;
 
 		// A single call never crosses a sector boundary. `Read::read` is
 		// permitted to return a short count, and the caller loops for the
@@ -319,7 +327,7 @@ impl Write for FatStream {
 
 		// A partial sector is read-modify-write; a full one is overwritten
 		// completely, so reading it first would be wasted.
-		let slot = self.slot(sector, n != SECTOR_SIZE)?;
+		let slot = self.slot(sector, n != SECTOR_SIZE).await?;
 
 		self.cache[slot].data[offset..offset + n].copy_from_slice(&buf[..n]);
 		self.cache[slot].dirty = true;
@@ -329,8 +337,10 @@ impl Write for FatStream {
 	}
 
 	async fn flush(&mut self) -> Result<(), IoError<Errno>> {
-		self.flush_all()?;
-		Ok(with_driver(|drv| drv.flush()).ok_or(Errno::Nodev)??)
+		self.flush_all().await?;
+		driver().ok_or(Errno::Nodev)?.flush().await?;
+
+		Ok(())
 	}
 }
 

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -204,7 +204,7 @@ impl FatStream {
 	/// Writes every dirty sector back, merging adjacent ones into one request.
 	///
 	/// The dirty sectors of a single operation are rarely scattered — a FAT
-	/// chain and the directory entry naming it occupy runs of neighbours — so
+	/// chain and the directory entry naming it occupy runs of neighbors — so
 	/// sorting them and writing each run as a whole turns a flush of the
 	/// entire cache into a handful of requests.
 	async fn flush_all(&mut self) -> Result<(), Errno> {

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -30,9 +30,14 @@ use crate::time::SystemTime;
 /// A FAT walk, the file data it addresses and the directory entry naming the
 /// file live in three different regions of the device. With a single staging
 /// sector they evict each other at every step, which roughly doubles the
-/// transfers of a plain sequential read. Sixteen sectors keep the active FAT
-/// and directory sectors resident while data streams past, for 8 KiB of memory.
-const CACHE_SECTORS: usize = 16;
+/// transfers of a plain sequential read. The cache keeps the active FAT and
+/// directory sectors resident while data streams past, and has to be several
+/// times [`RUN_SECTORS`] so that one read-ahead cannot displace them.
+const CACHE_SECTORS: usize = 128;
+
+/// Number of sectors a cache miss fetches, and the largest write the cache
+/// coalesces adjacent dirty sectors into.
+const RUN_SECTORS: usize = 32;
 
 /// One cached device sector.
 struct CachedSector {
@@ -58,6 +63,14 @@ struct FatStream {
 	clock: u64,
 	/// Absolute byte position of the stream within the device.
 	pos: usize,
+	/// Staging buffer for read-ahead, see `FatStream::with_run`.
+	read_run: Vec<u8>,
+	/// Staging buffer for coalesced write-back.
+	///
+	/// Separate from `read_run` because a read-ahead that has to evict a dirty
+	/// sector flushes from inside its own transfer, and the two would
+	/// otherwise contend for one buffer.
+	write_run: Vec<u8>,
 }
 
 impl FatStream {
@@ -66,23 +79,35 @@ impl FatStream {
 			cache: Vec::with_capacity(CACHE_SECTORS),
 			clock: 0,
 			pos: 0,
+			read_run: Vec::new(),
+			write_run: Vec::new(),
 		}
+	}
+
+	/// Lends out one of the staging buffers for a multi-sector transfer.
+	///
+	/// The buffers are owned by the stream so that a transfer does not
+	/// allocate, but the driver call needs `&mut self` for the cache as well.
+	/// Taking the buffer out for the duration and putting it back keeps both
+	/// borrows disjoint.
+	fn with_run<T>(
+		&mut self,
+		pick: fn(&mut Self) -> &mut Vec<u8>,
+		sectors: usize,
+		f: impl FnOnce(&mut Self, &mut [u8]) -> T,
+	) -> T {
+		let mut run = core::mem::take(pick(self));
+		run.resize(RUN_SECTORS * SECTOR_SIZE, 0);
+
+		let result = f(self, &mut run[..sectors * SECTOR_SIZE]);
+
+		*pick(self) = run;
+		result
 	}
 
 	/// The number of sectors the device holds.
 	fn capacity(&self) -> Result<usize, Errno> {
 		with_driver(|drv| drv.capacity()).ok_or(Errno::Nodev)
-	}
-
-	/// Writes the cached sector in `slot` back if it holds unsaved changes.
-	fn write_back(&mut self, slot: usize) -> Result<(), Errno> {
-		let entry = &mut self.cache[slot];
-		if entry.dirty {
-			with_driver(|drv| drv.write(entry.sector, &entry.data)).ok_or(Errno::Nodev)??;
-			entry.dirty = false;
-		}
-
-		Ok(())
 	}
 
 	/// Returns the slot holding `sector`, reading it in if it is not cached.
@@ -92,19 +117,64 @@ impl FatStream {
 	fn slot(&mut self, sector: usize, fill: bool) -> Result<usize, Errno> {
 		self.clock += 1;
 
-		if let Some(slot) = self.cache.iter().position(|entry| entry.sector == sector) {
+		if let Some(slot) = self.find(sector) {
 			self.cache[slot].used = self.clock;
 			return Ok(slot);
 		}
 
-		let mut data = [0u8; SECTOR_SIZE];
-		if fill {
-			with_driver(|drv| drv.read(sector, &mut data)).ok_or(Errno::Nodev)??;
+		if !fill {
+			return self.install(sector, &[0u8; SECTOR_SIZE]);
 		}
 
+		// Fetch the requested sector together with the ones that follow it,
+		// bounded by the device. One request for the whole run costs about
+		// what a single-sector one would, and a file system reads forwards.
+		let sectors = RUN_SECTORS.min(self.capacity()? - sector);
+		self.with_run(
+			|this| &mut this.read_run,
+			sectors,
+			|this, run| {
+				with_driver(|drv| drv.read(sector, run)).ok_or(Errno::Nodev)??;
+
+				let mut requested = None;
+				for (index, data) in run.as_chunks::<SECTOR_SIZE>().0.iter().enumerate() {
+					// A sector already in the cache keeps its cached copy: that one
+					// may be dirty, and would then be newer than what the device
+					// just handed us.
+					if this
+						.cache
+						.iter()
+						.any(|entry| entry.sector == sector + index)
+					{
+						continue;
+					}
+
+					let slot = this.install(sector + index, data)?;
+					if index == 0 {
+						requested = Some(slot);
+					}
+				}
+
+				match requested {
+					Some(slot) => Ok(slot),
+					// Only reachable if the requested sector was cached after all,
+					// which `slot` has already ruled out above.
+					None => this.find(sector).ok_or(Errno::Io),
+				}
+			},
+		)
+	}
+
+	/// Returns the slot holding `sector`, if it is cached.
+	fn find(&self, sector: usize) -> Option<usize> {
+		self.cache.iter().position(|entry| entry.sector == sector)
+	}
+
+	/// Puts `data` into a free or freshly evicted slot and returns it.
+	fn install(&mut self, sector: usize, data: &[u8]) -> Result<usize, Errno> {
 		let entry = CachedSector {
 			sector,
-			data,
+			data: data.try_into().unwrap(),
 			dirty: false,
 			used: self.clock,
 		};
@@ -114,7 +184,9 @@ impl FatStream {
 			return Ok(self.cache.len() - 1);
 		}
 
-		// Evict the least recently used sector, flushing it if needed.
+		// Evict the least recently used sector. The sectors installed earlier
+		// in this run carry the current clock value and are therefore never
+		// the victim.
 		let victim = self
 			.cache
 			.iter()
@@ -122,16 +194,68 @@ impl FatStream {
 			.min_by_key(|(_, entry)| entry.used)
 			.map(|(slot, _)| slot)
 			.unwrap();
-		self.write_back(victim)?;
+
+		// Writing just the victim back would issue one request per evicted
+		// sector, and a sequential write dirties the whole cache — that was
+		// the bulk of the traffic. Flushing everything instead lets the runs
+		// merge, and leaves every later eviction free until something is
+		// dirtied again.
+		if self.cache[victim].dirty {
+			self.flush_all()?;
+		}
+
 		self.cache[victim] = entry;
 
 		Ok(victim)
 	}
 
-	/// Writes every dirty sector back to the device.
+	/// Writes every dirty sector back, merging adjacent ones into one request.
+	///
+	/// The dirty sectors of a single operation are rarely scattered — a FAT
+	/// chain and the directory entry naming it occupy runs of neighbours — so
+	/// sorting them and writing each run as a whole turns a flush of the
+	/// entire cache into a handful of requests.
 	fn flush_all(&mut self) -> Result<(), Errno> {
-		for slot in 0..self.cache.len() {
-			self.write_back(slot)?;
+		let mut dirty: Vec<usize> = (0..self.cache.len())
+			.filter(|&slot| self.cache[slot].dirty)
+			.collect();
+		dirty.sort_unstable_by_key(|&slot| self.cache[slot].sector);
+
+		let mut rest = dirty.as_slice();
+		while let Some((&first, _)) = rest.split_first() {
+			// Longest prefix of consecutive sectors that still fits the buffer.
+			let len = rest
+				.iter()
+				.enumerate()
+				.take(RUN_SECTORS)
+				.take_while(|&(index, &slot)| {
+					self.cache[slot].sector == self.cache[first].sector + index
+				})
+				.count();
+			let (group, tail) = rest.split_at(len);
+			rest = tail;
+
+			let sector = self.cache[first].sector;
+			let group: Vec<usize> = group.to_vec();
+
+			self.with_run(
+				|this| &mut this.write_run,
+				len,
+				|this, run| {
+					for (index, &slot) in group.iter().enumerate() {
+						run[index * SECTOR_SIZE..(index + 1) * SECTOR_SIZE]
+							.copy_from_slice(&this.cache[slot].data);
+					}
+
+					with_driver(|drv| drv.write(sector, run)).ok_or(Errno::Nodev)??;
+
+					for &slot in &group {
+						this.cache[slot].dirty = false;
+					}
+
+					Ok::<(), Errno>(())
+				},
+			)?;
 		}
 
 		Ok(())

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -241,7 +241,7 @@ impl FatStream {
 				.await;
 
 			self.write_run = run;
-			
+
 			result?;
 		}
 
@@ -415,7 +415,7 @@ pub(crate) fn init() {
 
 	info!("Mounting {} volume at {MOUNT_POINT}", volume.fat_type());
 
-	if VFAT.set(volume).is_err() {
+	if VFAT.set(async_lock::Mutex::new(volume)).is_err() {
 		error!("Unable to mount block device at {MOUNT_POINT}");
 		return;
 	}
@@ -472,7 +472,13 @@ static TIME_PROVIDER: HermitTimeProvider = HermitTimeProvider::new();
 // VFS integration
 // ---------------------------------------------------------------------------
 
-static VFAT: OnceCell<FatVolume<FatStream>> = OnceCell::new();
+static VFAT: OnceCell<async_lock::Mutex<FatVolume<FatStream>>> = OnceCell::new();
+
+// check if VFAT is Sync
+const _: () = {
+	const fn assert_sync<T: Sync>() {}
+	assert_sync::<async_lock::Mutex<FatVolume<FatStream>>>();
+};
 
 /// Where the FAT file system is attached in the VFS.
 const MOUNT_POINT: &str = "/root";
@@ -493,9 +499,16 @@ fn map_err(err: hadris_fat::error::Error) -> Errno {
 	}
 }
 
-/// The mounted volume.
-fn volume() -> io::Result<&'static FatVolume<FatStream>> {
-	VFAT.get().ok_or(Errno::Nodev)
+/// Locks the mounted volume for the duration of one file system operation.
+///
+/// `hadris-fat` locks its sector stream per access, not per operation, so a
+/// lookup and the write that follows it would otherwise be separate critical
+/// sections and two cores could pick the same free directory slot or cluster.
+/// Holding the volume itself is also what keeps that stream lock uncontended,
+/// which matters because it is a spin lock and the driver awaits the device
+/// underneath it.
+async fn volume() -> io::Result<async_lock::MutexGuard<'static, FatVolume<FatStream>>> {
+	Ok(VFAT.get().ok_or(Errno::Nodev)?.lock().await)
 }
 
 /// Joins the directory's own path with a path relative to it.
@@ -508,7 +521,7 @@ fn join(prefix: &str, path: &str) -> String {
 }
 
 /// Finds the entry called `name` directly below `dir`.
-async fn find(dir: &FatDir<'static, FatStream>, name: &str) -> io::Result<Option<FileEntry>> {
+async fn find(dir: &FatDir<'_, FatStream>, name: &str) -> io::Result<Option<FileEntry>> {
 	let mut entries = dir.entries();
 	while let Some(entry) = entries.next_entry().await {
 		let entry = entry.map_err(map_err)?;
@@ -524,8 +537,10 @@ async fn find(dir: &FatDir<'static, FatStream>, name: &str) -> io::Result<Option
 
 /// Walks `path` and returns the directory holding its last component together
 /// with that component's entry, if it exists.
-async fn resolve(path: &str) -> io::Result<(FatDir<'static, FatStream>, Option<FileEntry>)> {
-	let volume = volume()?;
+async fn resolve<'a>(
+	volume: &'a FatVolume<FatStream>,
+	path: &str,
+) -> io::Result<(FatDir<'a, FatStream>, Option<FileEntry>)> {
 	let mut dir = volume.root_dir();
 
 	let mut components = path.split('/').filter(|part| !part.is_empty()).peekable();
@@ -547,8 +562,11 @@ async fn resolve(path: &str) -> io::Result<(FatDir<'static, FatStream>, Option<F
 }
 
 /// Resolves `path` to a directory.
-async fn resolve_dir(path: &str) -> io::Result<FatDir<'static, FatStream>> {
-	let (parent, entry) = resolve(path).await?;
+async fn resolve_dir<'a>(
+	volume: &'a FatVolume<FatStream>,
+	path: &str,
+) -> io::Result<FatDir<'a, FatStream>> {
+	let (parent, entry) = resolve(volume, path).await?;
 
 	match entry {
 		Some(entry) => parent.open_entry(&entry).map_err(map_err),
@@ -558,8 +576,8 @@ async fn resolve_dir(path: &str) -> io::Result<FatDir<'static, FatStream>> {
 }
 
 /// Resolves `path` to an existing file entry.
-async fn resolve_file(path: &str) -> io::Result<FileEntry> {
-	let (_, entry) = resolve(path).await?;
+async fn resolve_file(volume: &FatVolume<FatStream>, path: &str) -> io::Result<FileEntry> {
+	let (_, entry) = resolve(volume, path).await?;
 	let entry = entry.ok_or(Errno::Noent)?;
 
 	if entry.is_directory() {
@@ -591,8 +609,11 @@ fn file_attr(size: u64, kind: NodeKind) -> FileAttr {
 }
 
 /// Lists the entries of the directory at `path`, relative to the FAT root.
-async fn readdir_at(path: String) -> io::Result<Vec<DirectoryEntry>> {
-	let dir = resolve_dir(&path).await?;
+async fn readdir_at(
+	volume: &FatVolume<FatStream>,
+	path: String,
+) -> io::Result<Vec<DirectoryEntry>> {
+	let dir = resolve_dir(volume, &path).await?;
 
 	let mut result = Vec::new();
 	let mut entries = dir.entries();
@@ -633,7 +654,16 @@ impl VfsNode for VfatDirectory {
 	}
 
 	fn traverse_readdir(&self, path: &str) -> io::Result<Vec<DirectoryEntry>> {
-		block_on(readdir_at(join(&self.prefix, path)), None)
+		let path = join(&self.prefix, path);
+
+		block_on(
+			async {
+				let volume = volume().await?;
+
+				readdir_at(&volume, path).await
+			},
+			None,
+		)
 	}
 
 	fn traverse_stat(&self, path: &str) -> io::Result<FileAttr> {
@@ -641,7 +671,9 @@ impl VfsNode for VfatDirectory {
 
 		block_on(
 			async {
-				let (_, entry) = resolve(&path).await?;
+				let volume = volume().await?;
+
+				let (_, entry) = resolve(&volume, &path).await?;
 				let Some(entry) = entry else {
 					// The root of the mounted volume.
 					return Ok(file_attr(0, NodeKind::Directory));
@@ -668,12 +700,14 @@ impl VfsNode for VfatDirectory {
 
 		block_on(
 			async {
-				let (parent, entry) = resolve(&path).await?;
+				let volume = volume().await?;
+
+				let (parent, entry) = resolve(&volume, &path).await?;
 				if entry.is_some() {
 					return Err(Errno::Exist);
 				}
 
-				volume()?.create_dir(&parent, name).await.map_err(map_err)?;
+				volume.create_dir(&parent, name).await.map_err(map_err)?;
 
 				Ok(())
 			},
@@ -684,7 +718,9 @@ impl VfsNode for VfatDirectory {
 	fn traverse_rmdir(&self, path: &str) -> io::Result<()> {
 		block_on(
 			async {
-				let entry = resolve(&join(&self.prefix, path))
+				let volume = volume().await?;
+
+				let entry = resolve(&volume, &join(&self.prefix, path))
 					.await?
 					.1
 					.ok_or(Errno::Noent)?;
@@ -692,7 +728,7 @@ impl VfsNode for VfatDirectory {
 					return Err(Errno::Notdir);
 				}
 
-				volume()?.delete(&entry).await.map_err(map_err)
+				volume.delete(&entry).await.map_err(map_err)
 			},
 			None,
 		)
@@ -701,9 +737,11 @@ impl VfsNode for VfatDirectory {
 	fn traverse_unlink(&self, path: &str) -> io::Result<()> {
 		block_on(
 			async {
-				let entry = resolve_file(&join(&self.prefix, path)).await?;
+				let volume = volume().await?;
 
-				volume()?.delete(&entry).await.map_err(map_err)
+				let entry = resolve_file(&volume, &join(&self.prefix, path)).await?;
+
+				volume.delete(&entry).await.map_err(map_err)
 			},
 			None,
 		)
@@ -719,7 +757,9 @@ impl VfsNode for VfatDirectory {
 
 		block_on(
 			async {
-				let (parent, entry) = resolve(&full).await?;
+				let volume = volume().await?;
+
+				let (parent, entry) = resolve(&volume, &full).await?;
 
 				// A directory is opened as a directory handle, whatever the flags say.
 				if let Some(entry) = &entry
@@ -736,7 +776,7 @@ impl VfsNode for VfatDirectory {
 							return Err(Errno::Exist);
 						}
 						if opt.contains(OpenOption::O_TRUNC) {
-							volume()?.truncate(&entry, 0).await.map_err(map_err)?;
+							volume.truncate(&entry, 0).await.map_err(map_err)?;
 						}
 						entry
 					}
@@ -745,10 +785,7 @@ impl VfsNode for VfatDirectory {
 							return Err(Errno::Noent);
 						}
 						let name = full.rsplit('/').next().ok_or(Errno::Inval)?;
-						volume()?
-							.create_file(&parent, name)
-							.await
-							.map_err(map_err)?
+						volume.create_file(&parent, name).await.map_err(map_err)?
 					}
 				};
 
@@ -789,10 +826,11 @@ impl VfatFileHandle {
 
 impl ObjectInterface for VfatFileHandle {
 	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-		let entry = resolve_file(&self.path).await?;
+		let volume = volume().await?;
+		let entry = resolve_file(&volume, &self.path).await?;
 		let mut pos = self.pos.lock().await;
 
-		let mut reader = volume()?.read_file(&entry).map_err(map_err)?;
+		let mut reader = volume.read_file(&entry).map_err(map_err)?;
 
 		// Walks the FAT chain to the position without touching file data;
 		// positions at or past the end make the following read return 0.
@@ -805,13 +843,14 @@ impl ObjectInterface for VfatFileHandle {
 	}
 
 	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
-		let entry = resolve_file(&self.path).await?;
+		let volume = volume().await?;
+		let entry = resolve_file(&volume, &self.path).await?;
 		let mut pos = self.pos.lock().await;
 
 		// `FileWriter` rewrites the file from the start, so anything before the
 		// offset has to be carried over.
 		let prefix = if *pos > 0 {
-			let mut reader = volume()?.read_file(&entry).map_err(map_err)?;
+			let mut reader = volume.read_file(&entry).map_err(map_err)?;
 			let mut kept = Vec::with_capacity(usize::try_from(*pos).unwrap());
 			let mut scratch = [0u8; SECTOR_SIZE];
 			while u64::try_from(kept.len()).unwrap() < *pos {
@@ -831,7 +870,7 @@ impl ObjectInterface for VfatFileHandle {
 			Vec::new()
 		};
 
-		let mut writer = volume()?.write_file(&entry).map_err(map_err)?;
+		let mut writer = volume.write_file(&entry).map_err(map_err)?;
 		if !prefix.is_empty() {
 			writer.write(&prefix).await.map_err(map_err)?;
 		}
@@ -844,6 +883,7 @@ impl ObjectInterface for VfatFileHandle {
 	}
 
 	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		let volume = volume().await?;
 		let mut pos = self.pos.lock().await;
 		let offset = i64::try_from(offset).unwrap();
 
@@ -851,7 +891,7 @@ impl ObjectInterface for VfatFileHandle {
 			SeekWhence::Set => offset,
 			SeekWhence::Cur => i64::try_from(*pos).unwrap() + offset,
 			SeekWhence::End => {
-				let entry = resolve_file(&self.path).await?;
+				let entry = resolve_file(&volume, &self.path).await?;
 				i64::try_from(entry.len()).unwrap() + offset
 			}
 			_ => return Err(Errno::Inval),
@@ -867,15 +907,17 @@ impl ObjectInterface for VfatFileHandle {
 	}
 
 	async fn fstat(&self) -> io::Result<FileAttr> {
-		let entry = resolve_file(&self.path).await?;
+		let volume = volume().await?;
+		let entry = resolve_file(&volume, &self.path).await?;
 
 		Ok(file_attr(entry.len(), NodeKind::File))
 	}
 
 	async fn truncate(&self, size: usize) -> io::Result<()> {
-		let entry = resolve_file(&self.path).await?;
+		let volume = volume().await?;
+		let entry = resolve_file(&volume, &self.path).await?;
 
-		volume()?.truncate(&entry, size).await.map_err(map_err)
+		volume.truncate(&entry, size).await.map_err(map_err)
 	}
 
 	async fn isatty(&self) -> io::Result<bool> {
@@ -883,8 +925,7 @@ impl ObjectInterface for VfatFileHandle {
 	}
 
 	async fn fsync(&self) -> io::Result<()> {
-		// currently, we can just sync the whole file system
-		volume()?.sync().await.map_err(map_err)
+		volume().await?.sync().await.map_err(map_err)
 	}
 }
 
@@ -907,7 +948,11 @@ impl VfatDirectoryHandle {
 
 impl ObjectInterface for VfatDirectoryHandle {
 	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
-		let entries = readdir_at(self.prefix.clone()).await?;
+		let entries = {
+			let volume = volume().await?;
+
+			readdir_at(&volume, self.prefix.clone()).await?
+		};
 
 		let mut next = self.next.lock().await;
 		let mut offset = 0usize;
@@ -962,11 +1007,13 @@ impl ObjectInterface for VfatDirectoryHandle {
 	}
 
 	async fn fsync(&self) -> io::Result<()> {
-		// currently, we can just sync the whole file system
-		volume()?.sync().await.map_err(map_err)
+		volume().await?.sync().await.map_err(map_err)
 	}
 }
 
 pub(crate) fn sync() -> io::Result<()> {
-	block_on(async { volume()?.sync().await.map_err(map_err) }, None)
+	block_on(
+		async { volume().await?.sync().await.map_err(map_err) },
+		None,
+	)
 }

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -1,0 +1,828 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+
+use hadris_fat::r#async::{
+	Error as IoError, FatDir, FatVolume, FatVolumeReadExt, FatVolumeWriteExt, FileEntry, Read,
+	Seek, SeekFrom, Write,
+};
+use hadris_fat::time::{FatDateTime, TimeProvider};
+use hermit_sync::OnceCell;
+use time::OffsetDateTime;
+
+#[cfg(not(feature = "pci"))]
+use crate::arch::kernel::mmio::get_block_driver;
+use crate::drivers::blk::{SECTOR_SIZE, with_driver};
+#[cfg(feature = "pci")]
+use crate::drivers::pci::get_block_driver;
+use crate::errno::Errno;
+use crate::executor::block_on;
+use crate::fd::{AccessPermission, Fd, ObjectInterface, OpenOption};
+use crate::fs::{self, DirectoryEntry, FileAttr, FileType, NodeKind, SeekWhence, VfsNode};
+use crate::io;
+use crate::syscalls::Dirent64;
+use crate::time::SystemTime;
+
+/// Number of sectors `FatStream` keeps in memory.
+///
+/// A FAT walk, the file data it addresses and the directory entry naming the
+/// file live in three different regions of the device. With a single staging
+/// sector they evict each other at every step, which roughly doubles the
+/// transfers of a plain sequential read. Sixteen sectors keep the active FAT
+/// and directory sectors resident while data streams past, for 8 KiB of memory.
+const CACHE_SECTORS: usize = 16;
+
+/// One cached device sector.
+struct CachedSector {
+	/// Sector index on the device.
+	sector: usize,
+	/// internal buffer to cache sectors
+	data: [u8; SECTOR_SIZE],
+	/// Whether `data` holds changes that are not on the device yet.
+	dirty: bool,
+	/// Value of `FatStream::clock` at the last access, for LRU eviction.
+	used: u64,
+}
+
+/// Byte-granular, cached view of the block device for `hadris-fat`.
+///
+/// The device transfers whole sectors, so this stages them and serves the
+/// byte-wise `Read`/`Write`/`Seek` the file system expects. Writes are cached
+/// and reach the device on eviction or on an explicit flush.
+struct FatStream {
+	/// Sector cache
+	cache: Vec<CachedSector>,
+	/// Monotonic access counter driving LRU eviction.
+	clock: u64,
+	/// Absolute byte position of the stream within the device.
+	pos: usize,
+}
+
+impl FatStream {
+	pub fn new() -> Self {
+		Self {
+			cache: Vec::with_capacity(CACHE_SECTORS),
+			clock: 0,
+			pos: 0,
+		}
+	}
+
+	/// The number of sectors the device holds.
+	fn capacity(&self) -> Result<usize, Errno> {
+		with_driver(|drv| drv.capacity()).ok_or(Errno::Nodev)
+	}
+
+	/// Writes the cached sector in `slot` back if it holds unsaved changes.
+	fn write_back(&mut self, slot: usize) -> Result<(), Errno> {
+		let entry = &mut self.cache[slot];
+		if entry.dirty {
+			with_driver(|drv| drv.write(entry.sector, &entry.data)).ok_or(Errno::Nodev)??;
+			entry.dirty = false;
+		}
+
+		Ok(())
+	}
+
+	/// Returns the slot holding `sector`, reading it in if it is not cached.
+	///
+	/// `fill` requests the sector's current contents. A caller that overwrites
+	/// the whole sector can pass `false` and save the read.
+	fn slot(&mut self, sector: usize, fill: bool) -> Result<usize, Errno> {
+		self.clock += 1;
+
+		if let Some(slot) = self.cache.iter().position(|entry| entry.sector == sector) {
+			self.cache[slot].used = self.clock;
+			return Ok(slot);
+		}
+
+		let mut data = [0u8; SECTOR_SIZE];
+		if fill {
+			with_driver(|drv| drv.read(sector, &mut data)).ok_or(Errno::Nodev)??;
+		}
+
+		let entry = CachedSector {
+			sector,
+			data,
+			dirty: false,
+			used: self.clock,
+		};
+
+		if self.cache.len() < CACHE_SECTORS {
+			self.cache.push(entry);
+			return Ok(self.cache.len() - 1);
+		}
+
+		// Evict the least recently used sector, flushing it if needed.
+		let victim = self
+			.cache
+			.iter()
+			.enumerate()
+			.min_by_key(|(_, entry)| entry.used)
+			.map(|(slot, _)| slot)
+			.unwrap();
+		self.write_back(victim)?;
+		self.cache[victim] = entry;
+
+		Ok(victim)
+	}
+
+	/// Writes every dirty sector back to the device.
+	fn flush_all(&mut self) -> Result<(), Errno> {
+		for slot in 0..self.cache.len() {
+			self.write_back(slot)?;
+		}
+
+		Ok(())
+	}
+}
+
+impl From<Errno> for IoError<Errno> {
+	fn from(e: Errno) -> Self {
+		IoError::from_source(e)
+	}
+}
+
+impl Read for FatStream {
+	type Error = Errno;
+
+	async fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError<Errno>> {
+		if buf.is_empty() {
+			return Ok(0);
+		}
+
+		let sector = self.pos / SECTOR_SIZE;
+		let offset = self.pos % SECTOR_SIZE;
+
+		// Reading past the last sector is end of stream, not a failure.
+		if sector >= self.capacity()? {
+			return Ok(0);
+		}
+
+		let slot = self.slot(sector, true)?;
+
+		// A single call never crosses a sector boundary. `Read::read` is
+		// permitted to return a short count, and the caller loops for the
+		// remainder, so there is no reason to chain sectors here.
+		let n = usize::min(buf.len(), SECTOR_SIZE - offset);
+		buf[..n].copy_from_slice(&self.cache[slot].data[offset..offset + n]);
+		self.pos += n;
+
+		Ok(n)
+	}
+}
+
+impl Write for FatStream {
+	type Error = Errno;
+
+	async fn write(&mut self, buf: &[u8]) -> Result<usize, IoError<Errno>> {
+		if buf.is_empty() {
+			return Ok(0);
+		}
+
+		let sector = self.pos / SECTOR_SIZE;
+		let offset = self.pos % SECTOR_SIZE;
+
+		// The device has a fixed size, so there is nothing to grow into.
+		if sector >= self.capacity()? {
+			return Err(IoError::from_source(Errno::Nospc));
+		}
+
+		// Like `read`, a single call stays within one sector and the caller
+		// loops for the remainder.
+		let n = usize::min(buf.len(), SECTOR_SIZE - offset);
+
+		// A partial sector is read-modify-write; a full one is overwritten
+		// completely, so reading it first would be wasted.
+		let slot = self.slot(sector, n != SECTOR_SIZE)?;
+
+		self.cache[slot].data[offset..offset + n].copy_from_slice(&buf[..n]);
+		self.cache[slot].dirty = true;
+		self.pos += n;
+
+		Ok(n)
+	}
+
+	async fn flush(&mut self) -> Result<(), IoError<Errno>> {
+		self.flush_all()?;
+
+		match with_driver(|drv| drv.flush()) {
+			Some(_) => Ok(()),
+			_ => Err(IoError::from_source(Errno::Nodev)),
+		}
+	}
+}
+
+impl Seek for FatStream {
+	type Error = Errno;
+
+	async fn seek(&mut self, pos: SeekFrom) -> Result<u64, IoError<Errno>> {
+		let end = i64::try_from(self.capacity()? * SECTOR_SIZE).unwrap();
+		let cur = i64::try_from(self.pos).unwrap();
+
+		let new = match pos {
+			SeekFrom::Start(n) => i64::try_from(n).ok(),
+			SeekFrom::Current(offset) => cur.checked_add(offset),
+			SeekFrom::End(offset) => end.checked_add(offset),
+		};
+
+		// Seeking before 0 is an error. Seeking past the end is not:
+		// it only fails once something is actually read or written there.
+		let new = new.filter(|new| *new >= 0).ok_or(Errno::Inval)?;
+
+		// The cache stays valid — it is keyed by sector index, independent of
+		// where the stream happens to point.
+		self.pos = usize::try_from(new).unwrap();
+
+		Ok(new as u64)
+	}
+}
+
+fn format_file_size(size: u64) -> String {
+	const KB: u64 = 1024;
+	const MB: u64 = 1024 * KB;
+	const GB: u64 = 1024 * MB;
+	if size < KB {
+		format!("{size}B")
+	} else if size < MB {
+		format!("{}KB", size / KB)
+	} else if size < GB {
+		format!("{}MB", size / MB)
+	} else {
+		format!("{}GB", size / GB)
+	}
+}
+
+pub(crate) fn init() {
+	debug!("Try to initialize vfat filesystem");
+
+	if get_block_driver().is_none() {
+		return;
+	};
+
+	let stream = FatStream::new();
+	debug!(
+		"Found block device with a capacity of {}",
+		format_file_size(
+			(stream.capacity().unwrap() * SECTOR_SIZE)
+				.try_into()
+				.unwrap()
+		)
+	);
+
+	let volume = block_on(
+		async {
+			FatVolume::builder(stream)
+				.time_provider(&TIME_PROVIDER)
+				.open()
+				.await
+				.map_err(map_err)
+		},
+		None,
+	)
+	.expect("Unable to create FAT volume");
+
+	info!("Mounting {} volume at {MOUNT_POINT}", volume.fat_type());
+
+	if VFAT.set(volume).is_err() {
+		error!("Unable to mount block device at {MOUNT_POINT}");
+		return;
+	}
+
+	if let Err(err) = fs::FILESYSTEM
+		.get()
+		.unwrap()
+		.mount(MOUNT_POINT, Box::new(VfatDirectory::new(String::new())))
+	{
+		error!("Unable to mount block device at {MOUNT_POINT}: {err:?}");
+	}
+}
+
+/// Stamps directory entries with the system's wall-clock time.
+#[derive(Debug)]
+struct HermitTimeProvider;
+
+impl HermitTimeProvider {
+	pub const fn new() -> Self {
+		Self {}
+	}
+}
+
+impl TimeProvider for HermitTimeProvider {
+	fn now(&self) -> FatDateTime {
+		let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
+		let Ok(now) = OffsetDateTime::from_unix_timestamp_nanos(now.as_nanos().cast_signed())
+		else {
+			return FatDateTime::EPOCH;
+		};
+
+		let mut date_time = FatDateTime::new(
+			u16::try_from(now.year()).unwrap_or(1980),
+			now.month() as u8,
+			now.day(),
+			now.hour(),
+			now.minute(),
+			now.second(),
+		);
+
+		// `time_tenth` counts 10 ms units on top of the two-second resolution
+		// of the `time` field, so the odd second has to be folded back in.
+		date_time.time_tenth =
+			u8::try_from((u16::from(now.second() % 2) * 100 + now.millisecond() / 10).min(199))
+				.unwrap();
+
+		date_time
+	}
+}
+
+static TIME_PROVIDER: HermitTimeProvider = HermitTimeProvider::new();
+
+// ---------------------------------------------------------------------------
+// VFS integration
+// ---------------------------------------------------------------------------
+
+static VFAT: OnceCell<FatVolume<FatStream>> = OnceCell::new();
+
+/// Where the FAT file system is attached in the VFS.
+const MOUNT_POINT: &str = "/root";
+
+/// Translates a `hadris-fat` error into the kernel's error number.
+fn map_err(err: hadris_fat::error::Error) -> Errno {
+	use hadris_fat::error::Error;
+
+	match err {
+		Error::EntryNotFound => Errno::Noent,
+		Error::NotADirectory => Errno::Notdir,
+		Error::NotAFile => Errno::Isdir,
+		Error::NoFreeSpace => Errno::Nospc,
+		Error::InvalidPath | Error::InvalidShortFilename => Errno::Inval,
+		// Everything else — corrupt structures, cluster-chain damage, and the
+		// underlying block device's own errors — surfaces as an I/O error.
+		_ => Errno::Io,
+	}
+}
+
+/// The mounted volume.
+fn volume() -> io::Result<&'static FatVolume<FatStream>> {
+	VFAT.get().ok_or(Errno::Nodev)
+}
+
+/// Joins the directory's own path with a path relative to it.
+fn join(prefix: &str, path: &str) -> String {
+	match (prefix.trim_matches('/'), path.trim_matches('/')) {
+		("", rest) => rest.to_string(),
+		(base, "") => base.to_string(),
+		(base, rest) => [base, rest].join("/"),
+	}
+}
+
+/// Finds the entry called `name` directly below `dir`.
+async fn find(dir: &FatDir<'static, FatStream>, name: &str) -> io::Result<Option<FileEntry>> {
+	let mut entries = dir.entries();
+	while let Some(entry) = entries.next_entry().await {
+		let entry = entry.map_err(map_err)?;
+		if entry.name() == name
+			&& let Some(entry) = entry.as_entry()
+		{
+			return Ok(Some(entry.clone()));
+		}
+	}
+
+	Ok(None)
+}
+
+/// Walks `path` and returns the directory holding its last component together
+/// with that component's entry, if it exists.
+async fn resolve(path: &str) -> io::Result<(FatDir<'static, FatStream>, Option<FileEntry>)> {
+	let volume = volume()?;
+	let mut dir = volume.root_dir();
+
+	let mut components = path.split('/').filter(|part| !part.is_empty()).peekable();
+
+	while let Some(component) = components.next() {
+		let entry = find(&dir, component).await?;
+
+		if components.peek().is_none() {
+			return Ok((dir, entry));
+		}
+
+		// An intermediate component has to exist and be a directory.
+		let entry = entry.ok_or(Errno::Noent)?;
+		dir = dir.open_entry(&entry).map_err(map_err)?;
+	}
+
+	// The path named the root directory itself.
+	Ok((dir, None))
+}
+
+/// Resolves `path` to a directory.
+async fn resolve_dir(path: &str) -> io::Result<FatDir<'static, FatStream>> {
+	let (parent, entry) = resolve(path).await?;
+
+	match entry {
+		Some(entry) => parent.open_entry(&entry).map_err(map_err),
+		// No trailing component left: `parent` already is the directory.
+		None => Ok(parent),
+	}
+}
+
+/// Resolves `path` to an existing file entry.
+async fn resolve_file(path: &str) -> io::Result<FileEntry> {
+	let (_, entry) = resolve(path).await?;
+	let entry = entry.ok_or(Errno::Noent)?;
+
+	if entry.is_directory() {
+		return Err(Errno::Isdir);
+	}
+
+	Ok(entry)
+}
+
+/// Builds a `FileAttr` from what FAT can tell us.
+///
+/// FAT has no ownership or link count, so those stay at their defaults.
+fn file_attr(size: u64, kind: NodeKind) -> FileAttr {
+	let mode = match kind {
+		NodeKind::Directory => {
+			AccessPermission::from_bits(0o755).unwrap() | AccessPermission::S_IFDIR
+		}
+		NodeKind::File => AccessPermission::from_bits(0o644).unwrap() | AccessPermission::S_IFREG,
+	};
+
+	FileAttr {
+		st_size: i64::try_from(size).unwrap_or(i64::MAX),
+		st_mode: mode,
+		st_blksize: i64::try_from(SECTOR_SIZE).unwrap(),
+		st_blocks: i64::try_from(size.div_ceil(SECTOR_SIZE as u64)).unwrap_or(i64::MAX),
+		st_nlink: 1,
+		..Default::default()
+	}
+}
+
+/// Lists the entries of the directory at `path`, relative to the FAT root.
+async fn readdir_at(path: String) -> io::Result<Vec<DirectoryEntry>> {
+	let dir = resolve_dir(&path).await?;
+
+	let mut result = Vec::new();
+	let mut entries = dir.entries();
+	while let Some(entry) = entries.next_entry().await {
+		let entry = entry.map_err(map_err)?;
+		result.push(DirectoryEntry::new(entry.name().into_owned()));
+	}
+
+	Ok(result)
+}
+
+/// A directory of the FAT file system, as seen by the VFS.
+#[derive(Debug)]
+pub(crate) struct VfatDirectory {
+	/// Path of this directory relative to the FAT root, without leading slash.
+	prefix: String,
+}
+
+impl VfatDirectory {
+	pub fn new(prefix: String) -> Self {
+		Self { prefix }
+	}
+}
+
+impl VfsNode for VfatDirectory {
+	fn get_kind(&self) -> NodeKind {
+		NodeKind::Directory
+	}
+
+	fn get_file_attributes(&self) -> io::Result<FileAttr> {
+		Ok(file_attr(0, NodeKind::Directory))
+	}
+
+	fn get_object(&self) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
+		Ok(Arc::new(async_lock::RwLock::new(
+			VfatDirectoryHandle::new(self.prefix.clone()).into(),
+		)))
+	}
+
+	fn traverse_readdir(&self, path: &str) -> io::Result<Vec<DirectoryEntry>> {
+		block_on(readdir_at(join(&self.prefix, path)), None)
+	}
+
+	fn traverse_stat(&self, path: &str) -> io::Result<FileAttr> {
+		let path = join(&self.prefix, path);
+
+		block_on(
+			async {
+				let (_, entry) = resolve(&path).await?;
+				let Some(entry) = entry else {
+					// The root of the mounted volume.
+					return Ok(file_attr(0, NodeKind::Directory));
+				};
+
+				if entry.is_directory() {
+					Ok(file_attr(0, NodeKind::Directory))
+				} else {
+					Ok(file_attr(entry.len(), NodeKind::File))
+				}
+			},
+			None,
+		)
+	}
+
+	fn traverse_lstat(&self, path: &str) -> io::Result<FileAttr> {
+		// FAT has no symbolic links, so `lstat` and `stat` cannot differ.
+		self.traverse_stat(path)
+	}
+
+	fn traverse_mkdir(&self, path: &str, _mode: AccessPermission) -> io::Result<()> {
+		let path = join(&self.prefix, path);
+		let name = path.rsplit('/').next().ok_or(Errno::Inval)?;
+
+		block_on(
+			async {
+				let (parent, entry) = resolve(&path).await?;
+				if entry.is_some() {
+					return Err(Errno::Exist);
+				}
+
+				volume()?.create_dir(&parent, name).await.map_err(map_err)?;
+
+				Ok(())
+			},
+			None,
+		)
+	}
+
+	fn traverse_rmdir(&self, path: &str) -> io::Result<()> {
+		block_on(
+			async {
+				let entry = resolve(&join(&self.prefix, path))
+					.await?
+					.1
+					.ok_or(Errno::Noent)?;
+				if !entry.is_directory() {
+					return Err(Errno::Notdir);
+				}
+
+				volume()?.delete(&entry).await.map_err(map_err)
+			},
+			None,
+		)
+	}
+
+	fn traverse_unlink(&self, path: &str) -> io::Result<()> {
+		block_on(
+			async {
+				let entry = resolve_file(&join(&self.prefix, path)).await?;
+
+				volume()?.delete(&entry).await.map_err(map_err)
+			},
+			None,
+		)
+	}
+
+	fn traverse_open(
+		&self,
+		path: &str,
+		opt: OpenOption,
+		_mode: AccessPermission,
+	) -> io::Result<Arc<async_lock::RwLock<Fd>>> {
+		let full = join(&self.prefix, path);
+
+		block_on(
+			async {
+				let (parent, entry) = resolve(&full).await?;
+
+				// A directory is opened as a directory handle, whatever the flags say.
+				if let Some(entry) = &entry
+					&& entry.is_directory()
+				{
+					return Ok(Arc::new(async_lock::RwLock::new(
+						VfatDirectoryHandle::new(full.clone()).into(),
+					)));
+				}
+
+				let entry = match entry {
+					Some(entry) => {
+						if opt.contains(OpenOption::O_CREAT | OpenOption::O_EXCL) {
+							return Err(Errno::Exist);
+						}
+						if opt.contains(OpenOption::O_TRUNC) {
+							volume()?.truncate(&entry, 0).await.map_err(map_err)?;
+						}
+						entry
+					}
+					None => {
+						if !opt.contains(OpenOption::O_CREAT) {
+							return Err(Errno::Noent);
+						}
+						let name = full.rsplit('/').next().ok_or(Errno::Inval)?;
+						volume()?
+							.create_file(&parent, name)
+							.await
+							.map_err(map_err)?
+					}
+				};
+
+				let pos = if opt.contains(OpenOption::O_APPEND) {
+					entry.len()
+				} else {
+					0
+				};
+
+				Ok(Arc::new(async_lock::RwLock::new(
+					VfatFileHandle::new(full.clone(), pos).into(),
+				)))
+			},
+			None,
+		)
+	}
+}
+
+/// An open file of the FAT file system.
+///
+/// The handle keeps only the path and the offset. Readers and writers borrow
+/// the volume and cannot be parked in a long lived file descriptor, so every
+/// operation resolves the path again.
+#[derive(Debug)]
+pub(crate) struct VfatFileHandle {
+	path: String,
+	pos: async_lock::Mutex<u64>,
+}
+
+impl VfatFileHandle {
+	pub fn new(path: String, pos: u64) -> Self {
+		Self {
+			path,
+			pos: async_lock::Mutex::new(pos),
+		}
+	}
+}
+
+impl ObjectInterface for VfatFileHandle {
+	async fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+		let entry = resolve_file(&self.path).await?;
+		let mut pos = self.pos.lock().await;
+
+		let mut reader = volume()?.read_file(&entry).map_err(map_err)?;
+
+		// Walks the FAT chain to the position without touching file data;
+		// positions at or past the end make the following read return 0.
+		reader.seek(SeekFrom::Start(*pos)).await.map_err(map_err)?;
+
+		let read = reader.read(buf).await.map_err(map_err)?;
+		*pos += u64::try_from(read).unwrap();
+
+		Ok(read)
+	}
+
+	async fn write(&self, buf: &[u8]) -> io::Result<usize> {
+		let entry = resolve_file(&self.path).await?;
+		let mut pos = self.pos.lock().await;
+
+		// `FileWriter` rewrites the file from the start, so anything before the
+		// offset has to be carried over.
+		let prefix = if *pos > 0 {
+			let mut reader = volume()?.read_file(&entry).map_err(map_err)?;
+			let mut kept = Vec::with_capacity(usize::try_from(*pos).unwrap());
+			let mut scratch = [0u8; SECTOR_SIZE];
+			while u64::try_from(kept.len()).unwrap() < *pos {
+				let want = usize::try_from(*pos - u64::try_from(kept.len()).unwrap())
+					.unwrap()
+					.min(SECTOR_SIZE);
+				let read = reader.read(&mut scratch[..want]).await.map_err(map_err)?;
+				if read == 0 {
+					// Writing past the end pads the gap with zeros.
+					kept.resize(usize::try_from(*pos).unwrap(), 0);
+					break;
+				}
+				kept.extend_from_slice(&scratch[..read]);
+			}
+			kept
+		} else {
+			Vec::new()
+		};
+
+		let mut writer = volume()?.write_file(&entry).map_err(map_err)?;
+		if !prefix.is_empty() {
+			writer.write(&prefix).await.map_err(map_err)?;
+		}
+		let written = writer.write(buf).await.map_err(map_err)?;
+		writer.finish().await.map_err(map_err)?;
+
+		*pos += u64::try_from(written).unwrap();
+
+		Ok(written)
+	}
+
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		let mut pos = self.pos.lock().await;
+		let offset = i64::try_from(offset).unwrap();
+
+		let new = match whence {
+			SeekWhence::Set => offset,
+			SeekWhence::Cur => i64::try_from(*pos).unwrap() + offset,
+			SeekWhence::End => {
+				let entry = resolve_file(&self.path).await?;
+				i64::try_from(entry.len()).unwrap() + offset
+			}
+			_ => return Err(Errno::Inval),
+		};
+
+		if new < 0 {
+			return Err(Errno::Inval);
+		}
+
+		*pos = u64::try_from(new).unwrap();
+
+		Ok(isize::try_from(new).unwrap())
+	}
+
+	async fn fstat(&self) -> io::Result<FileAttr> {
+		let entry = resolve_file(&self.path).await?;
+
+		Ok(file_attr(entry.len(), NodeKind::File))
+	}
+
+	async fn truncate(&self, size: usize) -> io::Result<()> {
+		let entry = resolve_file(&self.path).await?;
+
+		volume()?.truncate(&entry, size).await.map_err(map_err)
+	}
+
+	async fn isatty(&self) -> io::Result<bool> {
+		Ok(false)
+	}
+}
+
+/// An open directory of the FAT file system.
+#[derive(Debug)]
+pub(crate) struct VfatDirectoryHandle {
+	prefix: String,
+	/// Index of the next entry `getdents` will report.
+	next: async_lock::Mutex<usize>,
+}
+
+impl VfatDirectoryHandle {
+	pub fn new(prefix: String) -> Self {
+		Self {
+			prefix,
+			next: async_lock::Mutex::new(0),
+		}
+	}
+}
+
+impl ObjectInterface for VfatDirectoryHandle {
+	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+		let entries = readdir_at(self.prefix.clone()).await?;
+
+		let mut next = self.next.lock().await;
+		let mut offset = 0usize;
+
+		while let Some(entry) = entries.get(*next) {
+			let name = entry.name.as_bytes();
+			let len = core::mem::offset_of!(Dirent64, d_name) + name.len() + 1;
+			let reclen = len.next_multiple_of(align_of::<Dirent64>());
+
+			if offset + reclen > buf.len() {
+				if offset == 0 {
+					// Not even one entry fits.
+					return Err(Errno::Inval);
+				}
+				break;
+			}
+
+			let target = buf[offset].as_mut_ptr().cast::<Dirent64>();
+			// SAFETY: the bounds check above guarantees that the entry and its
+			// trailing zero byte fit into `buf`.
+			unsafe {
+				target.write(Dirent64 {
+					d_ino: 0,
+					d_off: 0,
+					d_reclen: u16::try_from(reclen).unwrap(),
+					d_type: FileType::Unknown,
+					d_name: core::marker::PhantomData {},
+				});
+				let name_ptr = core::ptr::from_mut(&mut (*target).d_name).cast::<u8>();
+				name_ptr.copy_from_nonoverlapping(name.as_ptr(), name.len());
+				name_ptr.add(name.len()).write(0);
+			}
+
+			offset += reclen;
+			*next += 1;
+		}
+
+		Ok(offset)
+	}
+
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		if whence != SeekWhence::Set || offset != 0 {
+			return Err(Errno::Inval);
+		}
+		*self.next.lock().await = 0;
+
+		Ok(0)
+	}
+
+	async fn fstat(&self) -> io::Result<FileAttr> {
+		Ok(file_attr(0, NodeKind::Directory))
+	}
+}

--- a/src/fs/vfat.rs
+++ b/src/fs/vfat.rs
@@ -206,11 +206,7 @@ impl Write for FatStream {
 
 	async fn flush(&mut self) -> Result<(), IoError<Errno>> {
 		self.flush_all()?;
-
-		match with_driver(|drv| drv.flush()) {
-			Some(_) => Ok(()),
-			_ => Err(IoError::from_source(Errno::Nodev)),
-		}
+		Ok(with_driver(|drv| drv.flush()).ok_or(Errno::Nodev)??)
 	}
 }
 

--- a/src/init_cell.rs
+++ b/src/init_cell.rs
@@ -2,7 +2,8 @@
 	not(any(
 		feature = "virtio-vsock",
 		feature = "virtio-fs",
-		feature = "virtio-rng"
+		feature = "virtio-rng",
+		feature = "virtio-blk"
 	)),
 	expect(dead_code)
 )]

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -263,6 +263,11 @@ pub(crate) fn get_application_parameters() -> (i32, *const *const u8, *const *co
 }
 
 pub(crate) fn shutdown(arg: i32) -> ! {
+	// force completion of pending disk writes
+	if fs::sync().is_err() {
+		error!("Unable to synchronize file system!");
+	}
+
 	// print some performance statistics
 	crate::arch::kernel::print_statistics();
 


### PR DESCRIPTION
The device driver is quite simple and supports just one virtqueue. The file system is extended to support FAT. The extension based mainly on [`Hadris FAT`](https://github.com/hxyulin/hadris/tree/main/crates/block/hadris-fat). 

I tested the current approach by using `rusty_demo`, which was build as followed:

```sh
HERMIT_LOG_LEVEL_FILTER="hermit::drivers::blk=debug,hermit::fs=debug,smoltcp,info" cargo build --release -Zbuild-std=std,panic_abort --target=aarch64-unknown-hermit -p rusty_demo --features hermit/pci,hermit/virtio-blk,hermit/loader,hermit/pci-ids,fs 
```

Afterwards, I tested the current approach by following command:

```sh
qemu-system-aarch64 -display none -serial stdio \
  -machine virt,gic-version=3 \
  -cpu host  \
  -smp 1 -m 1024M \
  -global virtio-mmio.force-legacy=off \
  -kernel hermit-loader-aarch64 \
  -device guest-loader,addr=0x48000000,initrd=target/aarch64-unknown-hermit/release/rusty_demo  -drive file=disk.img,format=raw,if=none,id=disk0 \
-device virtio-blk-pci,drive=disk0,disable-legacy=on
```