### PR TITLE
build(deps): Update generic_once_cell to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "generic_once_cell"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27ddeab45f9c2238a860db235b3e80ce23651fa8293b6f7f53fb72cbb5ce539"
+checksum = "2c68077b018781ddfbc95f9d333ddacd1c8c1da4f331407c5cecc63f53733eab"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Previous versions have been yanked due to:
- https://github.com/mkroening/generic_once_cell/issues/6