### PR TITLE
refactor(x86_64/acpi): prepare for `acpi` crate

### DIFF
--- a/src/arch/x86_64/kernel/acpi.rs
+++ b/src/arch/x86_64/kernel/acpi.rs
@@ -130,7 +130,7 @@ impl AcpiTable<'_> {
 		}
 	}
 
-	pub fn header_start_address(&self) -> usize {
+	fn header_start_address(&self) -> usize {
 		ptr::from_ref(self.header).addr()
 	}
 

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -504,9 +504,15 @@ fn apic_addr() -> PhysAddr {
 		return default_apic();
 	}
 
-	detect_from_acpi()
-		.or_else(|()| detect_from_mp())
-		.unwrap_or_else(|()| default_apic())
+	if let Ok(apic_addr) = detect_from_acpi() {
+		return apic_addr;
+	}
+
+	if let Ok(apic_addr) = detect_from_mp() {
+		return apic_addr;
+	}
+
+	default_apic()
 }
 
 pub fn eoi() {

--- a/src/arch/x86_64/kernel/apic.rs
+++ b/src/arch/x86_64/kernel/apic.rs
@@ -313,12 +313,6 @@ fn init_ioapic_address(phys_addr: PhysAddr) {
 		.unwrap();
 }
 
-#[cfg(not(feature = "acpi"))]
-fn detect_from_acpi() -> Result<PhysAddr, ()> {
-	// dummy implementation if acpi support is disabled
-	Err(())
-}
-
 #[cfg(feature = "acpi")]
 fn detect_from_acpi() -> Result<PhysAddr, ()> {
 	// Get the Multiple APIC Description Table (MADT) from the ACPI information and its specific table header.
@@ -504,6 +498,7 @@ fn apic_addr() -> PhysAddr {
 		return default_apic();
 	}
 
+	#[cfg(feature = "acpi")]
 	if let Ok(apic_addr) = detect_from_acpi() {
 		return apic_addr;
 	}

--- a/src/arch/x86_64/kernel/mod.rs
+++ b/src/arch/x86_64/kernel/mod.rs
@@ -13,7 +13,7 @@ use crate::arch::kernel::core_local::*;
 use crate::env::{self, UhyveStartInfo};
 
 #[cfg(feature = "acpi")]
-pub mod acpi;
+mod acpi;
 pub mod apic;
 pub mod core_local;
 pub mod gdt;

--- a/src/arch/x86_64/kernel/processor.rs
+++ b/src/arch/x86_64/kernel/processor.rs
@@ -23,8 +23,6 @@ use x86_64::registers::xcontrol::{XCr0, XCr0Flags};
 use x86_64::structures::DescriptorTablePointer;
 use x86_64::{VirtAddr, instructions};
 
-#[cfg(feature = "acpi")]
-use crate::arch::kernel::acpi;
 use crate::arch::kernel::{interrupts, pic, pit};
 use crate::env;
 
@@ -1090,7 +1088,7 @@ pub fn shutdown(error_code: i32) -> ! {
 
 	#[cfg(feature = "acpi")]
 	{
-		acpi::poweroff();
+		super::acpi::poweroff();
 	}
 
 	triple_fault()


### PR DESCRIPTION
This prepares for
- https://github.com/hermit-os/kernel/pull/2650