### PR TITLE
Implement posix_getdents

### DIFF
--- a/src/fd/delegate.rs
+++ b/src/fd/delegate.rs
@@ -27,6 +27,7 @@ use crate::fs::uhyve::UhyveFileHandle;
 use crate::fs::virtio_fs::{VirtioFsDirectoryHandle, VirtioFsFileHandle};
 use crate::fs::{DirectoryReader, FileAttr, SeekWhence};
 use crate::io;
+use crate::syscalls::DirentFormat;
 
 pub(crate) enum Fd {
 	ConsoleStdin(ConsoleStdin),
@@ -143,7 +144,7 @@ impl ObjectInterface for Fd {
 			async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize>;
 			async fn fsync(&self) -> io::Result<()>;
 			async fn fstat(&self) -> io::Result<FileAttr>;
-			async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize>;
+			async fn getdents(&self, buf: &mut [MaybeUninit<u8>], format: DirentFormat) -> io::Result<usize>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]
 			async fn accept(&mut self) -> io::Result<(Arc<async_lock::RwLock<Fd>>, Endpoint)>;
 			#[cfg(any(feature = "net", feature = "virtio-vsock"))]

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -19,6 +19,7 @@ use crate::errno::Errno;
 use crate::executor::block_on;
 use crate::fs::{FileAttr, SeekWhence};
 use crate::io;
+use crate::syscalls::DirentFormat;
 #[cfg(any(feature = "net", feature = "virtio-vsock"))]
 use crate::syscalls::socket::{Ipproto, SOL_SOCKET, socklen_t};
 
@@ -332,12 +333,17 @@ pub(crate) trait ObjectInterface: Sync + Send {
 		Err(Errno::Inval)
 	}
 
-	/// `getdents` fills the given buffer `_buf` with [`Dirent64`](crate::syscalls::Dirent64)
-	/// formatted entries of a directory, imitating the Linux `getdents64` syscall.
-	/// On success, the number of bytes read is returned.  On end of directory, 0 is returned.  On error, -1 is returned
-	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+	/// `getdents` fills the given buffer `buf` with directory entries in the given
+	/// [`DirentFormat`](crate::syscalls::DirentFormat).
+	/// On success, the number of bytes read is returned. On end of directory, 0 is returned.  On error, -1 is returned
+	async fn getdents(
+		&self,
+		buf: &mut [MaybeUninit<u8>],
+		format: DirentFormat,
+	) -> io::Result<usize> {
 		let _buf = buf;
-		Err(Errno::Inval)
+		let _format = format;
+		Err(Errno::Notdir)
 	}
 
 	/// `accept` a connection on a socket

--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -334,7 +334,7 @@ pub(crate) trait ObjectInterface: Sync + Send {
 	}
 
 	/// `getdents` fills the given buffer `buf` with directory entries in the given
-	/// [`DirentFormat`](crate::syscalls::DirentFormat).
+	/// [`DirentFormat`].
 	/// On success, the number of bytes read is returned. On end of directory, 0 is returned.  On error, -1 is returned
 	async fn getdents(
 		&self,

--- a/src/fs/mem.rs
+++ b/src/fs/mem.rs
@@ -6,18 +6,15 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use core::{mem, ptr};
 
-use align_address::Align;
 use async_lock::{Mutex, RwLock};
 
 use crate::errno::Errno;
 use crate::executor::block_on;
 use crate::fd::{AccessPermission, Fd, ObjectInterface, OpenOption, PollEvent};
 use crate::fs::{DirectoryEntry, FileAttr, FileType, NodeKind, SeekWhence, VfsNode};
-use crate::syscalls::Dirent64;
+use crate::syscalls::DirentFormat;
 use crate::time::timespec;
 use crate::{arch, io};
 
@@ -386,49 +383,33 @@ impl MemDirectoryInterface {
 }
 
 impl ObjectInterface for MemDirectoryInterface {
-	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+	async fn getdents(
+		&self,
+		buf: &mut [MaybeUninit<u8>],
+		format: DirentFormat,
+	) -> io::Result<usize> {
 		let mut buf_offset: usize = 0;
-		let mut ret = 0;
 		let mut read_idx = self.read_idx.lock().await;
 		for name in self.inner.read().await.keys().skip(*read_idx) {
-			let namelen = name.len();
-
-			let dirent_len = mem::offset_of!(Dirent64, d_name) + namelen + 1;
-			let next_dirent = (buf_offset + dirent_len).align_up(align_of::<Dirent64>());
-
-			if next_dirent > buf.len() {
-				if ret == 0 {
+			let Some(next_dirent) = format.write_entry(
+				buf,
+				buf_offset,
+				1, // TODO: we don't have inodes in the mem filesystem. Maybe this could lead to problems
+				FileType::Unknown, // TODO: Proper filetype
+				name.as_bytes(),
+			) else {
+				if buf_offset == 0 {
 					// Buffer too small to hold even one entry
 					return Err(Errno::Inval);
 				}
 				// Buffer full -> return bytes written so far; caller retries from rsp_offset
 				break;
-			}
+			};
 
 			*read_idx += 1;
-
-			// could be replaced with slice_as_ptr once maybe_uninit_slice is stabilized.
-			let target_dirent = buf[buf_offset].as_mut_ptr().cast::<Dirent64>();
-
-			unsafe {
-				target_dirent.write(Dirent64 {
-					d_ino: 1, // TODO: we don't have inodes in the mem filesystem. Maybe this could lead to problems
-					d_off: 0,
-					d_reclen: (dirent_len.align_up(align_of::<Dirent64>()))
-						.try_into()
-						.unwrap(),
-					d_type: FileType::Unknown, // TODO: Proper filetype
-					d_name: PhantomData {},
-				});
-				let nameptr = ptr::from_mut(&mut (*(target_dirent)).d_name).cast::<u8>();
-				nameptr.copy_from_nonoverlapping(name.as_bytes().as_ptr().cast::<u8>(), namelen);
-				nameptr.add(namelen).write(0); // zero termination
-			}
-
 			buf_offset = next_dirent;
-			ret = buf_offset;
 		}
-		Ok(ret)
+		Ok(buf_offset)
 	}
 
 	/// lseek for a directory entry is the equivalent for seekdir on linux. But on Hermit this is
@@ -602,6 +583,12 @@ impl VfsNode for MemDirectory {
 					let directory = inner.get(component).ok_or(Errno::Badf)?;
 					return directory.traverse_readdir(rest);
 				};
+
+				if !path.is_empty() {
+					let inner = self.inner.read().await;
+					let directory = inner.get(path).ok_or(Errno::Badf)?;
+					return directory.traverse_readdir("");
+				}
 
 				let mut entries = Vec::new();
 				for name in self.inner.read().await.keys() {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -23,6 +23,7 @@ use crate::errno::Errno;
 use crate::executor::block_on;
 use crate::fd::{AccessPermission, Fd, ObjectInterface, OpenOption, insert_object, remove_object};
 use crate::io;
+use crate::syscalls::DirentFormat;
 use crate::time::{SystemTime, timespec};
 
 static FILESYSTEM: OnceCell<Filesystem> = OnceCell::new();
@@ -123,20 +124,53 @@ pub(crate) trait VfsNode: Send + Sync + fmt::Debug {
 	}
 }
 
-#[derive(Clone)]
-pub(crate) struct DirectoryReader(Vec<DirectoryEntry>);
+pub(crate) struct DirectoryReader {
+	entries: Vec<DirectoryEntry>,
+	read_idx: async_lock::Mutex<usize>,
+}
 
 impl DirectoryReader {
-	pub fn new(data: Vec<DirectoryEntry>) -> Self {
-		Self(data)
+	pub fn new(entries: Vec<DirectoryEntry>) -> Self {
+		Self {
+			entries,
+			read_idx: async_lock::Mutex::new(0),
+		}
 	}
 }
 
 impl ObjectInterface for DirectoryReader {
-	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
-		let _buf = buf;
-		let _ = &self.0; // Dummy statement to avoid warning for the moment
-		unimplemented!()
+	async fn getdents(
+		&self,
+		buf: &mut [MaybeUninit<u8>],
+		format: DirentFormat,
+	) -> io::Result<usize> {
+		let mut buf_offset: usize = 0;
+		let mut read_idx = self.read_idx.lock().await;
+		for entry in self.entries.iter().skip(*read_idx) {
+			let Some(next_dirent) =
+				format.write_entry(buf, buf_offset, 1, FileType::Unknown, entry.name.as_bytes())
+			else {
+				if buf_offset == 0 {
+					// Buffer too small to hold even one entry
+					return Err(Errno::Inval);
+				}
+				// Buffer full -> return bytes written so far; caller retries from read_idx
+				break;
+			};
+
+			*read_idx += 1;
+			buf_offset = next_dirent;
+		}
+		Ok(buf_offset)
+	}
+
+	async fn lseek(&self, offset: isize, whence: SeekWhence) -> io::Result<isize> {
+		if whence != SeekWhence::Set && offset != 0 {
+			error!("Invalid offset for directory lseek ({offset})");
+			return Err(Errno::Inval);
+		}
+		*self.read_idx.lock().await = offset as usize;
+		Ok(offset)
 	}
 }
 

--- a/src/fs/virtio_fs.rs
+++ b/src/fs/virtio_fs.rs
@@ -8,9 +8,8 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::task::Poll;
-use core::{future, mem, ptr, slice};
+use core::{future, slice};
 
-use align_address::Align;
 use async_lock::Mutex;
 use embedded_io::{ErrorType, Read, Write};
 use fuse_abi::linux::*;
@@ -29,7 +28,7 @@ use crate::fs::{
 	SeekWhence, VfsNode,
 };
 use crate::mm::device_alloc::DeviceAlloc;
-use crate::syscalls::Dirent64;
+use crate::syscalls::DirentFormat;
 use crate::time::{time_t, timespec};
 use crate::{arch, io};
 
@@ -1035,7 +1034,11 @@ impl VirtioFsDirectoryHandle {
 }
 
 impl ObjectInterface for VirtioFsDirectoryHandle {
-	async fn getdents(&self, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+	async fn getdents(
+		&self,
+		buf: &mut [MaybeUninit<u8>],
+		format: DirentFormat,
+	) -> io::Result<usize> {
 		let path = if self.name.is_empty() {
 			CString::new("/").unwrap()
 		} else {
@@ -1082,8 +1085,6 @@ impl ObjectInterface for VirtioFsDirectoryHandle {
 			return Err(Errno::Noent);
 		}
 
-		let mut ret = 0;
-
 		while (rsp.headers.out_header.len as usize) - *rsp_offset > size_of::<fuse_dirent>() {
 			let dirent = unsafe {
 				&*rsp
@@ -1095,43 +1096,28 @@ impl ObjectInterface for VirtioFsDirectoryHandle {
 					.cast::<fuse_dirent>()
 			};
 
-			let dirent_len = mem::offset_of!(Dirent64, d_name) + dirent.namelen as usize + 1;
-			let next_dirent = (buf_offset + dirent_len).align_up(align_of::<Dirent64>());
-
-			if next_dirent > buf.len() {
-				if ret == 0 {
+			let name = unsafe {
+				slice::from_raw_parts(dirent.name.as_ptr().cast::<u8>(), dirent.namelen as usize)
+			};
+			let Some(next_dirent) = format.write_entry(
+				buf,
+				buf_offset,
+				dirent.ino,
+				(dirent.type_ as u8).try_into().unwrap(),
+				name,
+			) else {
+				if buf_offset == 0 {
 					// Buffer too small to hold even one entry
 					return Err(Errno::Inval);
 				}
 				// Buffer full -> return bytes written so far; caller retries from rsp_offset
 				break;
-			}
-
-			// could be replaced with slice_as_ptr once maybe_uninit_slice is stabilized.
-			let target_dirent = buf[buf_offset].as_mut_ptr().cast::<Dirent64>();
-			unsafe {
-				target_dirent.write(Dirent64 {
-					d_ino: dirent.ino,
-					d_off: 0,
-					d_reclen: (dirent_len.align_up(align_of::<Dirent64>()))
-						.try_into()
-						.unwrap(),
-					d_type: (dirent.type_ as u8).try_into().unwrap(),
-					d_name: PhantomData {},
-				});
-				let nameptr = ptr::from_mut(&mut (*(target_dirent)).d_name).cast::<u8>();
-				nameptr.copy_from_nonoverlapping(
-					dirent.name.as_ptr().cast::<u8>(),
-					dirent.namelen as usize,
-				);
-				nameptr.add(dirent.namelen as usize).write(0); // zero termination
-			}
+			};
 
 			*rsp_offset += size_of::<fuse_dirent>() + dirent.namelen as usize;
 			// Align to dirent struct
 			*rsp_offset = ((*rsp_offset) + U64_SIZE - 1) & (!(U64_SIZE - 1));
 			buf_offset = next_dirent;
-			ret = buf_offset;
 		}
 
 		let (cmd, rsp_payload_len) = ops::Release::create(fuse_nid, fuse_fh);
@@ -1140,7 +1126,7 @@ impl ObjectInterface for VirtioFsDirectoryHandle {
 			.lock()
 			.send_command(cmd, rsp_payload_len)?;
 
-		Ok(ret)
+		Ok(buf_offset)
 	}
 
 	async fn fsync(&self) -> io::Result<()> {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -6,7 +6,7 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::{CStr, c_char};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use core::{ptr, slice};
+use core::{mem, ptr, slice};
 
 use align_address::Align;
 use dirent_display::Dirent64Display;
@@ -798,6 +798,90 @@ mod dirent_display {
 	}
 }
 
+/// Directory entry as defined by POSIX.1-2024 (`struct posix_dent`).
+#[repr(C)]
+pub struct PosixDent {
+	/// File serial number
+	pub d_ino: u64,
+	/// Length of this entry, including trailing padding
+	pub d_reclen: u16,
+	/// File type or unknown-file-type indication
+	pub d_type: fs::FileType,
+	/// Filename string of this entry (null-terminated)
+	pub d_name: PhantomData<c_char>,
+}
+
+/// Format of the directory entries written by [`ObjectInterface::getdents`].
+#[derive(Clone, Copy)]
+pub(crate) enum DirentFormat {
+	/// Linux `struct linux_dirent64` entries for [`sys_getdents64`]
+	Dirent64,
+	/// POSIX `struct posix_dent` entries for [`sys_posix_getdents`]
+	PosixDent,
+}
+
+impl DirentFormat {
+	/// Writes one directory entry into `buf` at `offset`.
+	///
+	/// Returns the offset of the next entry or [`None`] if the entry does not fit into `buf`.
+	pub(crate) fn write_entry(
+		self,
+		buf: &mut [MaybeUninit<u8>],
+		offset: usize,
+		d_ino: u64,
+		d_type: fs::FileType,
+		name: &[u8],
+	) -> Option<usize> {
+		let (header_len, align) = match self {
+			Self::Dirent64 => (mem::offset_of!(Dirent64, d_name), align_of::<Dirent64>()),
+			Self::PosixDent => (mem::offset_of!(PosixDent, d_name), align_of::<PosixDent>()),
+		};
+		let entry_len = header_len + name.len() + 1;
+		let next_entry = (offset + entry_len).align_up(align);
+
+		if next_entry > buf.len() {
+			return None;
+		}
+
+		let d_reclen = entry_len.align_up(align).try_into().unwrap();
+
+		let entry_ptr = buf[offset].as_mut_ptr();
+		let name_ptr = match self {
+			Self::Dirent64 => {
+				let dirent = entry_ptr.cast::<Dirent64>();
+				unsafe {
+					dirent.write(Dirent64 {
+						d_ino,
+						d_off: 0,
+						d_reclen,
+						d_type,
+						d_name: PhantomData {},
+					});
+					(&raw mut (*dirent).d_name).cast::<u8>()
+				}
+			}
+			Self::PosixDent => {
+				let dirent = entry_ptr.cast::<PosixDent>();
+				unsafe {
+					dirent.write(PosixDent {
+						d_ino,
+						d_reclen,
+						d_type,
+						d_name: PhantomData {},
+					});
+					(&raw mut (*dirent).d_name).cast::<u8>()
+				}
+			}
+		};
+		unsafe {
+			name_ptr.copy_from_nonoverlapping(name.as_ptr(), name.len());
+			name_ptr.add(name.len()).write(0); // zero termination
+		}
+
+		Some(next_entry)
+	}
+}
+
 /// Read the entries of a directory.
 /// Similar as the Linux system-call, this reads up to `count` bytes and returns the number of
 /// bytes written. If the size was not sufficient to list all directory entries, subsequent calls
@@ -828,8 +912,67 @@ pub unsafe extern "C" fn sys_getdents64(fd: RawFd, dirp: *mut Dirent64, count: u
 	obj.map_or_else(
 		|_| (-i32::from(Errno::Inval)).into(),
 		|v| {
-			block_on(async { v.read().await.getdents(slice).await }, None)
-				.map_or_else(|e| (-i32::from(e)).into(), |cnt| cnt as i64)
+			block_on(
+				async { v.read().await.getdents(slice, DirentFormat::Dirent64).await },
+				None,
+			)
+			.map_or_else(|e| (-i32::from(e)).into(), |cnt| cnt as i64)
+		},
+	)
+}
+
+/// Read the entries of a directory as defined by POSIX.1-2024, [`posix_getdents`].
+///
+/// This reads up to `nbyte` bytes of [`PosixDent`] entries into `buf` and returns the number of
+/// bytes written. If the size was not sufficient to list all directory entries, subsequent calls
+/// to this fn return the next entries.
+///
+/// Parameters:
+///
+/// - `fd`: File Descriptor of the directory in question.
+/// - `buf`: Memory for the kernel to store the filled `PosixDent` objects including the c-strings with the filenames to.
+/// - `nbyte`: Size of the memory region described by `buf` in bytes.
+/// - `flags`: Must be zero; no flags are supported yet.
+///
+/// Return:
+///
+/// The number of bytes read into `buf` on success. Zero indicates that the end of the directory
+/// was reached. Negative numbers encode errors.
+///
+/// [`posix_getdents`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_getdents.html
+#[hermit_macro::system(errno)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sys_posix_getdents(
+	fd: RawFd,
+	buf: *mut PosixDent,
+	nbyte: usize,
+	flags: i32,
+) -> isize {
+	debug!("posix_getdents for fd {fd:?} - nbyte: {nbyte}, flags: {flags}");
+	// POSIX doesn't define any mandatory flags as of now
+	if buf.is_null() || nbyte == 0 || flags != 0 {
+		return isize::try_from(-i32::from(Errno::Inval)).unwrap();
+	}
+
+	let slice = unsafe { slice::from_raw_parts_mut(buf.cast(), nbyte) };
+
+	let obj = get_object(fd);
+	obj.map_or_else(
+		|e| isize::try_from(-i32::from(e)).unwrap(),
+		|v| {
+			block_on(
+				async {
+					v.read()
+						.await
+						.getdents(slice, DirentFormat::PosixDent)
+						.await
+				},
+				None,
+			)
+			.map_or_else(
+				|e| isize::try_from(-i32::from(e)).unwrap(),
+				|cnt| isize::try_from(cnt).unwrap(),
+			)
 		},
 	)
 }

--- a/tests/getdents.rs
+++ b/tests/getdents.rs
@@ -8,6 +8,8 @@ extern crate alloc;
 
 mod common;
 
+use alloc::ffi::CString;
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ffi::CStr;
@@ -141,6 +143,79 @@ fn getdents() {
 	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) };
 	assert_eq!(len, -isize::try_from(ENOTDIR).unwrap());
 	assert_eq!(sys_close(fd), 0);
+}
+
+/// Reads the whole directory with repeated calls and returns the entries and the number of
+/// calls that returned data.
+fn collect_all(fd: i32, posix: bool) -> (Vec<(u64, u16, String)>, usize) {
+	let mut buf = Buf([0; 1024]);
+	let mut entries = Vec::new();
+	let mut calls = 0;
+	loop {
+		let len = if posix {
+			unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) }
+		} else {
+			unsafe { sys_getdents64(fd, buf.0.as_mut_ptr().cast(), buf.0.len()) }
+				.try_into()
+				.unwrap()
+		};
+		assert!(len >= 0);
+		if len == 0 {
+			break;
+		}
+		calls += 1;
+		let new_entries = if posix {
+			unsafe { parse_posix_dent(&buf, len.try_into().unwrap()) }
+		} else {
+			unsafe { parse_dirent64(&buf, len.try_into().unwrap()) }
+		};
+		assert!(!new_entries.is_empty());
+		entries.extend(new_entries);
+	}
+	(entries, calls)
+}
+
+fn check_large_dir_fd(fd: i32, expected: &[String]) {
+	for posix in [false, true] {
+		assert_eq!(sys_lseek(fd, 0, 0), 0);
+		let (entries, calls) = collect_all(fd, posix);
+		// The directory must not fit into a single 1024-byte buffer.
+		assert!(calls > 1);
+		let names: Vec<&str> = entries.iter().map(|(_, _, name)| name.as_str()).collect();
+		assert_eq!(
+			names,
+			expected.iter().map(String::as_str).collect::<Vec<_>>()
+		);
+	}
+	assert_eq!(sys_close(fd), 0);
+}
+
+#[test_case]
+fn getdents_large_directory() {
+	assert_eq!(unsafe { sys_mkdir(c"/tmp/gd_large".as_ptr(), 0o755) }, 0);
+
+	// 40 files with name lengths from 12 to 124 bytes, so that records of many different
+	// sizes cross the buffer boundary and multiple getdents calls are required.
+	let mut expected = Vec::new();
+	for i in 0..40 {
+		let name = format!("f{i:02}_{}", "x".repeat(8 + (i * 7) % 113));
+		let path = CString::new(format!("/tmp/gd_large/{name}")).unwrap();
+		let fd = unsafe { sys_open(path.as_ptr(), O_WRONLY | O_CREAT, 0o644) };
+		assert!(fd >= 0);
+		assert_eq!(sys_close(fd), 0);
+		expected.push(name);
+	}
+	expected.sort();
+
+	// Directory opened with opendir
+	let fd = unsafe { sys_opendir(c"/tmp/gd_large".as_ptr()) };
+	assert!(fd >= 0);
+	check_large_dir_fd(fd, &expected);
+
+	// Directory opened with O_DIRECTORY
+	let fd = unsafe { sys_open(c"/tmp/gd_large".as_ptr(), O_DIRECTORY, 0) };
+	assert!(fd >= 0);
+	check_large_dir_fd(fd, &expected);
 }
 
 #[unsafe(no_mangle)]

--- a/tests/getdents.rs
+++ b/tests/getdents.rs
@@ -1,0 +1,150 @@
+#![no_std]
+#![no_main]
+#![test_runner(common::test_case_runner)]
+#![feature(custom_test_frameworks)]
+#![reexport_test_harness_main = "test_main"]
+
+extern crate alloc;
+
+mod common;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::ffi::CStr;
+
+use hermit::syscalls::{
+	Dirent64, PosixDent, sys_close, sys_getdents64, sys_lseek, sys_mkdir, sys_open, sys_opendir,
+	sys_posix_getdents,
+};
+
+const EINVAL: i32 = 22;
+const ENOTDIR: i32 = 20;
+
+const O_WRONLY: i32 = 0o1;
+const O_CREAT: i32 = 0o100;
+const O_DIRECTORY: i32 = 0o200_000;
+
+#[repr(align(8))]
+struct Buf([u8; 1024]);
+
+unsafe fn parse_dirent64(buf: &Buf, len: usize) -> Vec<(u64, u16, String)> {
+	let mut entries = Vec::new();
+	let mut offset = 0;
+	while offset < len {
+		let dirent = unsafe { &*buf.0.as_ptr().add(offset).cast::<Dirent64>() };
+		let name = unsafe { CStr::from_ptr((&raw const dirent.d_name).cast()) };
+		entries.push((
+			dirent.d_ino,
+			dirent.d_reclen,
+			String::from(name.to_str().unwrap()),
+		));
+		offset += usize::from(dirent.d_reclen);
+	}
+	assert_eq!(offset, len);
+	entries
+}
+
+unsafe fn parse_posix_dent(buf: &Buf, len: usize) -> Vec<(u64, u16, String)> {
+	let mut entries = Vec::new();
+	let mut offset = 0;
+	while offset < len {
+		let dirent = unsafe { &*buf.0.as_ptr().add(offset).cast::<PosixDent>() };
+		let name = unsafe { CStr::from_ptr((&raw const dirent.d_name).cast()) };
+		entries.push((
+			dirent.d_ino,
+			dirent.d_reclen,
+			String::from(name.to_str().unwrap()),
+		));
+		offset += usize::from(dirent.d_reclen);
+	}
+	assert_eq!(offset, len);
+	entries
+}
+
+fn check_dir_fd(fd: i32) {
+	let mut buf = Buf([0; 1024]);
+
+	// getdents64: Dirent64 has a 19-byte header, entries are 8-byte aligned.
+	let len = unsafe { sys_getdents64(fd, buf.0.as_mut_ptr().cast(), buf.0.len()) };
+	assert!(len > 0);
+	let entries = unsafe { parse_dirent64(&buf, len.try_into().unwrap()) };
+	assert_eq!(entries.len(), 3);
+	assert_eq!(entries[0], (1, 24, String::from("a")));
+	assert_eq!(entries[1], (1, 24, String::from("bb")));
+	assert_eq!(entries[2], (1, 24, String::from("ccc")));
+
+	// End of directory
+	let len = unsafe { sys_getdents64(fd, buf.0.as_mut_ptr().cast(), buf.0.len()) };
+	assert_eq!(len, 0);
+
+	// posix_getdents: PosixDent has an 11-byte header, entries are 8-byte aligned.
+	assert_eq!(sys_lseek(fd, 0, 0), 0);
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) };
+	assert!(len > 0);
+	let entries = unsafe { parse_posix_dent(&buf, len.try_into().unwrap()) };
+	assert_eq!(entries.len(), 3);
+	assert_eq!(entries[0], (1, 16, String::from("a")));
+	assert_eq!(entries[1], (1, 16, String::from("bb")));
+	assert_eq!(entries[2], (1, 16, String::from("ccc")));
+
+	// End of directory
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) };
+	assert_eq!(len, 0);
+
+	// Partial reads: a buffer with space for exactly one entry
+	assert_eq!(sys_lseek(fd, 0, 0), 0);
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), 16, 0) };
+	assert_eq!(len, 16);
+	let entries = unsafe { parse_posix_dent(&buf, 16) };
+	assert_eq!(entries[0].2, "a");
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) };
+	assert_eq!(len, 32);
+	let entries = unsafe { parse_posix_dent(&buf, 32) };
+	assert_eq!(entries[0].2, "bb");
+	assert_eq!(entries[1].2, "ccc");
+
+	// No flags are supported
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 1) };
+	assert_eq!(len, -isize::try_from(EINVAL).unwrap());
+
+	// A buffer too small for even one entry
+	assert_eq!(sys_lseek(fd, 0, 0), 0);
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), 8, 0) };
+	assert_eq!(len, -isize::try_from(EINVAL).unwrap());
+
+	assert_eq!(sys_close(fd), 0);
+}
+
+#[test_case]
+fn getdents() {
+	assert_eq!(unsafe { sys_mkdir(c"/tmp/gd".as_ptr(), 0o755) }, 0);
+	for name in [c"/tmp/gd/a", c"/tmp/gd/bb", c"/tmp/gd/ccc"] {
+		let fd = unsafe { sys_open(name.as_ptr(), O_WRONLY | O_CREAT, 0o644) };
+		assert!(fd >= 0);
+		assert_eq!(sys_close(fd), 0);
+	}
+
+	// Directory opened with opendir
+	let fd = unsafe { sys_opendir(c"/tmp/gd".as_ptr()) };
+	assert!(fd >= 0);
+	check_dir_fd(fd);
+
+	// Directory opened with O_DIRECTORY
+	let fd = unsafe { sys_open(c"/tmp/gd".as_ptr(), O_DIRECTORY, 0) };
+	assert!(fd >= 0);
+	check_dir_fd(fd);
+
+	// A non-directory file descriptor
+	let mut buf = Buf([0; 1024]);
+	let fd = unsafe { sys_open(c"/tmp/gd/a".as_ptr(), O_WRONLY, 0) };
+	assert!(fd >= 0);
+	let len = unsafe { sys_posix_getdents(fd, buf.0.as_mut_ptr().cast(), buf.0.len(), 0) };
+	assert_eq!(len, -isize::try_from(ENOTDIR).unwrap());
+	assert_eq!(sys_close(fd), 0);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn runtime_entry(_argc: i32, _argv: *const *const u8, _env: *const *const u8) -> ! {
+	test_main();
+	common::exit(false)
+}


### PR DESCRIPTION
Closes #2034.

Adds `sys_posix_getdents` as specified by [POSIX.1-2024 `posix_getdents`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_getdents.html), alongside the existing `sys_getdents64`.

```rust
pub unsafe extern "C" fn sys_posix_getdents(fd: RawFd, buf: *mut PosixDent, nbyte: usize, flags: i32) -> isize
```

`PosixDent` matches `struct posix_dent { d_ino, d_reclen, d_type, d_name[] }` . `flags` must be `0` for now because POSIX defines no mandatory flags and `DT_FORCE_TYPE` is optional). Anything else returns `EINVAL`.

## Implementation

- The entry-serialization logic that was duplicated across `mem.rs` and `virtio_fs.rs` is now a single `DirentFormat::write_entry`, parameterized over the two entry formats. `ObjectInterface::getdents` takes the requested `DirentFormat`.
- The default `ObjectInterface::getdents` now returns `ENOTDIR` instead of `EINVAL`, matching both POSIX and Linux `getdents64(2)` behavior for non-directory descriptors.

## fixes surfaced by the new tests

- `DirectoryReader::getdents` was `unimplemented!()`, so `sys_opendir` + `sys_getdents64` panicked the kernel. It is now implemented.
- `MemDirectory::traverse_readdir` never resolved the final path component.`readdir("/tmp/gd")` listed the contents of `/tmp` instead of `/tmp/gd`. Both went unnoticed because nothing exercised the `sys_opendir` path before.

## Tests

New `tests/getdents.rs` integration test covers both syscalls through both the `sys_opendir` and `O_DIRECTORY` paths: entry layout/reclen for both formats, end-of-directory, partial reads with a one-entry buffer, rejected flags, `EINVAL` for a too-small buffer, and `ENOTDIR` for a file descriptor.