### PR TITLE
build(deps): Upgrade to arm-gic 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arm-gic"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84372c6068152f635a04870779f0fa0d1b0273dd09dbe1c6747688693d061f06"
+checksum = "492963dde6a522f1c33383a5aecd9f34f7518e2f9e74baae932e7cf182f6c9b2"
 dependencies = [
  "arm-sysregs",
  "bitflags 2.13.1",
@@ -159,13 +159,56 @@ dependencies = [
 
 [[package]]
 name = "arm-sysregs"
-version = "0.2.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df3fc5d821089c553fa32966bbe7defbd23d857756a5091ecb094de5e18d1ac"
+checksum = "377602e4256d8c07771de23f18deeec7e0b15e4b55f566c3f3bb2a1d6ee0da50"
 dependencies = [
+ "arm-sysregs-aarch32",
+ "arm-sysregs-common",
+ "arm-sysregs-el0",
+ "arm-sysregs-el1",
+]
+
+[[package]]
+name = "arm-sysregs-aarch32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bb51b52291b6fd6223bca38043e85ac9c18c0180a4098809e3b3954c2c0842"
+dependencies = [
+ "arm-sysregs-common",
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "arm-sysregs-common"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4c8f79ed92200bf954b76d2eced94115b8f6677103652504eda1059a07739a"
+dependencies = [
  "num_enum",
  "paste",
+]
+
+[[package]]
+name = "arm-sysregs-el0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207069aab5de955e8f5f88c0cf64c8403084f650a7295524ea61220bea5c4f6c"
+dependencies = [
+ "arm-sysregs-aarch32",
+ "arm-sysregs-common",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "arm-sysregs-el1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9baf952c54557a9d47cc268a72a27252af23b351df2d94a32f65160f1de79c77"
+dependencies = [
+ "arm-sysregs-common",
+ "arm-sysregs-el0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1624,8 +1667,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe-mmio"
-version = "0.3.0"
-source = "git+https://github.com/hermit-os/safe-mmio?branch=0.3.x#161ce2de85c96f00e8ed9eaa0eb1b78c490220b2"
+version = "0.3.1"
+source = "git+https://github.com/hermit-os/safe-mmio?branch=0.3.x#7761a450a69f37ea524dbd2ec3e7c6919d13a3b5"
 dependencies = [
  "zerocopy",
 ]
@@ -2397,18 +2440,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,7 @@ x86_64 = { version = "0.15", default-features = false, features = ["instructions
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "11"
-arm-gic = { version = "0.8" }
+arm-gic = "0.9"
 arm-pl011-uart = { version = "0.5", default-features = false }
 fdt = { version = "0.1", features = ["pretty-printing"] }
 memory_addresses = { version = "0.4", default-features = false, features = ["aarch64"] }

--- a/src/arch/aarch64/kernel/interrupts.rs
+++ b/src/arch/aarch64/kernel/interrupts.rs
@@ -8,7 +8,6 @@ use aarch64_cpu::registers::*;
 use ahash::RandomState;
 use arm_gic::gicv3::{GicCpuInterface, GicV3, SgiTarget, SgiTargetGroup};
 use arm_gic::{IntId, InterruptGroup, Trigger, UniqueMmioPointer};
-use fdt::standard_nodes::Compatible;
 use free_list::PageLayout;
 use hashbrown::HashMap;
 use hermit_sync::{InterruptSpinMutex, InterruptTicketMutex, OnceCell, SpinMutex};
@@ -320,7 +319,7 @@ pub(crate) fn init() {
 
 	let fdt = env::start_info().fdt().unwrap();
 
-	let intc_node = fdt.find_node("/intc").unwrap();
+	let intc_node = fdt.find_compatible(&["arm,gic-v3", "arm,gic-v4"]).unwrap();
 	let mut reg_iter = intc_node.reg().unwrap();
 	let gicd_reg = reg_iter.next().unwrap();
 	let gicr_reg = reg_iter.next().unwrap();
@@ -332,20 +331,6 @@ pub(crate) fn init() {
 	let num_cpus = fdt.cpus().count();
 
 	let cpu_id: usize = core_id().try_into().unwrap();
-
-	let compatible = intc_node
-		.compatible()
-		.map(Compatible::first)
-		.unwrap_or("unknown");
-	let is_gic_v4 = if compatible == "arm,gic-v4" {
-		info!("Found GIC v4 with {num_cpus} cpus");
-		true
-	} else if compatible == "arm,gic-v3" {
-		info!("Found GIC v3 with {num_cpus} cpus");
-		false
-	} else {
-		panic!("{compatible} isn't supported")
-	};
 
 	info!("Found GIC Distributor interface at {gicd_start:p} (size {gicd_size:#X})");
 	info!(
@@ -380,7 +365,7 @@ pub(crate) fn init() {
 	let gicd = unsafe { UniqueMmioPointer::new(NonNull::new(gicd_address.as_mut_ptr()).unwrap()) };
 	let gicr = NonNull::new(gicr_address.as_mut_ptr()).unwrap();
 
-	let mut gic = unsafe { GicV3::new(gicd, gicr, num_cpus, is_gic_v4) };
+	let mut gic = unsafe { GicV3::new(gicd, gicr, num_cpus) }.unwrap();
 	gic.setup(cpu_id);
 	GicCpuInterface::set_priority_mask(0xff);
 


### PR DESCRIPTION
Since the arm-gic crate can now figure out whether we have a GICv3 or GICv4 on its own, we don't need to inspect the compatible of the interrupt controller node anymore.

While I'm at it, I decided to replace the hardcoded lookup path for the GIC with a lookup by compatible to ensure that we retain the previous behavior of panic on unsupport GIC version.
