### PR TITLE
Small mm adjustments

### DIFF
--- a/src/drivers/pci.rs
+++ b/src/drivers/pci.rs
@@ -178,7 +178,7 @@ impl<T: ConfigRegionAccess> PciDevice<T> {
 			// Map bar into RW^X virtual memory
 			let physical_address = address;
 			let virtual_address =
-				crate::mm::map(PhysAddr::new(physical_address), size, true, true, no_cache);
+				crate::mm::device_map(PhysAddr::new(physical_address), size, true, true, no_cache);
 
 			Some((virtual_address, size))
 		})

--- a/src/mm/device_alloc.rs
+++ b/src/mm/device_alloc.rs
@@ -43,8 +43,8 @@ unsafe impl Allocator for DeviceAlloc {
 impl DeviceAlloc {
 	/// Returns a pointer corresponding to `phys_addr`.
 	#[inline]
-	pub fn ptr_from<T>(&self, phys_addr: PhysAddr) -> *mut T {
-		let addr = phys_addr.as_usize() + self.phys_offset().as_usize();
+	pub const fn ptr_from<T>(&self, phys_addr: PhysAddr) -> *mut T {
+		let addr = phys_addr.as_usize() + const { Self.phys_offset().as_usize() };
 		ptr::with_exposed_provenance_mut(addr)
 	}
 
@@ -53,7 +53,8 @@ impl DeviceAlloc {
 	/// The address is only correct if `ptr` has been allocated by this allocator.
 	#[inline]
 	pub fn phys_addr_from<T: ?Sized>(&self, ptr: *mut T) -> PhysAddr {
-		let addr = u64::try_from(ptr.expose_provenance()).unwrap() - self.phys_offset().as_u64();
+		let addr =
+			u64::try_from(ptr.expose_provenance()).unwrap() - const { Self.phys_offset().as_u64() };
 		PhysAddr::new(addr)
 	}
 
@@ -61,11 +62,11 @@ impl DeviceAlloc {
 	///
 	/// This device allocator expects the complete physical memory to be mapped device-readable at this offset.
 	#[inline]
-	pub fn phys_offset(&self) -> VirtAddr {
+	pub const fn phys_offset(&self) -> VirtAddr {
 		if cfg!(careful) {
-			virtualmem::kernel_heap_end().as_u64().div_ceil(4).into()
+			VirtAddr::new(virtualmem::kernel_heap_end().as_u64().div_ceil(4))
 		} else {
-			0u64.into()
+			VirtAddr::new(0u64)
 		}
 	}
 }

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -298,7 +298,7 @@ pub(crate) fn print_information() {
 
 /// Maps a given physical address and size in virtual space and returns address.
 #[cfg(feature = "pci")]
-pub(crate) fn map(
+pub(crate) fn device_map(
 	physical_address: PhysAddr,
 	size: usize,
 	writable: bool,

--- a/src/mm/virtualmem.rs
+++ b/src/mm/virtualmem.rs
@@ -64,7 +64,7 @@ unsafe fn init() {
 /// End of the virtual memory address space reserved for kernel memory (inclusive).
 /// The virtual memory address space reserved for the task heap starts after this.
 #[inline]
-pub fn kernel_heap_end() -> VirtAddr {
+pub const fn kernel_heap_end() -> VirtAddr {
 	cfg_select! {
 		target_arch = "aarch64" => {
 			// maximum address, which can be supported by TTBR0
@@ -75,17 +75,13 @@ pub fn kernel_heap_end() -> VirtAddr {
 			VirtAddr::new(0x0040_0000_0000 - 1)
 		}
 		target_arch = "x86_64" => {
-			use x86_64::structures::paging::PageTableIndex;
-
 			let p4_index = if cfg!(feature = "common-os") {
-				PageTableIndex::new(1)
+				1u64
 			} else {
-				PageTableIndex::new(256)
+				256u64
 			};
 
-			let addr = u64::from(p4_index) << 39;
-			assert_eq!(VirtAddr::new_truncate(addr).p4_index(), p4_index);
-
+			let addr = p4_index << 39;
 			VirtAddr::new_truncate(addr - 1)
 		}
 	}


### PR DESCRIPTION
* Renames `mm::map` to `mm::device_map`, as it's only used for devices, and the current naming seems to imply a more general usecase
* Makes a couple offset computation functions `const` to hopefully replace them with their values at compile time