### PR TITLE
feature(fsync) Prepare the kernel for additional io/file systems

### DIFF
--- a/src/fd/mod.rs
+++ b/src/fd/mod.rs
@@ -341,6 +341,11 @@ pub(crate) trait ObjectInterface: Sync + Send {
 	async fn isatty(&self) -> io::Result<bool> {
 		Ok(false)
 	}
+
+	/// Flushes the object to the storage it lives on.
+	async fn fsync(&self) -> io::Result<()> {
+		Ok(())
+	}
 }
 
 pub(crate) fn read(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
@@ -351,6 +356,13 @@ pub(crate) fn read(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
 	}
 
 	block_on(async { obj.read().await.read(buf).await }, None)
+}
+
+/// Flushes a file to the storage it lives on.
+pub(crate) fn fsync(fd: RawFd) -> io::Result<()> {
+	let obj = get_object(fd)?;
+
+	block_on(async { obj.read().await.fsync().await }, None)
 }
 
 pub(crate) fn lseek(fd: RawFd, offset: isize, whence: SeekWhence) -> io::Result<isize> {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -901,6 +901,13 @@ pub extern "C" fn sys_image_start_addr() -> usize {
 		.align_down(LargePageSize::SIZE as usize)
 }
 
+/// Flushes a file to the storage it lives on.
+#[hermit_macro::system(errno)]
+#[unsafe(no_mangle)]
+pub extern "C" fn sys_fsync(fd: RawFd) -> i32 {
+	fd::fsync(fd).map_or_else(|e| -i32::from(e), |()| 0)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;


### PR DESCRIPTION
Most I/O systems require flush support. An interface is integrated to prepare the kernel for upcoming IO systems.