### PR TITLE
Static analysis report and small fixes

### DIFF
--- a/src/drivers/net/gem.rs
+++ b/src/drivers/net/gem.rs
@@ -689,7 +689,7 @@ pub fn init_device(
 			);
 
 			// Wait for AN to complete
-			while (phy_read(gem, phy_addr, PhyReg::Status) | PhyStatus::ANCompleteMask as u16) == 0
+			while (phy_read(gem, phy_addr, PhyReg::Status) & PhyStatus::ANCompleteMask as u16) == 0
 			{
 			}
 

--- a/src/fd/eventfd.rs
+++ b/src/fd/eventfd.rs
@@ -152,7 +152,7 @@ impl ObjectInterface for EventFd {
 				let mut pinned = pin!(self.state.lock());
 				let mut guard = ready!(pinned.as_mut().poll(cx));
 				if event
-					.intersects(PollEvent::POLLIN | PollEvent::POLLRDNORM | PollEvent::POLLRDNORM)
+					.intersects(PollEvent::POLLIN | PollEvent::POLLRDNORM | PollEvent::POLLRDBAND)
 				{
 					guard.read_queue.push_back(cx.waker().clone());
 					Poll::Pending


### PR DESCRIPTION
Hey,
I have a rust static analysis prototype, I ran it against hermit kernel and found following and fixed two of them.
I haven't reviewed all of these reports but I include full report so you can check it yourself further if you are interested, Please consider this an alpha version of a SAST with high false positive ratio.
Note that I experienced sometimes when it reports panic or div-by-zero FPs those are actually lost optimization chances.

```
./src/arch/x86_64/kernel/apic.rs:386:7: [demorgan] !(apic_mp.version > 4 || apic_mp.features[0] != 0) can be simplified to apic_mp.version <= 4 && apic_mp.features[0] == 0 by De Morgan's law (confidence: 5.0/10, CWE-480)
./src/arch/x86_64/kernel/mod.rs:201:15: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/arch/x86_64/kernel/mod.rs:202:20: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/arch/x86_64/kernel/mod.rs:215:12: [unchecked-length] slice::from_raw_parts with an attacker-controlled length reads out of bounds (confidence: 7.0/10, CWE-787)
./src/arch/x86_64/kernel/mod.rs:221:19: [tainted-slice-bounds] slice bound is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/arch/x86_64/kernel/mod.rs:261:2: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/arch/x86_64/kernel/mod.rs:265:3: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/arch/x86_64/kernel/pit.rs:50:14: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/arch/x86_64/kernel/processor.rs:1100:1: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/arch/x86_64/kernel/systemtime.rs:69:14: [integer-overflow] arithmetic may overflow (panics in debug builds) (confidence: 6.0/10, CWE-190)
./src/console/mod.rs:175:1: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/drivers/net/gem.rs:692:3: [dead-condition] branch condition is always false; the then branch is dead (confidence: 6.0/10, CWE-570)
./src/drivers/net/rtl8139.rs:629:3: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/net/virtio.rs:549:8: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/virtio/virtqueue/packed.rs:337:12: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/virtio/virtqueue/packed.rs:393:12: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/virtio/virtqueue/packed.rs:398:18: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/virtio/virtqueue/split.rs:90:39: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/drivers/virtio/virtqueue/split.rs:105:23: [divide-by-zero] divisor may be zero; could panic (confidence: 6.0/10, CWE-369)
./src/entropy.rs:68:41: [integer-overflow] unsigned subtraction with an attacker-controlled subtrahend can underflow (panics in debug builds, wraps in release); use checked_sub or saturating_sub (confidence: 5.0/10, CWE-190)
./src/entropy.rs:74:4: [integer-overflow] unsigned subtraction with an attacker-controlled subtrahend can underflow (panics in debug builds, wraps in release); use checked_sub or saturating_sub (confidence: 5.0/10, CWE-190)
./src/fd/eventfd.rs:155:61: [identical-operand] PollEvent::POLLRDNORM duplicates an earlier operand in the | chain (the repeat has no effect) (confidence: 5.0/10, CWE-682)
./src/scheduler/mod.rs:295:2: [dead-condition] branch condition is always false; the then branch is dead (confidence: 6.0/10, CWE-570)
./src/scheduler/mod.rs:631:4: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/scheduler/mod.rs:903:25: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/scheduler/mod.rs:919:2: [lossy-cast] attacker-controlled value is cast to a narrower integer type; the high bits are silently discarded (use try_into()) (confidence: 5.0/10, CWE-197)
./src/scheduler/sleep_state.rs:134:1: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/sleep_state.rs:134:23: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/scheduler/task/mod.rs:189:28: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/task/mod.rs:194:3: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/task/mod.rs:224:28: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/task/mod.rs:266:19: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/task/mod.rs:346:14: [tainted-index] index is attacker-controlled and unbounded; may panic (confidence: 5.0/10, CWE-129)
./src/scheduler/timer_interrupts.rs:77:4: [integer-overflow] unsigned subtraction with an attacker-controlled subtrahend can underflow (panics in debug builds, wraps in release); use checked_sub or saturating_sub (confidence: 5.0/10, CWE-190)
./src/syscalls/mman.rs:82:18: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mman.rs:93:3: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mman.rs:130:21: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mman.rs:131:20: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:85:14: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:104:14: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:121:14: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:165:15: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:204:15: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:222:15: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:572:11: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/mod.rs:649:11: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/socket/mod.rs:108:28: [lossy-cast] attacker-controlled value is cast to a narrower integer type; the high bits are silently discarded (use try_into()) (confidence: 5.0/10, CWE-197)
./src/syscalls/socket/mod.rs:650:2: [dead-condition] branch condition is always true; the else branch is dead (confidence: 6.0/10, CWE-570)
./src/syscalls/socket/mod.rs:694:19: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/socket/mod.rs:723:19: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/socket/mod.rs:1236:5: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/syscalls/tasks.rs:253:2: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/time.rs:89:3: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
./src/time.rs:92:17: [unwrap-panic] unwrap() on an attacker-reachable value that may be None could panic (confidence: 6.0/10, CWE-755)
````
