### PR TITLE
rtl8139: fix tx buffer handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,27 +298,22 @@ jobs:
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package httpd --no-default-features --features ci,hermit/dhcpv4,hermit/tcp,hermit/virtio-net qemu ${{ matrix.qemu_flags }} --devices virtio-net-mmio
         if: matrix.arch == 'x86_64' || matrix.arch == 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package httpd --features ci,hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.qemu_flags }} --devices rtl8139
-        if: matrix.arch != 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package httpd --no-default-features --features ci,hermit/dhcpv4,hermit/tcp,hermit/gem-net qemu ${{ matrix.qemu_flags }} --devices cadence-gem
         if: matrix.arch == 'riscv64'
       - run: cargo clean
         working-directory: .
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package testudp --features hermit/udp,hermit/dhcpv4,hermit/virtio-net qemu ${{ matrix.qemu_flags }} --devices virtio-net-pci
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package testudp --features hermit/udp,hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.qemu_flags }} --devices rtl8139
-        if: matrix.arch != 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package testudp --no-default-features --features hermit/udp,hermit/dhcpv4,hermit/gem-net qemu ${{ matrix.qemu_flags }} --devices cadence-gem
         if: matrix.arch == 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package miotcp --features hermit/dhcpv4,hermit/virtio-net qemu ${{ matrix.qemu_flags }} --devices virtio-net-pci
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package miotcp --features hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.qemu_flags }} --devices rtl8139
-        if: matrix.arch != 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package miotcp --no-default-features --features hermit/dhcpv4,hermit/tcp,hermit/gem-net qemu ${{ matrix.qemu_flags }} --devices cadence-gem
         if: matrix.arch == 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package poll --features hermit/dhcpv4,hermit/virtio-net qemu ${{ matrix.qemu_flags }} --devices virtio-net-pci
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package poll --features hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.qemu_flags }} --devices rtl8139
-        if: matrix.arch != 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package mioudp --features hermit/udp,hermit/dhcpv4,hermit/virtio-net qemu ${{ matrix.qemu_flags }} --devices virtio-net-pci
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package mioudp --features hermit/udp,hermit/dhcpv4,hermit/rtl8139 qemu ${{ matrix.qemu_flags }} --devices rtl8139
-        if: matrix.arch != 'riscv64'
       - run: cargo xtask ci rs --arch ${{ matrix.arch }} --profile ${{ matrix.profile }} ${{ matrix.rs_flags }} --package loopback qemu ${{ matrix.qemu_flags }}
         env:
           HERMIT_IP: 127.0.0.1

--- a/src/drivers/net/rtl8139.rs
+++ b/src/drivers/net/rtl8139.rs
@@ -5,7 +5,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::hint::spin_loop;
-use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
 use endian_num::{le16, le32, le64};
@@ -470,7 +469,6 @@ struct TxFields {
 	tx_in_use: [bool; NO_TX_BUFFERS],
 	tx_counter: usize,
 	txbuffer: Box<[u8], DeviceAlloc>,
-	remaining_bufs: usize,
 }
 
 /// RealTek RTL8139 network driver struct.
@@ -531,20 +529,12 @@ pub struct TxToken<'a> {
 	tx_fields: &'a mut TxFields,
 }
 
-impl Drop for TxToken<'_> {
-	// For when the token is dropped without being used. When the token is consumed, the remaining buffer
-	// count should only be increased after we receive confirmation of the actual transmission (i.e. TOK).
-	fn drop(&mut self) {
-		self.tx_fields.remaining_bufs += 1;
-	}
-}
-
 impl smoltcp::phy::TxToken for TxToken<'_> {
 	fn consume<R, F>(self, len: usize, f: F) -> R
 	where
 		F: FnOnce(&mut [u8]) -> R,
 	{
-		let mut token = ManuallyDrop::new(self);
+		let token = self;
 		let id = token.tx_fields.tx_counter % NO_TX_BUFFERS;
 
 		assert!(
@@ -586,6 +576,12 @@ impl smoltcp::phy::Device for RTL8139Driver {
 			return None;
 		}
 
+		// The receive token is only useful together with the transmit token,
+		// so both have to be available.
+		if !self.reclaim_next_tx_buffer() {
+			return None;
+		}
+
 		self.rx_fields.rx_in_use = true;
 		let regs = self.regs.as_mut_ptr();
 
@@ -605,7 +601,7 @@ impl smoltcp::phy::Device for RTL8139Driver {
 	}
 
 	fn transmit(&mut self, _: smoltcp::time::Instant) -> Option<TxToken<'_>> {
-		if self.tx_fields.remaining_bufs == 0 {
+		if !self.reclaim_next_tx_buffer() {
 			return None;
 		}
 
@@ -716,6 +712,7 @@ impl RTL8139Driver {
 
 				if (txstatus & (TSD_TABT | TSD_OWC)) > 0 {
 					error!("RTL8139: major error");
+					self.tx_fields.tx_in_use[i] = false;
 					continue;
 				}
 
@@ -725,10 +722,19 @@ impl RTL8139Driver {
 
 				if (txstatus & TSD_TOK) == TSD_TOK {
 					self.tx_fields.tx_in_use[i] = false;
-					self.tx_fields.remaining_bufs += 1;
 				}
 			}
 		}
+	}
+
+	fn reclaim_next_tx_buffer(&mut self) -> bool {
+		let id = self.tx_fields.tx_counter % NO_TX_BUFFERS;
+
+		if self.tx_fields.tx_in_use[id] {
+			self.tx_handler();
+		}
+
+		!self.tx_fields.tx_in_use[id]
 	}
 }
 
@@ -899,7 +905,6 @@ pub(crate) fn init_device(
 			tx_in_use: [false; NO_TX_BUFFERS],
 			tx_counter: 0,
 			txbuffer,
-			remaining_bufs: NO_TX_BUFFERS,
 		},
 	})
 }


### PR DESCRIPTION
Fixes #2636.

Transmit buffers are usually released by the TOK interrupt.
Though several frames may have to be sent while handling a single interrupt so the transmit buffer status descriptors are polled too.

Needs https://github.com/hermit-os/kernel/pull/2699 to activate miotcp ci jobs.